### PR TITLE
fix: gorilla-27 infrastructure fixes (contracts, template, tests)

### DIFF
--- a/CLAUDE-TEMPLATE.md
+++ b/CLAUDE-TEMPLATE.md
@@ -228,6 +228,9 @@ sum(d * multiplier for d in data)
   The last expression's value is automatically captured.
   WRONG: `return json.dumps(data)`
   RIGHT: `json.dumps(data)`
+  **Dict/list as last expression:** If returning a dict `{...}` or list `[...]`,
+  wrap in `json.dumps()`: `json.dumps({"key": val})`. Without this, Python's `repr()`
+  uses single quotes which NAAb cannot parse as JSON.
 - **JavaScript**: Uses embedded QuickJS (NOT Node.js). Last expression is the return value.
   Use `const`/`let`, NOT `var`. Multi-line JS is wrapped in an IIFE for return capture.
   **Keep JS blocks simple**: declare variables, compute, then put the result expression last.

--- a/CLAUDE-TEMPLATE.md
+++ b/CLAUDE-TEMPLATE.md
@@ -405,13 +405,18 @@ year, month, day, hour, minute, second, weekday
 parse, stringify
 
 ### regex
-search (partial match, returns match or null), matches (full string match, true/false),
-find (returns matched string), find_all (all matches as array),
+search (partial match, returns **true/false** — NOT the matched text),
+matches (full string match, true/false),
+find (returns matched **string** or null — use this when you need the match text),
+find_all (all matches as array),
 replace, replace_first, split, groups, escape, is_valid
 find_groups — returns **2D array**: `[[full_match, group1, group2, ...], ...]`
   Each inner array is one match. First capture group: `result[0][1]` (NOT `result[1]`).
   No match: returns `[]`. Guard with: `if len(groups) > 0 { ... }`
 **GOTCHA**: `regex.match()` and `regex.test()` do NOT exist — use `regex.search()` or `regex.matches()`
+**GOTCHA**: `regex.search()` returns **bool**, NOT the matched string. To get the matched
+  text, use `regex.find()`. Common mistake: `let match = regex.search(text, pat); string.lower(match)`
+  — this crashes because `match` is `true`, not a string. Use `regex.find()` instead.
 
 ### env
 get, get_args, set_var (NOT set — the function is set_var), list
@@ -502,8 +507,8 @@ create, send, run, messages, usage, batch, fan_out, pipeline
 - `array.merge(a, b)` — use `a + b` (array concatenation with +)
 - `array.concat(a, b)` — use `a + b`
 - `array.flat()` — not available, manually iterate
-- `string.match()` — use `regex.search()` or `regex.matches()` with `use regex`
-- `regex.match()` — use `regex.search()` (partial match, returns match or null)
+- `string.match()` — use `regex.find()` (returns matched string or null) or `regex.search()` (returns bool) with `use regex`
+- `regex.match()` — use `regex.search()` (returns bool) or `regex.find()` (returns matched string)
 - `regex.test()` — use `regex.matches()` (full string match, returns bool)
 - `time.format()` — use `time.format_timestamp()` (the function name is `format_timestamp`, NOT `format`)
 - `env.set()` — use `env.set_var(name, value)` (the function name is `set_var`, NOT `set`)
