### PR TITLE
feat: execution-based governance contracts (6 contract types + VM support)

### DIFF
--- a/include/naab/governance.h
+++ b/include/naab/governance.h
@@ -1335,11 +1335,54 @@ struct FunctionContract {
     std::vector<std::string> params;   // v4: input params, format "name:type" (type = any|int|float|string|bool|dict|array)
     std::vector<std::string> must_call;    // v5: patterns that MUST appear in function body (static analysis)
     std::vector<std::string> must_contain; // v5: literal strings that MUST appear in function body
+
+    // v6: Execution-based contracts (golden tests)
+    struct MustProduceCase {
+        std::vector<std::string> args_json;  // Each arg as JSON string (header-safe, no nlohmann)
+        std::string expect_json;              // Expected result as JSON string
+    };
+    std::vector<MustProduceCase> must_produce;
+
+    // v6: Static derivation check — return key must reference specified parameters
+    struct MustDeriveFromSpec {
+        std::string return_key;              // Key in the return dict
+        std::vector<std::string> params;     // Parameter names it must derive from
+    };
+    std::vector<MustDeriveFromSpec> must_derive_from;
+
+    // v6: Anti-hardcoding — return key must change when input varies
+    struct MustVarySpec {
+        std::string key;                         // Return key to check
+        std::string across;                      // Parameter name to vary
+        std::vector<std::string> fixtures_json;  // Optional: user-provided test inputs as JSON
+    };
+    std::vector<MustVarySpec> must_vary;
+
+    // v6: Mutation testing — function must produce different outputs for different inputs
+    struct MustDifferentiateCase {
+        std::string input_a_json;  // First input as JSON
+        std::string input_b_json;  // Second input as JSON
+        std::string key;           // Return key that must differ
+    };
+    std::vector<MustDifferentiateCase> must_differentiate;
+
+    // v6: Case-sensitivity awareness — function must handle case variants consistently
+    struct MustHandleCaseSpec {
+        std::vector<std::string> inputs_json;  // Case-varied inputs as JSON strings
+        std::string expect;                     // "consistent" or "different"
+    };
+    std::vector<MustHandleCaseSpec> must_handle_case;
+
+    // v6: Invariant checks — expressions that must hold on the function's return value
+    // Format: "result.key op value" (e.g., "result.compliance_rate >= 0")
+    std::vector<std::string> must_satisfy;
+    std::vector<std::string> must_satisfy_args_json;  // Test args for must_satisfy (JSON strings)
 };
 
 struct ContractsConfig {
     EnforcementLevel level = EnforcementLevel::SOFT;
     bool validate_inputs = false;
+    int contract_test_timeout_ms = 5000;  // Timeout per execution contract test case
     std::map<std::string, FunctionContract> functions;
 };
 
@@ -2048,6 +2091,10 @@ public:
         const std::string& func_body,
         int line = 0);
 
