### PR TITLE
fix: telemetry path leak + REPL hardcoded block count

### DIFF
--- a/src/repl/repl.cpp
+++ b/src/repl/repl.cpp
@@ -124,8 +124,7 @@ private:
             if (i > 0) fmt::print(", ");
             fmt::print("{}", languages[i]);
         }
-        fmt::print("\n");
-        fmt::print("24,167 blocks available\n\n");
+        fmt::print("\n\n");
     }
 
     void handleCommand(const std::string& cmd) {

--- a/src/runtime/governance_reports.cpp
+++ b/src/runtime/governance_reports.cpp
@@ -3,6 +3,7 @@
 
 #include "naab/governance.h"
 #include "naab/telemetry_forwarder.h"
+#include "naab/error_sanitizer.h"
 #include "naab/crypto_utils.h"
 #include "naab/language_registry.h"
 #include "naab/interpreter.h"
@@ -245,7 +246,7 @@ void GovernanceEngine::emitRefusalAttestation(
     ev["result"] = "refused";
     ev["binding_status"] = "non-binding";
     ev["execution_prevented"] = true;
-    ev["file"] = current_check_file_;
+    ev["file"] = error::ErrorSanitizer::sanitizeFilePaths(current_check_file_);
     ev["line"] = current_check_line_;
     // Cap violation message to prevent telemetry bloat
     ev["violation_message"] = violation_message.size() > 500
@@ -883,7 +884,7 @@ void GovernanceEngine::writeTelemetry() const {
             ? (r.passed ? "Check passed: " + r.rule_name : "Check failed: " + r.rule_name)
             : r.message;
         ev["timestamp"] = timestamp;
-        ev["file"] = r.file;
+        ev["file"] = error::ErrorSanitizer::sanitizeFilePaths(r.file);
         ev["line"] = r.line;
         ev["category"] = r.category;
         ev["severity"] = r.severity;


### PR DESCRIPTION
## Summary

Fixes from Gemini 30-level slop audit triage. Of ~20 findings, 15 were false positives or by-design. 2 real issues fixed here:

- **G-1 (CRITICAL)**: Telemetry events in `governance_reports.cpp` included raw absolute paths (`ev["file"] = current_check_file_`) forwarded unsanitized to external webhooks via `telemetry_forwarder.cpp`. Applied `ErrorSanitizer::sanitizeFilePaths()` at both emission sites (refusal attestation + check results loop).
- **G-2 (LOW)**: REPL printed hardcoded `"24,167 blocks available"` — a static number with no runtime basis. Removed.

### Notable false positives from the audit
- L9 "STANDARD sandbox too permissive" — BY DESIGN (enforce upgrades unrestricted→standard)
- L15 "Persistent executor loses state" — FALSE (name means subprocess lifetime, not session state)
- L27 "No retry in agent_provider" — FALSE (retry+backoff+jitter exists in agent_impl.cpp)
- L1 "51 STUBs" — OVERSTATED 8.5x (only 5 remain, already cleaned in R8)
- L17 "Redundant sort" — FALSE (SQL sorts by usage, C++ re-sorts by computed weighted score)

## Test plan

- [x] Build: 0 errors
- [x] Security leak test: 738/738, 0 failures
- [x] Config fuzz test: 100/100, 0 crashes
- [x] Full test suite: 396/396 accounted, 0 unexpected failures

🤖 Generated with [Claude Code](https://claude.com/claude-code)