@@ -662,9 +667,10 @@ main {
     `_ => throw "invalid value"` in a match arm is valid.
     Throw expressions diverge (never return), so the type system treats them as compatible
     with any branch type.
-24. `string.match()` does NOT exist — use `regex.search(text, pattern)` for partial match,
-    `regex.matches(text, pattern)` for full match, `regex.find_all(text, pattern)` for all matches.
-    Requires `use regex`.
+24. `string.match()` does NOT exist — use `regex.find(text, pattern)` to get the matched string
+    (returns string or null), `regex.search(text, pattern)` to check if a match exists (returns
+    **bool**, NOT the matched text), `regex.matches(text, pattern)` for full string match (bool),
+    `regex.find_all(text, pattern)` for all matches (array). Requires `use regex`.
 25. `-> JSON` behaves differently per language:
     **Python**: bare expressions (e.g. `json.dumps(data)`) as the last line are auto-wrapped
     in `print()`. Both `json.dumps(data)` and `print(json.dumps(data))` work.
@@ -888,6 +894,14 @@ main {
     RIGHT: `let days = total_hours / 8.0`       // 12/8.0 = 1.5
     This is the same as Python 2, C, Java, and Go integer division. If either operand
     is float, the result is float.
+60. **`regex.search()` returns bool, NOT the matched string.** This is the #1 regex mistake.
+    `regex.search(text, pattern)` returns `true`/`false`. To get the actual matched text,
+    use `regex.find(text, pattern)` which returns the matched string or `null`.
+    WRONG: `let match = regex.search(text, "\\d+"); int(match)` — `match` is `true`, not digits
+    WRONG: `let sev = regex.search(text, "ERROR|WARN"); string.lower(sev)` — crashes: "Expected string value"
+    RIGHT: `let match = regex.find(text, "\\d+"); if match != null { int(match) }`
+    RIGHT: `let sev = regex.find(text, "ERROR|WARN"); if sev != null { string.lower(sev) }`
+    Use `regex.search()` only for boolean checks: `if regex.search(text, pattern) { ... }`
 
 ## Complexity Scoring (for governance)
 

--- a/src/interpreter/polyglot.cpp
+++ b/src/interpreter/polyglot.cpp
@@ -484,12 +484,23 @@ void Interpreter::visit(ast::InlineCodeExpr& node) {
                         ? lines[expr_start].substr(0, sstart) : "";
                     std::string strimmed = (sstart != std::string::npos)
                         ? lines[expr_start].substr(sstart) : lines[expr_start];
-                    lines[expr_start] = leading + "print(" + strimmed;
-                    lines[i] = lines[i] + ")";
+                    bool is_structured = (!strimmed.empty() && (strimmed[0] == '{' || strimmed[0] == '['));
+                    if (is_structured) {
+                        lines[expr_start] = leading + "print(__import__('json').dumps(" + strimmed;
+                        lines[i] = lines[i] + "))";
+                    } else {
+                        lines[expr_start] = leading + "print(" + strimmed;
+                        lines[i] = lines[i] + ")";
+                    }
                 } else {
                     // Single-line bare expression — wrap in print()
                     std::string leading = lines[i].substr(0, start);
-                    lines[i] = leading + "print(" + trimmed + ")";
+                    bool is_structured = (!trimmed.empty() && (trimmed[0] == '{' || trimmed[0] == '['));
+                    if (is_structured) {
+                        lines[i] = leading + "print(__import__('json').dumps(" + trimmed + "))";
+                    } else {
+                        lines[i] = leading + "print(" + trimmed + ")";
+                    }
                 }
                 break;
             }

--- a/src/runtime/governance_checks.cpp
+++ b/src/runtime/governance_checks.cpp
@@ -3489,7 +3489,7 @@ interpreter::NaabVal GovernanceEngine::callContractTestFunction(
         if (fn.isVMClosure()) {
             int arity = fn.asVMClosureConst()->function->arity;
             while (static_cast<int>(padded_args.size()) < arity) {
-                padded_args.push_back(interpreter::NaabVal());  // null
+                padded_args.push_back(interpreter::NaabVal::makeList({}));  // empty list
             }
         }
         return vm_call_fn_(fn, padded_args);
@@ -3547,12 +3547,12 @@ interpreter::NaabVal GovernanceEngine::callContractTestFunction(
     if (fn.isFunction()) {
         size_t arity = fn.asFunctionConst()->params.size();
         while (padded_args.size() < arity) {
-            padded_args.push_back(interpreter::NaabVal());  // null
+            padded_args.push_back(interpreter::NaabVal::makeList({}));  // empty list
         }
     } else if (fn.isVMClosure()) {
         int arity = fn.asVMClosureConst()->function->arity;
         while (static_cast<int>(padded_args.size()) < arity) {
-            padded_args.push_back(interpreter::NaabVal());  // null
+            padded_args.push_back(interpreter::NaabVal::makeList({}));  // empty list
         }
     }
 
@@ -3660,13 +3660,13 @@ std::string GovernanceEngine::checkMustVary(
             d1["message"] = interpreter::NaabVal::makeString("test event 1");
             d1["timestamp"] = interpreter::NaabVal::makeInt(1000000);
             d2["severity"] = interpreter::NaabVal::makeInt(5);
-            d2["state"] = interpreter::NaabVal::makeInt(2);
+            d2["state"] = interpreter::NaabVal::makeInt(1);  // Firing — triggers state==1 checks
             d2["id"] = interpreter::NaabVal::makeString("synth-2");
             d2["source"] = interpreter::NaabVal::makeString("synthetic");
             d2["message"] = interpreter::NaabVal::makeString("test event 2");
             d2["timestamp"] = interpreter::NaabVal::makeInt(1000060);
             d3["severity"] = interpreter::NaabVal::makeInt(10);
-            d3["state"] = interpreter::NaabVal::makeInt(4);
+            d3["state"] = interpreter::NaabVal::makeInt(2);  // Acknowledged — triggers state>=2 checks
             d3["id"] = interpreter::NaabVal::makeString("synth-3");
             d3["source"] = interpreter::NaabVal::makeString("synthetic");
             d3["message"] = interpreter::NaabVal::makeString("test event 3");

--- a/src/runtime/governance_checks.cpp
+++ b/src/runtime/governance_checks.cpp
@@ -3848,10 +3848,20 @@ std::string GovernanceEngine::checkMustSatisfy(
         ? contract.level : rules_.contracts.level;
 
     // must_satisfy needs test inputs. Priority: must_satisfy_args > must_produce args > no args.
+    // must_satisfy_args entries are {"args": [...]} objects — unwrap the args array.
     std::vector<interpreter::NaabVal> test_args;
     if (!contract.must_satisfy_args_json.empty()) {
-        for (const auto& arg_json : contract.must_satisfy_args_json) {
-            test_args.push_back(jsonStringToNaabVal(arg_json));
+        // Use first test case. Each entry is JSON: {"args": [arg1, arg2, ...]}
+        auto test_case = nlohmann::json::parse(contract.must_satisfy_args_json[0]);
+        if (test_case.contains("args") && test_case["args"].is_array()) {
+            for (auto& arg : test_case["args"]) {
+                test_args.push_back(jsonStringToNaabVal(arg.dump()));
+            }
+        } else {
+            // Fallback: treat each must_satisfy_args entry as a direct arg value
+            for (const auto& arg_json : contract.must_satisfy_args_json) {
+                test_args.push_back(jsonStringToNaabVal(arg_json));
+            }
         }
     } else if (!contract.must_produce.empty() && !contract.must_produce[0].args_json.empty()) {
         for (const auto& arg_json : contract.must_produce[0].args_json) {

--- a/src/runtime/governance_checks.cpp
+++ b/src/runtime/governance_checks.cpp
@@ -4,6 +4,7 @@
 #include "naab/governance.h"
 #include "naab/language_registry.h"
 #include "naab/interpreter.h"
+#include "naab/vm.h"
 #include "naab/analyzer/task_pattern_detector.h"
 #include "naab/analyzer/syntactic_analyzer.h"
 #include <nlohmann/json.hpp>
@@ -3482,7 +3483,16 @@ interpreter::NaabVal GovernanceEngine::callContractTestFunction(
             throw std::runtime_error(
                 fmt::format("Contract test: function '{}' not found in global scope", func_name));
         }
-        return vm_call_fn_(fn, args);
+        // Pad args to match function arity (contracts may supply fewer args
+        // than the function requires — e.g., must_vary supplies 1 arg for a 2-param fn)
+        auto padded_args = args;
+        if (fn.isVMClosure()) {
+            int arity = fn.asVMClosureConst()->function->arity;
+            while (static_cast<int>(padded_args.size()) < arity) {
+                padded_args.push_back(interpreter::NaabVal());  // null
+            }
+        }
+        return vm_call_fn_(fn, padded_args);
     }
 
     // --- Tree-walker path ---
@@ -3532,7 +3542,21 @@ interpreter::NaabVal GovernanceEngine::callContractTestFunction(
             fmt::format("Contract test: function '{}' is null", func_name));
     }
 
-    return interp->callFunction(fn, args);
+    // Pad args to match function arity (same as VM path above)
+    auto padded_args = args;
+    if (fn.isFunction()) {
+        size_t arity = fn.asFunctionConst()->params.size();
+        while (padded_args.size() < arity) {
+            padded_args.push_back(interpreter::NaabVal());  // null
+        }
+    } else if (fn.isVMClosure()) {
+        int arity = fn.asVMClosureConst()->function->arity;
+        while (static_cast<int>(padded_args.size()) < arity) {
+            padded_args.push_back(interpreter::NaabVal());  // null
+        }
+    }
+
+    return interp->callFunction(fn, padded_args);
 }
 
 std::string GovernanceEngine::checkMustProduce(
@@ -3624,12 +3648,29 @@ std::string GovernanceEngine::checkMustVary(
             args_b.push_back(jsonStringToNaabVal(spec.fixtures_json[1]));
         } else {
             // Generate synthetic inputs: empty list vs populated list
+            // Include common domain fields so functions that access .get("state"),
+            // .get("source"), etc. don't crash on missing keys
             args_a.push_back(interpreter::NaabVal::makeList({}));
             std::vector<interpreter::NaabVal> items;
             std::unordered_map<std::string, interpreter::NaabVal> d1, d2, d3;
             d1["severity"] = interpreter::NaabVal::makeInt(0);
+            d1["state"] = interpreter::NaabVal::makeInt(0);
+            d1["id"] = interpreter::NaabVal::makeString("synth-1");
+            d1["source"] = interpreter::NaabVal::makeString("synthetic");
+            d1["message"] = interpreter::NaabVal::makeString("test event 1");
+            d1["timestamp"] = interpreter::NaabVal::makeInt(1000000);
             d2["severity"] = interpreter::NaabVal::makeInt(5);
+            d2["state"] = interpreter::NaabVal::makeInt(2);
+            d2["id"] = interpreter::NaabVal::makeString("synth-2");
+            d2["source"] = interpreter::NaabVal::makeString("synthetic");
+            d2["message"] = interpreter::NaabVal::makeString("test event 2");
+            d2["timestamp"] = interpreter::NaabVal::makeInt(1000060);
             d3["severity"] = interpreter::NaabVal::makeInt(10);
+            d3["state"] = interpreter::NaabVal::makeInt(4);
+            d3["id"] = interpreter::NaabVal::makeString("synth-3");
+            d3["source"] = interpreter::NaabVal::makeString("synthetic");
+            d3["message"] = interpreter::NaabVal::makeString("test event 3");
+            d3["timestamp"] = interpreter::NaabVal::makeInt(1000120);
             items.push_back(interpreter::NaabVal::makeDict(std::move(d1)));
             items.push_back(interpreter::NaabVal::makeDict(std::move(d2)));
             items.push_back(interpreter::NaabVal::makeDict(std::move(d3)));

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -2874,12 +2874,23 @@ interpreter::NaabVal VM::run() {
                                     ? fc_lines[expr_start].substr(0, sstart) : "";
                                 std::string strimmed = (sstart != std::string::npos)
                                     ? fc_lines[expr_start].substr(sstart) : fc_lines[expr_start];
-                                fc_lines[expr_start] = leading + "print(" + strimmed;
-                                fc_lines[li] = fc_lines[li] + ")";
+                                bool is_structured = (!strimmed.empty() && (strimmed[0] == '{' || strimmed[0] == '['));
+                                if (is_structured) {
+                                    fc_lines[expr_start] = leading + "print(__import__('json').dumps(" + strimmed;
+                                    fc_lines[li] = fc_lines[li] + "))";
+                                } else {
+                                    fc_lines[expr_start] = leading + "print(" + strimmed;
+                                    fc_lines[li] = fc_lines[li] + ")";
+                                }
                             }
                         } else {
                             std::string leading = fc_lines[li].substr(0, start);
-                            fc_lines[li] = leading + "print(" + trimmed + ")";
+                            bool is_structured = (!trimmed.empty() && (trimmed[0] == '{' || trimmed[0] == '['));
+                            if (is_structured) {
+                                fc_lines[li] = leading + "print(__import__('json').dumps(" + trimmed + "))";
+                            } else {
+                                fc_lines[li] = leading + "print(" + trimmed + ")";
+                            }
                         }
                         break;
                     }

--- a/tests/governance/test_governance_enforcement.sh
+++ b/tests/governance/test_governance_enforcement.sh
@@ -32,6 +32,10 @@ fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); TOTAL=$((TOTAL + 1)); }
 WORK_DIR=$(mktemp -d "${TMPDIR:-/tmp}/gov_enforce_XXXXXX")
 trap "rm -rf $WORK_DIR" EXIT
 
+# Override HOME so the trust store at $HOME/.naab/trusted-keys is empty.
+# Without this, Ed25519 signing blocks unsigned temp governance files.
+export HOME="$WORK_DIR"
+
 echo "=== test_governance_enforcement.sh ==="
 
 # ---------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- **Auto-serialize Python dict/list returns** and fix `must_satisfy_args` unpacking for execution-based contracts
- **Pad execution contract args to match function arity** — `callContractTestFunction()` now pads with empty lists so multi-param functions don't crash with "Expected at least N arguments but got M"
- **Fix governance enforcement test** broken by Ed25519 trust store — isolate `$HOME` so unsigned temp governance files work
- **Contract arity padding uses empty list** instead of null — prevents Python `TypeError` when padded args hit `for item in param:` loops
- **Clarify `regex.search()` return type** in CLAUDE-TEMPLATE.md — returns bool, NOT matched string. LLMs were using the result as a string, causing "Expected string value" crashes. Added gotcha #60

All findings traced from gorilla tests naab-27_a through naab-27_e (Haiku 4.5 generating NAAb code against governance contracts).

## Test plan
- [ ] `bash run-all-tests.sh` — 391 tests, 1 pre-existing failure (`test_bsd_cdd_fixes.sh`)
- [ ] `bash tests/security/test_error_msg_leaks.sh` — 120 checks, 0 failures
- [ ] Verify gorilla test naab-27_c passes execution contracts (must_vary on multi-param functions)
- [ ] Verify gorilla test naab-27_d passes with empty list padding (no Python TypeError)

🤖 Generated with [Claude Code](https://claude.com/claude-code)