+    // --- Execution-Based Contract Tests ---
+    // Runs must_produce golden tests after program execution (post-execution pass)
+    std::string runExecutionContracts();
+
     // --- NAAb Function Body Quality Check ---
     // Scans ALL NAAb function bodies for stubs/oversimplification
     std::string checkNaabFunctionBody(const std::string& function_name,
@@ -2321,6 +2368,22 @@ private:
     mutable std::mutex taint_mutex_;  // BUG-N: Thread-safe taint operations
     bool last_return_tainted_ = false;  // BUG-D: Track function return taint
     std::string last_taint_source_;      // Lineage: which source function produced the taint
+
+    // Execution-based contracts (v6)
+    bool in_contract_test_ = false;  // Re-entrancy guard for execution contracts
+    interpreter::NaabVal jsonStringToNaabVal(const std::string& json_str);
+    interpreter::NaabVal callContractTestFunction(
+        const std::string& func_name, const std::vector<interpreter::NaabVal>& args);
+    std::string checkMustProduce(const std::string& func_name,
+                                  const FunctionContract& contract, int line);
+    std::string checkMustVary(const std::string& func_name,
+                               const FunctionContract& contract, int line);
+    std::string checkMustDifferentiate(const std::string& func_name,
+                                       const FunctionContract& contract, int line);
+    std::string checkMustHandleCase(const std::string& func_name,
+                                     const FunctionContract& contract, int line);
+    std::string checkMustSatisfy(const std::string& func_name,
+                                  const FunctionContract& contract, int line);
 
     // Behavioral Sequence Detection
     BehavioralSequenceDetector sequence_detector_;

--- a/include/naab/governance.h
+++ b/include/naab/governance.h
@@ -28,6 +28,7 @@
 
 namespace naab {
 namespace ast { class Program; }  // Forward declaration for drift detection
+namespace vm { class VM; }        // Forward declaration for execution contracts
 namespace governance {
 
 // ============================================================================
@@ -1924,6 +1925,9 @@ public:
     const std::string& getAgentId() const { return agent_id_; }
     void applyAgentRole();
 
+    // --- VM integration for execution contracts ---
+    void setVM(vm::VM* vm) { vm_ = vm; }
+
     // --- Path access control ---
     std::string checkPathAccess(const std::string& filepath, const std::string& mode);
 
@@ -2371,6 +2375,7 @@ private:
 
     // Execution-based contracts (v6)
     bool in_contract_test_ = false;  // Re-entrancy guard for execution contracts
+    vm::VM* vm_ = nullptr;          // VM engine for execution-based contracts
     interpreter::NaabVal jsonStringToNaabVal(const std::string& json_str);
     interpreter::NaabVal callContractTestFunction(
         const std::string& func_name, const std::vector<interpreter::NaabVal>& args);

--- a/include/naab/governance.h
+++ b/include/naab/governance.h
@@ -21,6 +21,7 @@
 #include <mutex>
 #include <atomic>
 #include <set>
+#include <functional>
 
 #include "naab/project_context.h"
 #include "naab/naab_val.h"
@@ -28,7 +29,6 @@
 
 namespace naab {
 namespace ast { class Program; }  // Forward declaration for drift detection
-namespace vm { class VM; }        // Forward declaration for execution contracts
 namespace governance {
 
 // ============================================================================
@@ -1925,8 +1925,14 @@ public:
     const std::string& getAgentId() const { return agent_id_; }
     void applyAgentRole();
 
-    // --- VM integration for execution contracts ---
-    void setVM(vm::VM* vm) { vm_ = vm; }
+    // --- VM integration for execution contracts (type-erased to avoid VM link dependency) ---
+    using ContractCallFn = std::function<interpreter::NaabVal(interpreter::NaabVal, const std::vector<interpreter::NaabVal>&)>;
+    using ContractGlobalsFn = std::function<const std::unordered_map<std::string, interpreter::NaabVal>&()>;
+    void setVMCallbacks(ContractCallFn call_fn, ContractGlobalsFn globals_fn) {
+        vm_call_fn_ = std::move(call_fn);
+        vm_globals_fn_ = std::move(globals_fn);
+    }
+    void clearVMCallbacks() { vm_call_fn_ = nullptr; vm_globals_fn_ = nullptr; }
 
     // --- Path access control ---
     std::string checkPathAccess(const std::string& filepath, const std::string& mode);
@@ -2375,7 +2381,8 @@ private:
 
     // Execution-based contracts (v6)
     bool in_contract_test_ = false;  // Re-entrancy guard for execution contracts
-    vm::VM* vm_ = nullptr;          // VM engine for execution-based contracts
+    ContractCallFn vm_call_fn_;        // VM function caller (type-erased)
+    ContractGlobalsFn vm_globals_fn_;  // VM globals accessor (type-erased)
     interpreter::NaabVal jsonStringToNaabVal(const std::string& json_str);
     interpreter::NaabVal callContractTestFunction(
         const std::string& func_name, const std::vector<interpreter::NaabVal>& args);

--- a/include/naab/vm.h
+++ b/include/naab/vm.h
@@ -347,6 +347,13 @@ public:
     void setGCThreshold(size_t t) { gc_threshold_ = t; }  // V-RT-008
     size_t getAllocationCount() const { return allocation_count_; }
 
+    // Access globals for governance contract function lookup
+    const std::unordered_map<std::string, interpreter::NaabVal>& getGlobals() const { return globals_; }
+
+    // Call a NAAb function from C++ (used by stdlib callbacks and governance contracts)
+    interpreter::NaabVal callNaabFunction(interpreter::NaabVal fn,
+                                          const std::vector<interpreter::NaabVal>& args);
+
     // Debugger: get current scope variables (slot → name mapping)
     std::map<std::string, interpreter::NaabVal> getCurrentScopeVariables() const;
 
@@ -487,9 +494,7 @@ private:
     interpreter::NaabVal callBuiltinFunction(const std::string& name, int argc,
                                              interpreter::NaabVal* args);
 
-    // Call a NAAb function from C++ (for stdlib callbacks like array.map_fn)
-    interpreter::NaabVal callNaabFunction(interpreter::NaabVal fn,
-                                          const std::vector<interpreter::NaabVal>& args);
+    // callNaabFunction moved to public section
 
     // Upvalue management
     std::shared_ptr<ObjUpvalue> captureUpvalue(interpreter::NaabVal* local);

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -2101,6 +2101,11 @@ int main(int argc, char** argv) {
                     vm_governance.runPostExecutionAudit();
                 }
 
+                // Pass 3: Execution-based contract tests (must_produce, etc.)
+                // VM path: only run static contracts (must_derive_from).
+                // Execution-based contracts (must_produce) require tree-walker;
+                // VM support planned for Phase 2 (setVM() API).
+
                 // Print governance dashboard summary
                 if (governance_dashboard && vm_governance.isActive()) {
                     vm_governance.printDashboard();
@@ -2247,6 +2252,20 @@ int main(int argc, char** argv) {
                 {
                     auto* gov = interpreter.getGovernance();
                     if (gov && gov->isActive()) gov->runPostExecutionAudit();
+                }
+
+                // Pass 3: Execution-based contract tests (must_produce, must_vary, etc.)
+                {
+                    auto* gov = interpreter.getGovernance();
+                    if (gov && gov->isActive() && !no_governance) {
+                        std::string contract_err = gov->runExecutionContracts();
+                        if (!contract_err.empty()) {
+                            fprintf(stderr, "Error: %s\n", contract_err.c_str());
+                            gov->writeReports();
+                            fflush(stdout); fflush(stderr);
+                            _exit(3);
+                        }
+                    }
                 }
 
                 // Print governance dashboard summary

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -2101,10 +2101,18 @@ int main(int argc, char** argv) {
                     vm_governance.runPostExecutionAudit();
                 }
 
-                // Pass 3: Execution-based contract tests (must_produce, etc.)
-                // VM path: only run static contracts (must_derive_from).
-                // Execution-based contracts (must_produce) require tree-walker;
-                // VM support planned for Phase 2 (setVM() API).
+                // Pass 3: Execution-based contract tests (must_produce, must_vary, etc.)
+                if (vm_governance.isActive() && !no_governance) {
+                    vm_governance.setVM(&bytecode_vm);
+                    std::string contract_err = vm_governance.runExecutionContracts();
+                    vm_governance.setVM(nullptr);  // Clear to avoid dangling pointer
+                    if (!contract_err.empty()) {
+                        fprintf(stderr, "Error: %s\n", contract_err.c_str());
+                        vm_governance.writeReports();
+                        fflush(stdout); fflush(stderr);
+                        _exit(3);
+                    }
+                }
 
                 // Print governance dashboard summary
                 if (governance_dashboard && vm_governance.isActive()) {

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -2103,9 +2103,16 @@ int main(int argc, char** argv) {
 
                 // Pass 3: Execution-based contract tests (must_produce, must_vary, etc.)
                 if (vm_governance.isActive() && !no_governance) {
-                    vm_governance.setVM(&bytecode_vm);
+                    vm_governance.setVMCallbacks(
+                        [&bytecode_vm](auto fn, const auto& args) {
+                            return bytecode_vm.callNaabFunction(fn, args);
+                        },
+                        [&bytecode_vm]() -> const auto& {
+                            return bytecode_vm.getGlobals();
+                        }
+                    );
                     std::string contract_err = vm_governance.runExecutionContracts();
-                    vm_governance.setVM(nullptr);  // Clear to avoid dangling pointer
+                    vm_governance.clearVMCallbacks();
                     if (!contract_err.empty()) {
                         fprintf(stderr, "Error: %s\n", contract_err.c_str());
                         vm_governance.writeReports();

--- a/src/interpreter/interpreter.cpp
+++ b/src/interpreter/interpreter.cpp
@@ -1021,8 +1021,9 @@ void Interpreter::visit(ast::Program& node) {
 
 void Interpreter::visit(ast::FunctionDecl& node) {
     // EVA-8: GOV-6 extended — scan ALL function bodies (not just exported)
-    // Skip during module loading to avoid expensive regex compilation overhead
-    if (governance_ && module_loading_depth_ == 0) {
+    // Full checks skip during module loading (expensive regex/heuristic overhead).
+    // Behavioral contracts (must_call, must_contain) always run — they are user-defined.
+    if (governance_) {
         auto loc = node.getLocation();
         if (loc.line > 0 && !current_file_.empty()) {
             std::ifstream src_file(current_file_);
@@ -1046,16 +1047,26 @@ void Interpreter::visit(ast::FunctionDecl& node) {
                         }
                         if (found_start && brace_depth <= 0) break;
                     }
-                    std::string err = governance_->checkNaabFunctionBody(
-                        node.getName(), body_text, loc.line, current_file_);
-                    if (!err.empty()) {
-                        throw std::runtime_error(err);
-                    }
-                    // Intent validation
-                    err = governance_->checkIntentValidation(
-                        node.getName(), node.getIntent(), body_text, loc.line);
-                    if (!err.empty()) {
-                        throw std::runtime_error(err);
+                    if (module_loading_depth_ == 0) {
+                        // Main file: full governance checks (includes behavioral contracts)
+                        std::string err = governance_->checkNaabFunctionBody(
+                            node.getName(), body_text, loc.line, current_file_);
+                        if (!err.empty()) {
+                            throw std::runtime_error(err);
+                        }
+                        // Intent validation
+                        err = governance_->checkIntentValidation(
+                            node.getName(), node.getIntent(), body_text, loc.line);
+                        if (!err.empty()) {
+                            throw std::runtime_error(err);
+                        }
+                    } else {
+                        // Module loading: only behavioral contracts (must_call, must_contain)
+                        std::string err = governance_->checkFunctionBehavioralContract(
+                            node.getName(), body_text, loc.line);
+                        if (!err.empty()) {
+                            throw std::runtime_error(err);
+                        }
                     }
                 }
             }

--- a/src/runtime/governance_checks.cpp
+++ b/src/runtime/governance_checks.cpp
@@ -4,7 +4,6 @@
 #include "naab/governance.h"
 #include "naab/language_registry.h"
 #include "naab/interpreter.h"
-#include "naab/vm.h"
 #include "naab/analyzer/task_pattern_detector.h"
 #include "naab/analyzer/syntactic_analyzer.h"
 #include <nlohmann/json.hpp>
@@ -3444,9 +3443,9 @@ interpreter::NaabVal GovernanceEngine::callContractTestFunction(
     const std::string& func_name,
     const std::vector<interpreter::NaabVal>& args) {
 
-    // --- VM path ---
-    if (vm_) {
-        const auto& globals = vm_->getGlobals();
+    // --- VM path (via type-erased callbacks to avoid link dependency) ---
+    if (vm_call_fn_ && vm_globals_fn_) {
+        const auto& globals = vm_globals_fn_();
         interpreter::NaabVal fn;
 
         // Phase 1: bare name lookup
@@ -3483,7 +3482,7 @@ interpreter::NaabVal GovernanceEngine::callContractTestFunction(
             throw std::runtime_error(
                 fmt::format("Contract test: function '{}' not found in global scope", func_name));
         }
-        return vm_->callNaabFunction(fn, args);
+        return vm_call_fn_(fn, args);
     }
 
     // --- Tree-walker path ---

--- a/src/runtime/governance_checks.cpp
+++ b/src/runtime/governance_checks.cpp
@@ -4,6 +4,7 @@
 #include "naab/governance.h"
 #include "naab/language_registry.h"
 #include "naab/interpreter.h"
+#include "naab/vm.h"
 #include "naab/analyzer/task_pattern_detector.h"
 #include "naab/analyzer/syntactic_analyzer.h"
 #include <nlohmann/json.hpp>
@@ -3443,10 +3444,53 @@ interpreter::NaabVal GovernanceEngine::callContractTestFunction(
     const std::string& func_name,
     const std::vector<interpreter::NaabVal>& args) {
 
+    // --- VM path ---
+    if (vm_) {
+        const auto& globals = vm_->getGlobals();
+        interpreter::NaabVal fn;
+
+        // Phase 1: bare name lookup
+        auto it = globals.find(func_name);
+        if (it != globals.end()) {
+            fn = it->second;
+        }
+        // Phase 2: search module dicts
+        if (fn.isNull()) {
+            for (const auto& [name, val] : globals) {
+                if (val.isDict()) {
+                    const auto& dict = val.asDictConst();
+                    auto dit = dict.find(func_name);
+                    if (dit != dict.end() && (dit->second.isFunction() || dit->second.isVMClosure())) {
+                        fn = dit->second;
+                        break;
+                    }
+                }
+            }
+        }
+        // Phase 3: dotted name lookup
+        if (fn.isNull()) {
+            std::string suffix = "." + func_name;
+            for (const auto& [name, val] : globals) {
+                if (name.size() > suffix.size() &&
+                    name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0 &&
+                    (val.isFunction() || val.isVMClosure())) {
+                    fn = val;
+                    break;
+                }
+            }
+        }
+        if (fn.isNull()) {
+            throw std::runtime_error(
+                fmt::format("Contract test: function '{}' not found in global scope", func_name));
+        }
+        return vm_->callNaabFunction(fn, args);
+    }
+
+    // --- Tree-walker path ---
     auto* interp = interpreter::g_current_interpreter;
     if (!interp) {
         throw std::runtime_error(
-            "Execution-based contracts require an active interpreter");
+            "Execution-based contracts require an active execution engine");
     }
 
     interpreter::NaabVal fn;

--- a/src/runtime/governance_checks.cpp
+++ b/src/runtime/governance_checks.cpp
@@ -20,6 +20,9 @@
 #include <fmt/core.h>
 
 namespace naab {
+namespace interpreter {
+    extern thread_local Interpreter* g_current_interpreter;  // defined in interpreter.cpp
+}
 namespace governance {
 
 // ============================================================================
@@ -3295,7 +3298,8 @@ std::string GovernanceEngine::checkFunctionBehavioralContract(
     if (it == rules_.contracts.functions.end()) return "";
 
     const auto& contract = it->second;
-    if (contract.must_call.empty() && contract.must_contain.empty()) return "";
+    if (contract.must_call.empty() && contract.must_contain.empty()
+        && contract.must_derive_from.empty()) return "";
 
     clearTrace();
     EnforcementLevel level = contract.level != EnforcementLevel::NONE
@@ -3350,7 +3354,604 @@ std::string GovernanceEngine::checkFunctionBehavioralContract(
         }
     }
 
+    // must_derive_from: check that function body references specified parameters
+    // Strip the function signature — only search inside the body braces.
+    // func_body is the full function text: "fn name(params) { ... }"
+    std::string inner_body;
+    {
+        auto brace_pos = func_body.find('{');
+        if (brace_pos != std::string::npos) {
+            inner_body = func_body.substr(brace_pos + 1);
+            // Remove trailing closing brace
+            auto last_brace = inner_body.rfind('}');
+            if (last_brace != std::string::npos) {
+                inner_body = inner_body.substr(0, last_brace);
+            }
+        } else {
+            inner_body = func_body;
+        }
+    }
+    for (const auto& spec : contract.must_derive_from) {
+        bool param_found = false;
+        for (const auto& param : spec.params) {
+            try {
+                std::regex param_pat("\\b" + param + "\\b");
+                if (std::regex_search(inner_body, param_pat)) {
+                    param_found = true;
+                    break;
+                }
+            } catch (...) {
+                // Invalid regex — fall back to literal search
+                if (inner_body.find(param) != std::string::npos) {
+                    param_found = true;
+                    break;
+                }
+            }
+        }
+        if (!param_found) {
+            std::string params_list;
+            for (size_t pi = 0; pi < spec.params.size(); ++pi) {
+                if (pi > 0) params_list += ", ";
+                params_list += spec.params[pi];
+            }
+            addTrace(fmt::format("function '{}' return key '{}' must derive from [{}] but none referenced",
+                func_name, spec.return_key, params_list));
+            return enforce("contracts." + func_name + ".must_derive_from", level,
+                formatError(level,
+                    fmt::format("Derivation contract: '{}' key '{}' must use parameter '{}'",
+                        func_name, spec.return_key, spec.params[0]),
+                    line > 0 ? fmt::format("line {}", line) : "",
+                    "contracts.must_derive_from",
+                    fmt::format("Function '{}' return key '{}' must be computed from parameter(s) [{}] "
+                        "but none of those parameters appear in the function body.",
+                        func_name, spec.return_key, params_list),
+                    "fn " + func_name + "(...) { return {\"" + spec.return_key + "\": 0.1} }",
+                    "fn " + func_name + "(" + spec.params[0] + ") { return {\"" + spec.return_key
+                        + "\": compute(" + spec.params[0] + ")} }"));
+        }
+    }
+
     recordPass("contracts." + func_name + ".behavioral", level);
+    return "";
+}
+
+// --- Execution-Based Contract Infrastructure (v6) ---
+
+interpreter::NaabVal GovernanceEngine::jsonStringToNaabVal(const std::string& json_str) {
+    try {
+        auto j = nlohmann::json::parse(json_str);
+        if (j.is_null()) return interpreter::NaabVal::makeNull();
+        if (j.is_boolean()) return interpreter::NaabVal::makeBool(j.get<bool>());
+        if (j.is_number_integer()) return interpreter::NaabVal::makeInt(j.get<int>());
+        if (j.is_number_float()) return interpreter::NaabVal::makeDouble(j.get<double>());
+        if (j.is_string()) return interpreter::NaabVal::makeString(j.get<std::string>());
+        if (j.is_array()) {
+            std::vector<interpreter::NaabVal> items;
+            for (auto& el : j) items.push_back(jsonStringToNaabVal(el.dump()));
+            return interpreter::NaabVal::makeList(std::move(items));
+        }
+        if (j.is_object()) {
+            std::unordered_map<std::string, interpreter::NaabVal> map;
+            for (auto& [k, v] : j.items()) map[k] = jsonStringToNaabVal(v.dump());
+            return interpreter::NaabVal::makeDict(std::move(map));
+        }
+    } catch (...) {}
+    return interpreter::NaabVal::makeNull();
+}
+
+interpreter::NaabVal GovernanceEngine::callContractTestFunction(
+    const std::string& func_name,
+    const std::vector<interpreter::NaabVal>& args) {
+
+    auto* interp = interpreter::g_current_interpreter;
+    if (!interp) {
+        throw std::runtime_error(
+            "Execution-based contracts require an active interpreter");
+    }
+
+    interpreter::NaabVal fn;
+    auto env = interp->getGlobalEnv();
+    // Try bare name first (global functions)
+    if (env->has(func_name)) {
+        fn = env->get(func_name);
+    } else {
+        // Search module dicts: wildcard imports store a dict under the alias,
+        // e.g. env["helper"] = {"normalize_severity": <fn>, ...}
+        for (const auto& [name, val] : env->getValues()) {
+            if (val.isDict()) {
+                const auto& dict = val.asDictConst();
+                auto it = dict.find(func_name);
+                if (it != dict.end() && (it->second.isFunction() || it->second.isVMClosure())) {
+                    fn = it->second;
+                    break;
+                }
+            }
+        }
+        // Also try module-qualified names: "alias.func" defined directly in global env
+        if (fn.isNull()) {
+            std::string suffix = "." + func_name;
+            for (const auto& [name, val] : env->getValues()) {
+                if (name.size() > suffix.size() &&
+                    name.compare(name.size() - suffix.size(), suffix.size(), suffix) == 0 &&
+                    (val.isFunction() || val.isVMClosure())) {
+                    fn = val;
+                    break;
+                }
+            }
+        }
+        if (fn.isNull()) {
+            throw std::runtime_error(
+                fmt::format("Contract test: function '{}' not found in global scope", func_name));
+        }
+    }
+    if (fn.isNull()) {
+        throw std::runtime_error(
+            fmt::format("Contract test: function '{}' is null", func_name));
+    }
+
+    return interp->callFunction(fn, args);
+}
+
+std::string GovernanceEngine::checkMustProduce(
+    const std::string& func_name,
+    const FunctionContract& contract,
+    int line) {
+
+    clearTrace();
+    EnforcementLevel level = contract.level != EnforcementLevel::NONE
+        ? contract.level : rules_.contracts.level;
+
+    for (size_t i = 0; i < contract.must_produce.size(); ++i) {
+        const auto& tc = contract.must_produce[i];
+
+        // Build args from JSON strings
+        std::vector<interpreter::NaabVal> args;
+        for (const auto& arg_json : tc.args_json) {
+            args.push_back(jsonStringToNaabVal(arg_json));
+        }
+
+        // Build display string for error messages
+        std::string args_display = "[";
+        for (size_t a = 0; a < tc.args_json.size(); ++a) {
+            if (a > 0) args_display += ", ";
+            args_display += tc.args_json[a];
+        }
+        args_display += "]";
+
+        // Call function with re-entrancy guard
+        interpreter::NaabVal result;
+        try {
+            in_contract_test_ = true;
+            result = callContractTestFunction(func_name, args);
+            in_contract_test_ = false;
+        } catch (const std::exception& e) {
+            in_contract_test_ = false;
+            addTrace(fmt::format("must_produce test #{}: call threw: {}", i + 1, e.what()));
+            return enforce("contracts." + func_name + ".must_produce", level,
+                formatError(level,
+                    fmt::format("must_produce test #{} for '{}' threw an exception", i + 1, func_name),
+                    line > 0 ? fmt::format("line {}", line) : "",
+                    "contracts.must_produce",
+                    fmt::format("Function threw: {}", e.what()),
+                    fmt::format("{}({}) => error", func_name, args_display),
+                    fmt::format("{}({}) => {}", func_name, args_display, tc.expect_json)));
+        }
+
+        // Compare result to expected
+        interpreter::NaabVal expected = jsonStringToNaabVal(tc.expect_json);
+        std::string result_str = result.isNull() ? "null" : result.toString();
+        std::string expect_str = expected.isNull() ? "null" : expected.toString();
+
+        if (result_str != expect_str) {
+            addTrace(fmt::format("must_produce test #{}: args={}, expected={}, got={}",
+                i + 1, args_display, expect_str, result_str));
+            return enforce("contracts." + func_name + ".must_produce", level,
+                formatError(level,
+                    fmt::format("must_produce: '{}' returned wrong value", func_name),
+                    line > 0 ? fmt::format("line {}", line) : "",
+                    "contracts.must_produce",
+                    fmt::format("Input: {}\n  Expected: {}\n  Got: {}",
+                        args_display, expect_str, result_str),
+                    fmt::format("{}({}) => {}", func_name, args_display, result_str),
+                    fmt::format("{}({}) => {}", func_name, args_display, expect_str)));
+        }
+    }
+
+    recordPass("contracts." + func_name + ".must_produce", level);
+    return "";
+}
+
+std::string GovernanceEngine::checkMustVary(
+    const std::string& func_name,
+    const FunctionContract& contract,
+    int line) {
+
+    clearTrace();
+    EnforcementLevel level = contract.level != EnforcementLevel::NONE
+        ? contract.level : rules_.contracts.level;
+
+    for (size_t i = 0; i < contract.must_vary.size(); ++i) {
+        const auto& spec = contract.must_vary[i];
+
+        // Build two distinct input sets
+        std::vector<interpreter::NaabVal> args_a, args_b;
+        if (spec.fixtures_json.size() >= 2) {
+            // User provided fixtures — use first two
+            args_a.push_back(jsonStringToNaabVal(spec.fixtures_json[0]));
+            args_b.push_back(jsonStringToNaabVal(spec.fixtures_json[1]));
+        } else {
+            // Generate synthetic inputs: empty list vs populated list
+            args_a.push_back(interpreter::NaabVal::makeList({}));
+            std::vector<interpreter::NaabVal> items;
+            std::unordered_map<std::string, interpreter::NaabVal> d1, d2, d3;
+            d1["severity"] = interpreter::NaabVal::makeInt(0);
+            d2["severity"] = interpreter::NaabVal::makeInt(5);
+            d3["severity"] = interpreter::NaabVal::makeInt(10);
+            items.push_back(interpreter::NaabVal::makeDict(std::move(d1)));
+            items.push_back(interpreter::NaabVal::makeDict(std::move(d2)));
+            items.push_back(interpreter::NaabVal::makeDict(std::move(d3)));
+            args_b.push_back(interpreter::NaabVal::makeList(std::move(items)));
+        }
+
+        // Call function with both inputs
+        interpreter::NaabVal result_a, result_b;
+        try {
+            in_contract_test_ = true;
+            result_a = callContractTestFunction(func_name, args_a);
+            result_b = callContractTestFunction(func_name, args_b);
+            in_contract_test_ = false;
+        } catch (const std::exception& e) {
+            in_contract_test_ = false;
+            addTrace(fmt::format("must_vary test #{}: call threw: {}", i + 1, e.what()));
+            return enforce("contracts." + func_name + ".must_vary", level,
+                formatError(level,
+                    fmt::format("must_vary test #{} for '{}' threw an exception", i + 1, func_name),
+                    "", "contracts.must_vary",
+                    fmt::format("Function threw: {}", e.what()), "", ""));
+        }
+
+        // Extract the specified key from both results
+        std::string val_a, val_b;
+        if (result_a.isDict()) {
+            auto& dict = result_a.asDict();
+            auto it = dict.find(spec.key);
+            val_a = (it != dict.end()) ? it->second.toString() : "<missing>";
+        } else {
+            val_a = result_a.toString();
+        }
+        if (result_b.isDict()) {
+            auto& dict = result_b.asDict();
+            auto it = dict.find(spec.key);
+            val_b = (it != dict.end()) ? it->second.toString() : "<missing>";
+        } else {
+            val_b = result_b.toString();
+        }
+
+        if (val_a == val_b) {
+            addTrace(fmt::format("must_vary: '{}' key '{}' returned '{}' for both inputs — hardcoded",
+                func_name, spec.key, val_a));
+            return enforce("contracts." + func_name + ".must_vary", level,
+                formatError(level,
+                    fmt::format("must_vary: '{}' key '{}' is hardcoded", func_name, spec.key),
+                    line > 0 ? fmt::format("line {}", line) : "",
+                    "contracts.must_vary",
+                    fmt::format("Key '{}' returned the same value '{}' for two different '{}' inputs.\n"
+                        "  The value appears to be hardcoded rather than computed from the input.",
+                        spec.key, val_a, spec.across),
+                    fmt::format("{}(...) => {{\"{}\": {}}} (always)", func_name, spec.key, val_a),
+                    fmt::format("{}(...) => {{\"{}\": <computed from {}>}}", func_name, spec.key, spec.across)));
+        }
+    }
+
+    recordPass("contracts." + func_name + ".must_vary", level);
+    return "";
+}
+
+std::string GovernanceEngine::checkMustDifferentiate(
+    const std::string& func_name,
+    const FunctionContract& contract,
+    int line) {
+
+    clearTrace();
+    EnforcementLevel level = contract.level != EnforcementLevel::NONE
+        ? contract.level : rules_.contracts.level;
+
+    for (size_t i = 0; i < contract.must_differentiate.size(); ++i) {
+        const auto& dc = contract.must_differentiate[i];
+
+        // Build args from the two inputs
+        std::vector<interpreter::NaabVal> args_a = {jsonStringToNaabVal(dc.input_a_json)};
+        std::vector<interpreter::NaabVal> args_b = {jsonStringToNaabVal(dc.input_b_json)};
+
+        // Call function with both inputs
+        interpreter::NaabVal result_a, result_b;
+        try {
+            in_contract_test_ = true;
+            result_a = callContractTestFunction(func_name, args_a);
+            result_b = callContractTestFunction(func_name, args_b);
+            in_contract_test_ = false;
+        } catch (const std::exception& e) {
+            in_contract_test_ = false;
+            addTrace(fmt::format("must_differentiate test #{}: call threw: {}", i + 1, e.what()));
+            return enforce("contracts." + func_name + ".must_differentiate", level,
+                formatError(level,
+                    fmt::format("must_differentiate test #{} for '{}' threw an exception", i + 1, func_name),
+                    "", "contracts.must_differentiate",
+                    fmt::format("Function threw: {}", e.what()), "", ""));
+        }
+
+        // Extract the specified key from both results
+        std::string val_a, val_b;
+        if (result_a.isDict()) {
+            auto& dict = result_a.asDict();
+            auto it = dict.find(dc.key);
+            val_a = (it != dict.end()) ? it->second.toString() : "<missing>";
+        } else {
+            val_a = result_a.toString();
+        }
+        if (result_b.isDict()) {
+            auto& dict = result_b.asDict();
+            auto it = dict.find(dc.key);
+            val_b = (it != dict.end()) ? it->second.toString() : "<missing>";
+        } else {
+            val_b = result_b.toString();
+        }
+
+        if (val_a == val_b) {
+            addTrace(fmt::format("must_differentiate: '{}' key '{}' returned '{}' for both inputs",
+                func_name, dc.key, val_a));
+            return enforce("contracts." + func_name + ".must_differentiate", level,
+                formatError(level,
+                    fmt::format("must_differentiate: '{}' does not distinguish inputs on key '{}'",
+                        func_name, dc.key),
+                    line > 0 ? fmt::format("line {}", line) : "",
+                    "contracts.must_differentiate",
+                    fmt::format("Input A: {}\n  Input B: {}\n  Both returned '{}' = '{}'\n"
+                        "  The function must produce different '{}' values for these distinct inputs.",
+                        dc.input_a_json, dc.input_b_json, dc.key, val_a, dc.key),
+                    fmt::format("{}(A) => {{\"{}\": \"{}\"}}, {}(B) => {{\"{}\": \"{}\"}}",
+                        func_name, dc.key, val_a, func_name, dc.key, val_a),
+                    fmt::format("{}(A) => {{\"{}\": \"<class_a>\"}}, {}(B) => {{\"{}\": \"<class_b>\"}}",
+                        func_name, dc.key, func_name, dc.key)));
+        }
+    }
+
+    recordPass("contracts." + func_name + ".must_differentiate", level);
+    return "";
+}
+
+std::string GovernanceEngine::checkMustHandleCase(
+    const std::string& func_name,
+    const FunctionContract& contract,
+    int line) {
+
+    clearTrace();
+    EnforcementLevel level = contract.level != EnforcementLevel::NONE
+        ? contract.level : rules_.contracts.level;
+
+    for (size_t i = 0; i < contract.must_handle_case.size(); ++i) {
+        const auto& spec = contract.must_handle_case[i];
+        if (spec.inputs_json.size() < 2) continue;
+
+        // Call function with each case-varied input, collect results
+        std::vector<std::string> results;
+        try {
+            in_contract_test_ = true;
+            for (const auto& inp_json : spec.inputs_json) {
+                std::vector<interpreter::NaabVal> args = {jsonStringToNaabVal(inp_json)};
+                auto result = callContractTestFunction(func_name, args);
+                results.push_back(result.isNull() ? "null" : result.toString());
+            }
+            in_contract_test_ = false;
+        } catch (const std::exception& e) {
+            in_contract_test_ = false;
+            addTrace(fmt::format("must_handle_case test #{}: call threw: {}", i + 1, e.what()));
+            return enforce("contracts." + func_name + ".must_handle_case", level,
+                formatError(level,
+                    fmt::format("must_handle_case test #{} for '{}' threw an exception", i + 1, func_name),
+                    "", "contracts.must_handle_case",
+                    fmt::format("Function threw: {}", e.what()), "", ""));
+        }
+
+        // Check all results are the same (consistent) or different
+        bool all_same = true;
+        for (size_t r = 1; r < results.size(); ++r) {
+            if (results[r] != results[0]) { all_same = false; break; }
+        }
+
+        if (spec.expect == "consistent" && !all_same) {
+            // Build input display
+            std::string inputs_display;
+            for (size_t j = 0; j < spec.inputs_json.size(); ++j) {
+                if (j > 0) inputs_display += ", ";
+                inputs_display += spec.inputs_json[j] + " => " + results[j];
+            }
+            addTrace(fmt::format("must_handle_case: '{}' returned inconsistent results for case variants",
+                func_name));
+            return enforce("contracts." + func_name + ".must_handle_case", level,
+                formatError(level,
+                    fmt::format("must_handle_case: '{}' is case-sensitive (expected consistent)", func_name),
+                    line > 0 ? fmt::format("line {}", line) : "",
+                    "contracts.must_handle_case",
+                    fmt::format("Case-varied inputs produced different results:\n  {}",
+                        inputs_display),
+                    fmt::format("{}({}) => {}", func_name, spec.inputs_json[0], results[0]),
+                    fmt::format("{}(any_case) => {} (consistent)", func_name, results[0])));
+        } else if (spec.expect == "different" && all_same) {
+            addTrace(fmt::format("must_handle_case: '{}' returned same result '{}' for all case variants",
+                func_name, results[0]));
+            return enforce("contracts." + func_name + ".must_handle_case", level,
+                formatError(level,
+                    fmt::format("must_handle_case: '{}' ignores case (expected different)", func_name),
+                    line > 0 ? fmt::format("line {}", line) : "",
+                    "contracts.must_handle_case",
+                    fmt::format("All case-varied inputs returned the same result: '{}'", results[0]),
+                    fmt::format("{}(any_case) => {}", func_name, results[0]),
+                    fmt::format("{}(upper) => A, {}(lower) => B", func_name, func_name)));
+        }
+    }
+
+    recordPass("contracts." + func_name + ".must_handle_case", level);
+    return "";
+}
+
+std::string GovernanceEngine::checkMustSatisfy(
+    const std::string& func_name,
+    const FunctionContract& contract,
+    int line) {
+
+    clearTrace();
+    EnforcementLevel level = contract.level != EnforcementLevel::NONE
+        ? contract.level : rules_.contracts.level;
+
+    // must_satisfy needs test inputs. Priority: must_satisfy_args > must_produce args > no args.
+    std::vector<interpreter::NaabVal> test_args;
+    if (!contract.must_satisfy_args_json.empty()) {
+        for (const auto& arg_json : contract.must_satisfy_args_json) {
+            test_args.push_back(jsonStringToNaabVal(arg_json));
+        }
+    } else if (!contract.must_produce.empty() && !contract.must_produce[0].args_json.empty()) {
+        for (const auto& arg_json : contract.must_produce[0].args_json) {
+            test_args.push_back(jsonStringToNaabVal(arg_json));
+        }
+    }
+
+    // Call function to get a result to check invariants against
+    interpreter::NaabVal result;
+    try {
+        in_contract_test_ = true;
+        result = callContractTestFunction(func_name, test_args);
+        in_contract_test_ = false;
+    } catch (const std::exception& e) {
+        in_contract_test_ = false;
+        addTrace(fmt::format("must_satisfy: call to '{}' threw: {}", func_name, e.what()));
+        return enforce("contracts." + func_name + ".must_satisfy", level,
+            formatError(level,
+                fmt::format("must_satisfy: '{}' threw an exception", func_name),
+                "", "contracts.must_satisfy",
+                fmt::format("Function threw: {}", e.what()), "", ""));
+    }
+
+    // Evaluate each invariant expression: "result.key op value"
+    // Regex: result\.(\w+(?:\.\w+)*)\s*(>=|<=|>|<|==|!=)\s*(.+)
+    std::regex expr_pat(R"(result\.(\w+(?:\.\w+)*)\s*(>=|<=|>|<|==|!=)\s*(.+))");
+
+    for (const auto& expr : contract.must_satisfy) {
+        std::smatch m;
+        if (!std::regex_match(expr, m, expr_pat)) {
+            addTrace(fmt::format("must_satisfy: unparseable expression: '{}'", expr));
+            continue;  // Skip unparseable expressions
+        }
+
+        std::string key_path = m[1].str();
+        std::string op = m[2].str();
+        std::string rhs_str = m[3].str();
+        // Trim rhs
+        while (!rhs_str.empty() && (rhs_str.back() == ' ' || rhs_str.back() == '\t'))
+            rhs_str.pop_back();
+
+        // Extract value at key_path from result
+        double lhs_val = 0.0;
+        bool found = false;
+        if (result.isDict()) {
+            auto& dict = result.asDict();
+            // Support single-level key for now (e.g., "compliance_rate")
+            auto it = dict.find(key_path);
+            if (it != dict.end()) {
+                found = true;
+                if (it->second.isInt()) lhs_val = static_cast<double>(it->second.asInt());
+                else if (it->second.isDouble()) lhs_val = it->second.asDouble();
+                else {
+                    addTrace(fmt::format("must_satisfy: result.{} is not numeric ('{}')",
+                        key_path, it->second.toString()));
+                    return enforce("contracts." + func_name + ".must_satisfy", level,
+                        formatError(level,
+                            fmt::format("must_satisfy: result.{} is not numeric", key_path),
+                            line > 0 ? fmt::format("line {}", line) : "",
+                            "contracts.must_satisfy",
+                            fmt::format("Expression '{}': result.{} = '{}' (not a number)",
+                                expr, key_path, it->second.toString()),
+                            "", ""));
+                }
+            }
+        }
+        if (!found) {
+            addTrace(fmt::format("must_satisfy: result.{} not found in return value", key_path));
+            return enforce("contracts." + func_name + ".must_satisfy", level,
+                formatError(level,
+                    fmt::format("must_satisfy: result.{} not found", key_path),
+                    line > 0 ? fmt::format("line {}", line) : "",
+                    "contracts.must_satisfy",
+                    fmt::format("Expression '{}': key '{}' not found in return dict",
+                        expr, key_path),
+                    fmt::format("{}(...) => {}", func_name, result.toString()),
+                    fmt::format("{}(...) => {{\"{}\":  <value>}}", func_name, key_path)));
+        }
+
+        // Parse rhs as double
+        double rhs_val = 0.0;
+        try { rhs_val = std::stod(rhs_str); }
+        catch (...) {
+            addTrace(fmt::format("must_satisfy: cannot parse RHS '{}' as number", rhs_str));
+            continue;
+        }
+
+        // Evaluate comparison
+        bool satisfied = false;
+        if (op == ">=") satisfied = lhs_val >= rhs_val;
+        else if (op == "<=") satisfied = lhs_val <= rhs_val;
+        else if (op == ">") satisfied = lhs_val > rhs_val;
+        else if (op == "<") satisfied = lhs_val < rhs_val;
+        else if (op == "==") satisfied = lhs_val == rhs_val;
+        else if (op == "!=") satisfied = lhs_val != rhs_val;
+
+        if (!satisfied) {
+            addTrace(fmt::format("must_satisfy: '{}' FAILED — result.{} = {}, expected {} {}",
+                expr, key_path, lhs_val, op, rhs_val));
+            return enforce("contracts." + func_name + ".must_satisfy", level,
+                formatError(level,
+                    fmt::format("must_satisfy: invariant '{}' violated", expr),
+                    line > 0 ? fmt::format("line {}", line) : "",
+                    "contracts.must_satisfy",
+                    fmt::format("result.{} = {}, but expected {} {}",
+                        key_path, lhs_val, op, rhs_val),
+                    fmt::format("{}(...) => {{\"{}\": {}}}", func_name, key_path, lhs_val),
+                    fmt::format("{}(...) => {{\"{}\": <val where val {} {}>}}",
+                        func_name, key_path, op, rhs_val)));
+        }
+    }
+
+    recordPass("contracts." + func_name + ".must_satisfy", level);
+    return "";
+}
+
+std::string GovernanceEngine::runExecutionContracts() {
+    if (!isActive()) return "";
+    if (in_contract_test_) return "";  // Re-entrancy guard
+
+    for (const auto& [func_name, contract] : rules_.contracts.functions) {
+        if (!contract.must_produce.empty()) {
+            std::string err = checkMustProduce(func_name, contract, 0);
+            if (!err.empty()) return err;
+        }
+        if (!contract.must_vary.empty()) {
+            std::string err = checkMustVary(func_name, contract, 0);
+            if (!err.empty()) return err;
+        }
+        if (!contract.must_differentiate.empty()) {
+            std::string err = checkMustDifferentiate(func_name, contract, 0);
+            if (!err.empty()) return err;
+        }
+        if (!contract.must_handle_case.empty()) {
+            std::string err = checkMustHandleCase(func_name, contract, 0);
+            if (!err.empty()) return err;
+        }
+        if (!contract.must_satisfy.empty()) {
+            std::string err = checkMustSatisfy(func_name, contract, 0);
+            if (!err.empty()) return err;
+        }
+    }
+
     return "";
 }
 

--- a/src/runtime/governance_config.cpp
+++ b/src/runtime/governance_config.cpp
@@ -1695,6 +1695,77 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
                 if (fn_obj.contains("must_contain") && fn_obj["must_contain"].is_array()) {
                     for (auto& mc : fn_obj["must_contain"]) fc.must_contain.push_back(mc.get<std::string>());
                 }
+                // v6: must_produce — golden tests (array of {args: [...], expect: value})
+                if (fn_obj.contains("must_produce") && fn_obj["must_produce"].is_array()) {
+                    for (auto& tc : fn_obj["must_produce"]) {
+                        if (!tc.is_object()) continue;
+                        FunctionContract::MustProduceCase mpc;
+                        if (tc.contains("args") && tc["args"].is_array()) {
+                            for (auto& a : tc["args"]) mpc.args_json.push_back(a.dump());
+                        }
+                        if (tc.contains("expect")) mpc.expect_json = tc["expect"].dump();
+                        fc.must_produce.push_back(std::move(mpc));
+                    }
+                }
+                // v6: must_derive_from — static derivation check ({return_key: [param1, ...]})
+                if (fn_obj.contains("must_derive_from") && fn_obj["must_derive_from"].is_object()) {
+                    for (auto& [rk, params] : fn_obj["must_derive_from"].items()) {
+                        FunctionContract::MustDeriveFromSpec spec;
+                        spec.return_key = rk;
+                        if (params.is_array()) {
+                            for (auto& p : params) spec.params.push_back(p.get<std::string>());
+                        }
+                        fc.must_derive_from.push_back(std::move(spec));
+                    }
+                }
+                // v6: must_vary — anti-hardcoding (array of {key, across, fixtures?})
+                if (fn_obj.contains("must_vary") && fn_obj["must_vary"].is_array()) {
+                    for (auto& mv : fn_obj["must_vary"]) {
+                        if (!mv.is_object()) continue;
+                        FunctionContract::MustVarySpec spec;
+                        if (mv.contains("key")) spec.key = mv["key"].get<std::string>();
+                        if (mv.contains("across")) spec.across = mv["across"].get<std::string>();
+                        if (mv.contains("fixtures") && mv["fixtures"].is_array()) {
+                            for (auto& f : mv["fixtures"]) spec.fixtures_json.push_back(f.dump());
+                        }
+                        fc.must_vary.push_back(std::move(spec));
+                    }
+                }
+                // v6: must_differentiate — mutation testing (array of {a, b, key})
+                if (fn_obj.contains("must_differentiate") && fn_obj["must_differentiate"].is_array()) {
+                    for (auto& md : fn_obj["must_differentiate"]) {
+                        if (!md.is_object()) continue;
+                        FunctionContract::MustDifferentiateCase dc;
+                        if (md.contains("a")) dc.input_a_json = md["a"].dump();
+                        if (md.contains("b")) dc.input_b_json = md["b"].dump();
+                        if (md.contains("key")) dc.key = md["key"].get<std::string>();
+                        fc.must_differentiate.push_back(std::move(dc));
+                    }
+                }
+                // v6: must_handle_case — case-sensitivity awareness (array of {inputs: [...], expect: str})
+                if (fn_obj.contains("must_handle_case") && fn_obj["must_handle_case"].is_array()) {
+                    for (auto& mh : fn_obj["must_handle_case"]) {
+                        if (!mh.is_object()) continue;
+                        FunctionContract::MustHandleCaseSpec spec;
+                        if (mh.contains("inputs") && mh["inputs"].is_array()) {
+                            for (auto& inp : mh["inputs"]) spec.inputs_json.push_back(inp.dump());
+                        }
+                        if (mh.contains("expect")) spec.expect = mh["expect"].get<std::string>();
+                        fc.must_handle_case.push_back(std::move(spec));
+                    }
+                }
+                // v6: must_satisfy — invariant expressions (array of strings)
+                if (fn_obj.contains("must_satisfy") && fn_obj["must_satisfy"].is_array()) {
+                    for (auto& expr : fn_obj["must_satisfy"]) {
+                        if (expr.is_string()) fc.must_satisfy.push_back(expr.get<std::string>());
+                    }
+                }
+                // v6: must_satisfy_args — test inputs for must_satisfy (array of JSON values)
+                if (fn_obj.contains("must_satisfy_args") && fn_obj["must_satisfy_args"].is_array()) {
+                    for (auto& a : fn_obj["must_satisfy_args"]) {
+                        fc.must_satisfy_args_json.push_back(a.dump());
+                    }
+                }
                 parseRationale(fn_obj, fc.rationale);
                 rules_.contracts.functions[fn_name] = std::move(fc);
             }

--- a/src/vm/compiler.cpp
+++ b/src/vm/compiler.cpp
@@ -1004,9 +1004,9 @@ void Compiler::visit(ast::FunctionDecl& node) {
     int line = node.getLocation().line;
 
     // Governance: function body quality checks (oversimplification, complexity floor, etc.)
-    // Skip during module loading to avoid checking imported functions — matches tree-walker
-    // behavior (interpreter.cpp uses module_loading_depth_ == 0 guard).
-    if (governance_ && governance_->isActive() && !skip_main_ && line > 0 && !source_file_.empty()) {
+    // Full checks skip during module loading (expensive regex/heuristic overhead).
+    // Behavioral contracts (must_call, must_contain) always run — they are user-defined.
+    if (governance_ && governance_->isActive() && line > 0 && !source_file_.empty()) {
         std::ifstream src_file(source_file_);
         if (src_file.is_open()) {
             std::vector<std::string> src_lines;
@@ -1035,10 +1035,20 @@ void Compiler::visit(ast::FunctionDecl& node) {
                     }
                     if (found_start && brace_depth <= 0) break;
                 }
-                std::string err = governance_->checkNaabFunctionBody(
-                    node.getName(), body_text, line, source_file_);
-                if (!err.empty()) {
-                    throw std::runtime_error(err);
+                if (!skip_main_) {
+                    // Main file: full governance checks (includes behavioral contracts)
+                    std::string err = governance_->checkNaabFunctionBody(
+                        node.getName(), body_text, line, source_file_);
+                    if (!err.empty()) {
+                        throw std::runtime_error(err);
+                    }
+                } else {
+                    // Module loading: only behavioral contracts (must_call, must_contain)
+                    std::string err = governance_->checkFunctionBehavioralContract(
+                        node.getName(), body_text, line);
+                    if (!err.empty()) {
+                        throw std::runtime_error(err);
+                    }
                 }
                 // Intent validation handled by preflight gate in main.cpp
             }
@@ -1117,8 +1127,9 @@ void Compiler::visit(ast::FunctionDeclStmt& node) {
     int line = decl->getLocation().line;
 
     // Governance: function body quality checks (oversimplification, complexity floor, etc.)
-    // Skip during module loading — matches tree-walker behavior.
-    if (governance_ && governance_->isActive() && !skip_main_ && line > 0 && !source_file_.empty()) {
+    // Full checks skip during module loading (expensive regex/heuristic overhead).
+    // Behavioral contracts (must_call, must_contain) always run — they are user-defined.
+    if (governance_ && governance_->isActive() && line > 0 && !source_file_.empty()) {
         std::ifstream src_file(source_file_);
         if (src_file.is_open()) {
             std::vector<std::string> lines;
@@ -1146,10 +1157,20 @@ void Compiler::visit(ast::FunctionDeclStmt& node) {
                     }
                     if (found_start && brace_depth <= 0) break;
                 }
-                std::string err = governance_->checkNaabFunctionBody(
-                    decl->getName(), body_text, line, source_file_);
-                if (!err.empty()) {
-                    throw std::runtime_error(err);
+                if (!skip_main_) {
+                    // Main file: full governance checks (includes behavioral contracts)
+                    std::string err = governance_->checkNaabFunctionBody(
+                        decl->getName(), body_text, line, source_file_);
+                    if (!err.empty()) {
+                        throw std::runtime_error(err);
+                    }
+                } else {
+                    // Module loading: only behavioral contracts (must_call, must_contain)
+                    std::string err = governance_->checkFunctionBehavioralContract(
+                        decl->getName(), body_text, line);
+                    if (!err.empty()) {
+                        throw std::runtime_error(err);
+                    }
                 }
                 // Intent validation handled by preflight gate in main.cpp
             }


### PR DESCRIPTION
## Summary

- Add 6 execution-based governance contract types that catch behavioral bugs by actually calling functions and checking outputs post-execution: `must_produce`, `must_derive_from`, `must_vary`, `must_differentiate`, `must_handle_case`, `must_satisfy`
- Enable all execution contracts in VM mode (default engine) by exposing `VM::getGlobals()` and `VM::callNaabFunction()`, adding `GovernanceEngine::setVM()`, and wiring post-execution contract testing into the VM path
- Fix `must_call`/`must_contain` behavioral contracts to work correctly on module-imported functions

## What each contract catches

| Contract | Category | Bug Type |
|----------|----------|----------|
| `must_produce` | Execution | Logic bugs, wrong return values |
| `must_derive_from` | Static | Dead computation, hardcoded values |
| `must_vary` | Execution | Hardcoded return values across inputs |
| `must_differentiate` | Execution | Flat/non-classifying functions |
| `must_handle_case` | Execution | Case-sensitivity bugs |
| `must_satisfy` | Execution | Invariant violations (e.g., negative rates) |

## Test plan

- [x] VM-mode `must_produce` pass/fail (bare function)
- [x] VM-mode `must_handle_case` with module imports (catches case-sensitivity bug)
- [x] Tree-walker regression (identical behavior preserved)
- [x] Full test suite: 391/391 accounted, 1 pre-existing failure only
- [x] Security leak check: 120/120 clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)