### PR TITLE
test: naab-x2 multi-agent gorilla test (50 assertions)

### DIFF
--- a/docs/book/verification/ch0_full_projects/Aegis/vessels/shield_src_1_1.rs
+++ b/docs/book/verification/ch0_full_projects/Aegis/vessels/shield_src_1_1.rs
@@ -39,7 +39,7 @@
     }
 
     fn main() {
-        let algo_type = 0;
+        let algo_type = 1;
 
         let mut buffer = String::new();
         io::stdin().read_to_string(&mut buffer).unwrap();

--- a/docs/book/verification/ch0_full_projects/Aegis/vessels/shield_src_1_2.rs
+++ b/docs/book/verification/ch0_full_projects/Aegis/vessels/shield_src_1_2.rs
@@ -39,7 +39,7 @@
     }
 
     fn main() {
-        let algo_type = 0;
+        let algo_type = 2;
 
         let mut buffer = String::new();
         io::stdin().read_to_string(&mut buffer).unwrap();

--- a/docs/book/verification/ch0_full_projects/Aegis/vessels/shield_src_1_3.rs
+++ b/docs/book/verification/ch0_full_projects/Aegis/vessels/shield_src_1_3.rs
@@ -39,7 +39,7 @@
     }
 
     fn main() {
-        let algo_type = 0;
+        let algo_type = 2;
 
         let mut buffer = String::new();
         io::stdin().read_to_string(&mut buffer).unwrap();

--- a/docs/book/verification/ch0_full_projects/Aegis/vessels/shield_src_2_1.rs
+++ b/docs/book/verification/ch0_full_projects/Aegis/vessels/shield_src_2_1.rs
@@ -39,7 +39,7 @@
     }
 
     fn main() {
-        let algo_type = 0;
+        let algo_type = 1;
 
         let mut buffer = String::new();
         io::stdin().read_to_string(&mut buffer).unwrap();

--- a/docs/book/verification/ch0_full_projects/Aegis/vessels/shield_src_2_2.rs
+++ b/docs/book/verification/ch0_full_projects/Aegis/vessels/shield_src_2_2.rs
@@ -39,7 +39,7 @@
     }
 
     fn main() {
-        let algo_type = 0;
+        let algo_type = 1;
 
         let mut buffer = String::new();
         io::stdin().read_to_string(&mut buffer).unwrap();

--- a/docs/govern-template.json
+++ b/docs/govern-template.json
@@ -1772,6 +1772,7 @@
 
   "_comment_agent_dispatch": "Agent Dispatch — parallel execution config for agent.batch() and agent.fan_out(). Controls thread pool size, concurrency limits, and run-level hard stop budgets.",
   "agent_dispatch": {
+    "default_timeout_seconds": 0,
     "max_concurrent": 6,
     "pool_size": 6,
     "pool_queue_max": 50,

--- a/govern-template.json
+++ b/govern-template.json
@@ -1772,6 +1772,7 @@
 
   "_comment_agent_dispatch": "Agent Dispatch — parallel execution config for agent.batch() and agent.fan_out(). Controls thread pool size, concurrency limits, and run-level hard stop budgets.",
   "agent_dispatch": {
+    "default_timeout_seconds": 0,
     "max_concurrent": 6,
     "pool_size": 6,
     "pool_queue_max": 50,

--- a/include/naab/governance.h
+++ b/include/naab/governance.h
@@ -1841,6 +1841,7 @@ struct TelemetryOutputConfig {
     int forward_retry_count = 2;        // retries on transient failure
     int forward_buffer_max = 1000;      // max queued events before drop
     int forward_shutdown_drain_ms = 5000; // M2: max shutdown drain time
+    bool deduplicate_checks = false;  // Fix 4B: collapse duplicate (rule,file,line) entries
 };
 
 // ============================================================================
@@ -1888,7 +1889,7 @@ struct AgentConfig {
     double temperature = 1.0;
     std::string stop_reason_action = "end";
     bool stream = false;
-    int timeout_seconds = 30;  // F11: per-call LLM API timeout
+    int timeout_seconds = 60;  // F11: per-call LLM API timeout (raised from 30 — slow models need 50+s)
     std::string response_format;  // "json" = validate + warn on non-JSON responses
     int risk_budget = 0;          // F8: finite risk budget (0 = unlimited), consumed by governance events
 
@@ -2105,6 +2106,7 @@ struct GovernanceRules {
         int pool_size = 6;         // thread pool worker count (I/O-bound, not CPU)
         int pool_queue_max = 50;   // max queued tasks before rejection
         int max_retries_per_run = 0; // 0 = unlimited
+        int default_timeout_seconds = 0; // 0 = use per-agent struct default (60s)
 
         // Hard stop: run-level kill switch for all agent API calls
         struct HardStopConfig {
@@ -2327,6 +2329,7 @@ public:
     bool isOverrideEnabled() const { return override_enabled_; }
     void setOverrideEnabled(bool enabled) { override_enabled_ = enabled; }
     void setOverrideReason(const std::string& reason) { override_reason_ = reason; }
+    void setAgentGovernanceActive(bool active) { agent_governance_active_.store(active, std::memory_order_relaxed); }
     const std::string& getOverrideReason() const { return override_reason_; }
     bool hasValidApproval(const std::string& rule_name, std::string& approver_id_out) const;
     const std::string& getLoadedPath() const { return loaded_path_; }
@@ -2355,7 +2358,7 @@ public:
     void applyAgentRole();
 
     // --- VM integration for execution contracts (type-erased to avoid VM link dependency) ---
-    using ContractCallFn = std::function<interpreter::NaabVal(interpreter::NaabVal, const std::vector<interpreter::NaabVal>&)>;
+    using ContractCallFn = std::function<interpreter::NaabVal(interpreter::NaabVal, const std::vector<interpreter::NaabVal>&, bool)>;
     using ContractGlobalsFn = std::function<const std::unordered_map<std::string, interpreter::NaabVal>&()>;
     void setVMCallbacks(ContractCallFn call_fn, ContractGlobalsFn globals_fn) {
         vm_call_fn_ = std::move(call_fn);
@@ -2364,12 +2367,14 @@ public:
     void clearVMCallbacks() { vm_call_fn_ = nullptr; vm_globals_fn_ = nullptr; }
 
     // Call a NaabVal function via the VM callback (used by tool execution loop)
+    // taint_all_args: when true, mark all arguments as tainted on the VM stack
     interpreter::NaabVal callVMFunction(const interpreter::NaabVal& fn,
-                                         const std::vector<interpreter::NaabVal>& args) {
+                                         const std::vector<interpreter::NaabVal>& args,
+                                         bool taint_all_args = false) {
         if (!vm_call_fn_) {
             throw std::runtime_error("Agent error: no VM callback available for tool execution");
         }
-        return vm_call_fn_(fn, args);
+        return vm_call_fn_(fn, args, taint_all_args);
     }
     bool hasVMCallbacks() const { return vm_call_fn_ != nullptr; }
 
@@ -2722,6 +2727,7 @@ public:
     int consumeRiskBudget(const std::string& config, int cost);   // F8: consume budget, return remaining
     int getRemainingBudget(const std::string& config) const;      // F8: query remaining budget
     std::string checkGovernanceHealth(int turn);    // F4: verify governance instrumentation
+    void emitEndOfRunHealthWarnings(FILE* fp, const std::string& timestamp) const;  // Fix 5B: end-of-run safety net
     double computeGovernanceEntropy() const;        // F16: entropy of governance check results
     GovernanceLevel getGovernanceLevel() const;     // F6: current system-wide governance level
     PulseVerdict computePulseVerdict(int turn);     // compute and update pulse health
@@ -2919,6 +2925,7 @@ private:
     std::unordered_set<std::string> unique_agents_;
     mutable std::mutex exposure_mutex_;         // guards unique_agents_
     std::atomic<bool> cdd_enabled_{false};
+    std::atomic<bool> agent_governance_active_{false};  // Fix 3B: only count consecutive_passes during agent phase
 
     // F8: Per-agent risk budget
     std::unordered_map<std::string, int> agent_risk_consumed_;

--- a/include/naab/vm.h
+++ b/include/naab/vm.h
@@ -351,8 +351,10 @@ public:
     const std::unordered_map<std::string, interpreter::NaabVal>& getGlobals() const { return globals_; }
 
     // Call a NAAb function from C++ (used by stdlib callbacks and governance contracts)
+    // taint_all_args: when true, mark all arguments as tainted (for tool execution with LLM-generated args)
     interpreter::NaabVal callNaabFunction(interpreter::NaabVal fn,
-                                          const std::vector<interpreter::NaabVal>& args);
+                                          const std::vector<interpreter::NaabVal>& args,
+                                          bool taint_all_args = false);
 
     // Debugger: get current scope variables (slot → name mapping)
     std::map<std::string, interpreter::NaabVal> getCurrentScopeVariables() const;

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -2350,8 +2350,8 @@ int main(int argc, char** argv) {
                 // (must be set before execute so callVMFunction works in tool loops)
                 if (vm_governance.isActive()) {
                     vm_governance.setVMCallbacks(
-                        [&bytecode_vm](auto fn, const auto& args) {
-                            return bytecode_vm.callNaabFunction(fn, args);
+                        [&bytecode_vm](naab::interpreter::NaabVal fn, const std::vector<naab::interpreter::NaabVal>& args, bool taint) {
+                            return bytecode_vm.callNaabFunction(fn, args, taint);
                         },
                         [&bytecode_vm]() -> const auto& {
                             return bytecode_vm.getGlobals();
@@ -2385,8 +2385,8 @@ int main(int argc, char** argv) {
                 // Pass 3: Execution-based contract tests (must_produce, must_vary, etc.)
                 if (vm_governance.isActive() && !no_governance) {
                     vm_governance.setVMCallbacks(
-                        [&bytecode_vm](auto fn, const auto& args) {
-                            return bytecode_vm.callNaabFunction(fn, args);
+                        [&bytecode_vm](naab::interpreter::NaabVal fn, const std::vector<naab::interpreter::NaabVal>& args, bool taint) {
+                            return bytecode_vm.callNaabFunction(fn, args, taint);
                         },
                         [&bytecode_vm]() -> const auto& {
                             return bytecode_vm.getGlobals();

--- a/src/runtime/agent_provider.cpp
+++ b/src/runtime/agent_provider.cpp
@@ -93,7 +93,7 @@ static HttpResult httpPostRaw(
     curl_easy_setopt(curl, CURLOPT_WRITEFUNCTION, ProviderWriteCallback);
     curl_easy_setopt(curl, CURLOPT_WRITEDATA, &sink);
 
-    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : 30L);
+    curl_easy_setopt(curl, CURLOPT_TIMEOUT, timeout_seconds > 0 ? timeout_seconds : 60L);
     curl_easy_setopt(curl, CURLOPT_PROTOCOLS_STR, "https");
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYPEER, 1L);
     curl_easy_setopt(curl, CURLOPT_SSL_VERIFYHOST, 2L);

--- a/src/runtime/governance_checks.cpp
+++ b/src/runtime/governance_checks.cpp
@@ -3638,7 +3638,7 @@ interpreter::NaabVal GovernanceEngine::callContractTestFunction(
                 padded_args.push_back(interpreter::NaabVal::makeList({}));  // empty list
             }
         }
-        return vm_call_fn_(fn, padded_args);
+        return vm_call_fn_(fn, padded_args, false);  // contract test args — not tainted
     }
 
     // --- Tree-walker path ---

--- a/src/runtime/governance_config.cpp
+++ b/src/runtime/governance_config.cpp
@@ -2181,6 +2181,10 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
             int v = tel["forward_shutdown_drain_ms"].get<int>();
             rules_.telemetry_output.forward_shutdown_drain_ms = v < 0 ? 0 : v;
         }
+        // Fix 4B: opt-in telemetry check deduplication
+        if (tel.contains("deduplicate_checks") && tel["deduplicate_checks"].is_boolean()) {
+            rules_.telemetry_output.deduplicate_checks = tel["deduplicate_checks"].get<bool>();
+        }
     }
 
     // Auto-enable tamper-evident hash chain when output_file is set
@@ -2194,6 +2198,7 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
     // --- Agents (unified config: permissions + LLM) ---
     // Prefer "agents" key; fall back to legacy "agent_roles" for backward compat
     std::string agents_key = j.contains("agents") ? "agents" : "agent_roles";
+    std::unordered_set<std::string> agents_with_explicit_timeout;
     if (j.contains(agents_key) && j[agents_key].is_object()) {
         for (auto& [name, cfg_json] : j[agents_key].items()) {
             AgentConfig agent;
@@ -2303,8 +2308,10 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
                     agent.stop_reason_action = cfg_json["stop_reason_action"].get<std::string>();
                 if (cfg_json.contains("stream") && cfg_json["stream"].is_boolean())
                     agent.stream = cfg_json["stream"].get<bool>();
-                if (cfg_json.contains("timeout") && cfg_json["timeout"].is_number_integer())
+                if (cfg_json.contains("timeout") && cfg_json["timeout"].is_number_integer()) {
                     agent.timeout_seconds = cfg_json["timeout"].get<int>();
+                    agents_with_explicit_timeout.insert(name);
+                }
                 if (cfg_json.contains("response_format") && cfg_json["response_format"].is_string())
                     agent.response_format = cfg_json["response_format"].get<std::string>();
                 if (cfg_json.contains("risk_budget") && cfg_json["risk_budget"].is_number_integer()) {
@@ -2491,6 +2498,8 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
             rules_.agent_dispatch.pool_queue_max = ad["pool_queue_max"].get<int>(); rules_.explicitly_set.insert("agent_dispatch.pool_queue_max"); }
         if (ad.contains("max_retries_per_run") && ad["max_retries_per_run"].is_number_integer()) {
             rules_.agent_dispatch.max_retries_per_run = std::max(0, ad["max_retries_per_run"].get<int>()); rules_.explicitly_set.insert("agent_dispatch.max_retries_per_run"); }
+        if (ad.contains("default_timeout_seconds") && ad["default_timeout_seconds"].is_number_integer()) {
+            rules_.agent_dispatch.default_timeout_seconds = std::max(0, ad["default_timeout_seconds"].get<int>()); rules_.explicitly_set.insert("agent_dispatch.default_timeout_seconds"); }
         if (ad.contains("hard_stop") && ad["hard_stop"].is_object()) {
             auto& hs = ad["hard_stop"];
             if (hs.contains("max_calls_per_run") && hs["max_calls_per_run"].is_number_integer()) {
@@ -2503,6 +2512,15 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
                 rules_.agent_dispatch.hard_stop.consecutive_failure_limit = std::max(0, hs["consecutive_failure_limit"].get<int>()); rules_.explicitly_set.insert("agent_dispatch.hard_stop.consecutive_failure_limit"); }
             if (hs.contains("action") && hs["action"].is_string()) {
                 rules_.agent_dispatch.hard_stop.action = hs["action"].get<std::string>(); rules_.explicitly_set.insert("agent_dispatch.hard_stop.action"); }
+        }
+    }
+
+    // Apply agent_dispatch.default_timeout_seconds to agents without explicit timeout
+    if (rules_.agent_dispatch.default_timeout_seconds > 0) {
+        for (auto& agent : rules_.agents) {
+            if (!agents_with_explicit_timeout.count(agent.name)) {
+                agent.timeout_seconds = rules_.agent_dispatch.default_timeout_seconds;
+            }
         }
     }
 
@@ -2998,6 +3016,9 @@ static bool checkRatchetViolation(
         if (new_agent.timeout_seconds < old_agent->timeout_seconds)
             notices.push_back(fmt::format("agent.{}.timeout_seconds: {} -> {} (reduced)",
                 new_agent.name, old_agent->timeout_seconds, new_agent.timeout_seconds));
+        if (new_agent.timeout_seconds > old_agent->timeout_seconds && old_agent->timeout_seconds > 0)
+            violations.push_back(fmt::format("agent.{}.timeout_seconds: {} -> {} (loosened)",
+                new_agent.name, old_agent->timeout_seconds, new_agent.timeout_seconds));
         if (new_agent.temperature != old_agent->temperature)
             notices.push_back(fmt::format("agent.{}.temperature: {:.1f} -> {:.1f}",
                 new_agent.name, old_agent->temperature, new_agent.temperature));
@@ -3118,6 +3139,15 @@ static bool checkRatchetViolation(
                 old_agent.name));
         }
     }
+
+    // --- Agent dispatch ratchet enforcement ---
+    if (new_r.agent_dispatch.default_timeout_seconds > old_r.agent_dispatch.default_timeout_seconds
+        && old_r.agent_dispatch.default_timeout_seconds > 0)
+        violations.push_back(fmt::format("agent_dispatch.default_timeout_seconds: {} -> {} (loosened)",
+            old_r.agent_dispatch.default_timeout_seconds, new_r.agent_dispatch.default_timeout_seconds));
+    else if (new_r.agent_dispatch.default_timeout_seconds < old_r.agent_dispatch.default_timeout_seconds)
+        notices.push_back(fmt::format("agent_dispatch.default_timeout_seconds: {} -> {} (tightened)",
+            old_r.agent_dispatch.default_timeout_seconds, new_r.agent_dispatch.default_timeout_seconds));
 
     // --- Codegen ratchet enforcement ---
     // codegen.enabled: false→true = loosening
@@ -3946,6 +3976,7 @@ void GovernanceEngine::mergeRules(const GovernanceRules& base, GovernanceRules& 
             if (bad.pool_size != defaults.agent_dispatch.pool_size) cad.pool_size = bad.pool_size;
             if (bad.pool_queue_max != defaults.agent_dispatch.pool_queue_max) cad.pool_queue_max = bad.pool_queue_max;
             if (bad.max_retries_per_run > 0) cad.max_retries_per_run = bad.max_retries_per_run;
+            if (bad.default_timeout_seconds > 0) cad.default_timeout_seconds = bad.default_timeout_seconds;
             if (bad.hard_stop.max_calls_per_run > 0) cad.hard_stop.max_calls_per_run = bad.hard_stop.max_calls_per_run;
             if (bad.hard_stop.max_tokens_per_run > 0) cad.hard_stop.max_tokens_per_run = bad.hard_stop.max_tokens_per_run;
             if (bad.hard_stop.max_agent_time_ms > 0) cad.hard_stop.max_agent_time_ms = bad.hard_stop.max_agent_time_ms;
@@ -3961,6 +3992,8 @@ void GovernanceEngine::mergeRules(const GovernanceRules& base, GovernanceRules& 
                 cad.pool_queue_max = bad.pool_queue_max;
             if (!child.explicitly_set.count("agent_dispatch.max_retries_per_run") && bad.max_retries_per_run > 0)
                 cad.max_retries_per_run = bad.max_retries_per_run;
+            if (!child.explicitly_set.count("agent_dispatch.default_timeout_seconds") && bad.default_timeout_seconds > 0)
+                cad.default_timeout_seconds = bad.default_timeout_seconds;
             if (!child.explicitly_set.count("agent_dispatch.hard_stop.max_calls_per_run") && bad.hard_stop.max_calls_per_run > 0)
                 cad.hard_stop.max_calls_per_run = bad.hard_stop.max_calls_per_run;
             if (!child.explicitly_set.count("agent_dispatch.hard_stop.max_tokens_per_run") && bad.hard_stop.max_tokens_per_run > 0)

--- a/src/runtime/governance_engine.cpp
+++ b/src/runtime/governance_engine.cpp
@@ -873,7 +873,12 @@ void GovernanceEngine::recordPass(const std::string& rule_name,
     }
     // Pulse: track governance liveness
     pulse_.total_checks++;
-    pulse_.consecutive_passes++;
+    // Fix 3B: only count consecutive passes during agent phase.
+    // Static source checks (~1,800) naturally all pass, inflating the counter
+    // past consecutive_passes_suspicion and triggering spurious DEGRADED verdict.
+    if (agent_governance_active_.load(std::memory_order_relaxed)) {
+        pulse_.consecutive_passes++;
+    }
     pulse_.last_check_epoch_ms = std::chrono::duration_cast<std::chrono::milliseconds>(
         std::chrono::steady_clock::now().time_since_epoch()).count();
 }
@@ -5962,6 +5967,54 @@ std::string GovernanceEngine::checkGovernanceHealth(int turn) {
     return warnings;
 }
 
+// Fix 5B: End-of-run health check — emits GOVERNANCE_HEALTH_WARNING telemetry events
+// for instrumentation failures that the per-turn checkGovernanceHealth() missed
+// (e.g., because check_after_turns was never reached).
+// This is const-safe: uses only atomic loads and const methods on drift_analyzer_/sequence_detector_.
+void GovernanceEngine::emitEndOfRunHealthWarnings(FILE* fp, const std::string& timestamp) const {
+    if (!rules().governance_health.enabled) return;
+
+    auto emitWarning = [&](const std::string& detail) {
+        nlohmann::json ev;
+        ev["run_id"] = run_id_;
+        ev["event_type"] = "GOVERNANCE_HEALTH_WARNING";
+        ev["source"] = "end_of_run";
+        ev["timestamp"] = timestamp;
+        ev["detail"] = detail;
+        if (rules().telemetry_output.tamper_evidence.enabled) {
+            std::lock_guard<std::mutex> hlock(telemetry_hash_mutex_);
+            ev["prev_hash"] = last_telemetry_hash_.empty()
+                ? rules().telemetry_output.tamper_evidence.chain_genesis
+                : last_telemetry_hash_;
+            last_telemetry_hash_ = computeHash(ev.dump(),
+                rules().telemetry_output.tamper_evidence);
+            ev["hash"] = last_telemetry_hash_;
+        }
+        std::string line = ev.dump() + "\n";
+        fwrite(line.c_str(), 1, line.size(), fp);
+    };
+
+    // Check 1: CDD enabled but never analyzed any turns
+    if (cdd_enabled_.load(std::memory_order_relaxed) &&
+        drift_analyzer_.totalTurnsAnalyzed() == 0) {
+        emitWarning("CDD enabled but analyzed 0 turns — context drift detection was inert this run");
+    }
+
+    // Check 2: BSD enabled but received no events
+    if (bsd_enabled_.load(std::memory_order_relaxed) &&
+        sequence_detector_.totalEventsProcessed() == 0) {
+        emitWarning("BSD enabled but received 0 events — behavioral sequence detection was inert this run");
+    }
+
+    // Check 3: check_after_turns never reached (agents ran but too few turns)
+    size_t cdd_turns = drift_analyzer_.totalTurnsAnalyzed();
+    if (rules().governance_health.check_after_turns > static_cast<int>(cdd_turns) && cdd_turns > 0) {
+        emitWarning("check_after_turns=" + std::to_string(rules().governance_health.check_after_turns) +
+            " but only " + std::to_string(cdd_turns) +
+            " agent turns occurred — per-turn health check never fired");
+    }
+}
+
 int GovernanceEngine::checkDecisionTraceCoherence(const std::string& agent_config) {
     std::lock_guard<std::mutex> lock(trace_history_mutex_);
     auto& traces = agent_decision_traces_[agent_config];
@@ -6065,9 +6118,13 @@ PulseVerdict GovernanceEngine::computePulseVerdict(int turn) {
     bool cdd_ok = (cdd_turns > 0 || turn < 3 || !cdd_enabled_.load());
     if (!cdd_ok && cdd_enabled_.load()) degradation_signals++;
 
-    // Subsystem: entropy health
+    // Subsystem: entropy health — only after agent phase startup.
+    // Static source checks (~1,800) are inherently uniform (all pass = entropy ~0)
+    // and dominate check_results_ for the first few agent turns. Grace period (turn >= 3)
+    // matches BSD/CDD startup grace to let agent-phase checks accumulate.
     double ent = computeGovernanceEntropy();
-    if (ent >= 0.0 && ent < rules().governance_health.governance_entropy_warning)
+    if (agent_governance_active_.load(std::memory_order_relaxed) && turn >= 3 &&
+        ent >= 0.0 && ent < rules().governance_health.governance_entropy_warning)
         degradation_signals++;
 
     // Subsystem: telemetry health (hash chain advancing = telemetry operational)

--- a/src/runtime/governance_reports.cpp
+++ b/src/runtime/governance_reports.cpp
@@ -17,6 +17,7 @@
 #include <regex>
 #include <chrono>
 #include <functional>
+#include <unordered_set>
 #ifndef _WIN32
 #  include <sys/file.h>
 #endif
@@ -873,7 +874,17 @@ void GovernanceEngine::writeTelemetry() const {
     std::strftime(ts_buf, sizeof(ts_buf), "%Y-%m-%dT%H:%M:%S", &tm_buf);
     std::string timestamp(ts_buf);
 
+    // Fix 4B: opt-in deduplication of governance check entries
+    std::unordered_set<std::string> seen_keys;
+    size_t dedup_count = 0;
+
     for (const auto& r : check_results_) {
+        // Fix 4B: skip duplicate (rule_name, file, line) entries
+        if (rules().telemetry_output.deduplicate_checks) {
+            std::string key = r.rule_name + "|" + r.file + "|" + std::to_string(r.line);
+            if (!seen_keys.insert(key).second) { dedup_count++; continue; }
+        }
+
         nlohmann::json ev;
         ev["run_id"] = run_id_;
         ev["agent_id"] = agent_id_;
@@ -921,6 +932,33 @@ void GovernanceEngine::writeTelemetry() const {
             if (fwd) fwd->enqueue(ev.dump());
         }
     }
+
+    // Fix 4B: emit summary event recording dedup stats
+    if (rules().telemetry_output.deduplicate_checks && dedup_count > 0) {
+        nlohmann::json summary;
+        summary["run_id"] = run_id_;
+        summary["event_type"] = "GovernanceCheckSummary";
+        summary["timestamp"] = timestamp;
+        summary["total_checks"] = check_results_.size();
+        summary["unique_sites"] = seen_keys.size();
+        summary["deduplicated"] = dedup_count;
+        if (rules().telemetry_output.tamper_evidence.enabled) {
+            std::lock_guard<std::mutex> hlock(telemetry_hash_mutex_);
+            summary["prev_hash"] = last_telemetry_hash_.empty()
+                ? rules().telemetry_output.tamper_evidence.chain_genesis
+                : last_telemetry_hash_;
+            last_telemetry_hash_ = computeHash(summary.dump(),
+                rules().telemetry_output.tamper_evidence);
+            summary["hash"] = last_telemetry_hash_;
+        }
+        std::string sline = summary.dump() + "\n";
+        fwrite(sline.c_str(), 1, sline.size(), fp.get());
+    }
+
+    // Fix 5B: emit end-of-run health warnings (catches instrumentation failures
+    // that per-turn checkGovernanceHealth() missed due to check_after_turns gate)
+    emitEndOfRunHealthWarnings(fp.get(), timestamp);
+
     // fp_deleter handles flock(LOCK_UN) + fclose automatically.
 
     if (!check_results_.empty()) {

--- a/src/stdlib/agent_impl.cpp
+++ b/src/stdlib/agent_impl.cpp
@@ -613,6 +613,10 @@ static NaabVal agentCreate(std::vector<NaabVal>& args) {
             "  - Agents must be defined in governance config before use\n");
     }
 
+    // Fix 3B: mark agent phase active so Pulse consecutive_passes counter
+    // only tracks agent-phase checks, not static source scanning.
+    engine->setAgentGovernanceActive(true);
+
     // Find agent config
     const auto* config = findAgentConfig(config_name);
     if (!config) {
@@ -1809,7 +1813,7 @@ static NaabVal agentSend(std::vector<NaabVal>& args) {
                         NaabVal result_val;
                         if (gov_engine && gov_engine->hasVMCallbacks()) {
                             result_val = gov_engine->callVMFunction(
-                                snap_it->second.function, naab_args);
+                                snap_it->second.function, naab_args, true);  // taint: args from LLM
                         } else {
                             throw std::runtime_error("Agent error: no VM callback for tool execution");
                         }

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -3824,7 +3824,8 @@ bool VM::callFunction(VMClosure* closure, int argc) {
 }
 
 interpreter::NaabVal VM::callNaabFunction(interpreter::NaabVal fn,
-                                          const std::vector<interpreter::NaabVal>& args) {
+                                          const std::vector<interpreter::NaabVal>& args,
+                                          bool taint_all_args) {
     if (!fn.isVMClosure()) {
         runtimeError("callNaabFunction: value is not a function");
     }
@@ -3842,9 +3843,12 @@ interpreter::NaabVal VM::callNaabFunction(interpreter::NaabVal fn,
     interpreter::NaabVal* saved_stack_top = stack_top_;
 
     // Push function + args onto stack
-    push(fn);  // callee slot
+    push(fn);  // callee slot (untainted — it's the function itself)
     for (auto& arg : args) {
         push(arg);
+        if (taint_all_args) {
+            *(taint_top_ - 1) = true;  // override the false set by push()
+        }
     }
 
     // Set up the call

--- a/tests/gorilla/naab-x2/phases/code-review-loop.json
+++ b/tests/gorilla/naab-x2/phases/code-review-loop.json
@@ -1,0 +1,116 @@
+{
+  "version": "5.0",
+  "mode": "enforce",
+  "description": "NAAb-X2 Cat 6: Code review loop with execution",
+  "languages": {
+    "allowed": ["python"],
+    "require_explicit": false
+  },
+  "capabilities": {
+    "network": { "enabled": true },
+    "filesystem": { "mode": "write" },
+    "shell": { "enabled": false }
+  },
+  "codegen": {
+    "enabled": true,
+    "allowed_languages": ["python"],
+    "allow_tainted_code": true,
+    "per_call_timeout_seconds": 10,
+    "max_calls_per_run": 30,
+    "max_output_chars": 4096
+  },
+  "agents": {
+    "architect": {
+      "provider": "gemini",
+      "model": "gemma-4-31b-it",
+      "api_key_env": ["GK1", "GK2", "GK3", "GK4", "GK5", "GK6", "GK7", "GK8", "GK9"],
+      "max_tokens": 1024,
+      "max_turns": 5,
+      "max_total_tokens": 20000,
+      "system_prompt": "You are a software architect. Design clear, testable specifications. Be concise.",
+      "tools_enabled": false,
+      "allowed_actions": ["AGENT_SEND"],
+      "retry": { "max_attempts": 3, "backoff_ms": 5000 }
+    },
+    "coder": {
+      "provider": "gemini",
+      "model": "gemma-4-31b-it",
+      "api_key_env": ["GK1", "GK2", "GK3", "GK4", "GK5", "GK6", "GK7", "GK8", "GK9"],
+      "max_tokens": 2048,
+      "max_turns": 10,
+      "max_total_tokens": 60000,
+      "system_prompt": "You are a Python programmer. When you write code, ALWAYS test it by calling the run_code tool before giving your final answer. If the tool shows errors, fix the code and run it again. Wrap your final code in ```python fences.",
+      "tools_enabled": true,
+      "tools": ["run_code"],
+      "max_tool_calls_per_turn": 5,
+      "max_tool_loop_turns": 5,
+      "tool_result_max_chars": 4096,
+      "tool_timeout_seconds": 15,
+      "allowed_actions": ["AGENT_SEND", "TOOL_EXEC"],
+      "retry": { "max_attempts": 3, "backoff_ms": 5000 }
+    },
+    "executor": {
+      "provider": "gemini",
+      "model": "gemma-4-31b-it",
+      "api_key_env": ["GK1", "GK2", "GK3", "GK4", "GK5", "GK6", "GK7", "GK8", "GK9"],
+      "max_tokens": 1024,
+      "max_turns": 5,
+      "max_total_tokens": 20000,
+      "system_prompt": "You are a QA engineer. You receive code and its execution output. Analyze whether the output is correct and complete. Report any bugs, missing edge cases, or incorrect behavior. Be specific and factual. End with PASS or FAIL.",
+      "tools_enabled": false,
+      "allowed_actions": ["AGENT_SEND"],
+      "retry": { "max_attempts": 3, "backoff_ms": 5000 }
+    },
+    "reviewer": {
+      "provider": "gemini",
+      "model": "gemma-4-31b-it",
+      "api_key_env": ["GK1", "GK2", "GK3", "GK4", "GK5", "GK6", "GK7", "GK8", "GK9"],
+      "max_tokens": 1024,
+      "max_turns": 5,
+      "max_total_tokens": 20000,
+      "system_prompt": "You are a senior code reviewer. You receive code, execution output, and a QA report. Decide if the code is production-ready. If not, give specific, actionable feedback the developer can use to fix it. End with APPROVED or REJECTED with a one-line reason.",
+      "tools_enabled": false,
+      "allowed_actions": ["AGENT_SEND"],
+      "retry": { "max_attempts": 3, "backoff_ms": 5000 }
+    }
+  },
+  "agent_dispatch": {
+    "default_timeout_seconds": 90,
+    "max_concurrent": 4,
+    "max_calls_per_run": 50,
+    "max_tokens_per_run": 500000,
+    "max_agent_time_ms": 600000
+  },
+  "taint_tracking": {
+    "enabled": true,
+    "level": "detect",
+    "sources": ["env.get", "polyglot_output", "agent_output"],
+    "sinks": ["file.write", "file.append"]
+  },
+  "limits": {
+    "timeout": {"global": 600},
+    "call_depth": 100,
+    "loop_iterations": 100000
+  },
+  "security": {
+    "sandbox_level": "elevated"
+  },
+  "pipeline_separation": {
+    "enabled": true,
+    "level": "soft",
+    "max_pipeline_depth": 5
+  },
+  "scanner": {
+    "enabled": true,
+    "code_quality": true,
+    "lang_naab": true
+  },
+  "requirements": {
+    "variable_binding": "soft",
+    "main_block": "hard"
+  },
+  "code_quality": {
+    "no_secrets": "hard",
+    "no_placeholders": "soft"
+  }
+}

--- a/tests/gorilla/naab-x2/phases/multi-agent.json
+++ b/tests/gorilla/naab-x2/phases/multi-agent.json
@@ -24,7 +24,7 @@
       "response_format": "text",
       "tools_enabled": false,
       "allowed_actions": ["AGENT_SEND"],
-      "retry": { "max_attempts": 6, "backoff_ms": 500 }
+      "retry": { "max_attempts": 3, "backoff_ms": 5000 }
     },
     "coder": {
       "provider": "gemini",
@@ -37,7 +37,7 @@
       "response_format": "text",
       "tools_enabled": false,
       "allowed_actions": ["AGENT_SEND"],
-      "retry": { "max_attempts": 6, "backoff_ms": 500 }
+      "retry": { "max_attempts": 3, "backoff_ms": 5000 }
     },
     "reviewer_a": {
       "provider": "gemini",
@@ -50,7 +50,7 @@
       "response_format": "text",
       "tools_enabled": false,
       "allowed_actions": ["AGENT_SEND"],
-      "retry": { "max_attempts": 6, "backoff_ms": 500 }
+      "retry": { "max_attempts": 3, "backoff_ms": 5000 }
     },
     "reviewer_b": {
       "provider": "gemini",
@@ -63,7 +63,7 @@
       "response_format": "text",
       "tools_enabled": false,
       "allowed_actions": ["AGENT_SEND"],
-      "retry": { "max_attempts": 6, "backoff_ms": 500 }
+      "retry": { "max_attempts": 3, "backoff_ms": 5000 }
     },
     "integrator": {
       "provider": "gemini",
@@ -81,7 +81,7 @@
       "tool_result_max_chars": 2048,
       "tool_timeout_seconds": 10,
       "allowed_actions": ["AGENT_SEND", "TOOL_EXEC"],
-      "retry": { "max_attempts": 6, "backoff_ms": 500 }
+      "retry": { "max_attempts": 3, "backoff_ms": 5000 }
     },
     "no_send_agent": {
       "provider": "gemini",
@@ -96,6 +96,7 @@
     }
   },
   "agent_dispatch": {
+    "default_timeout_seconds": 90,
     "max_concurrent": 4,
     "max_calls_per_run": 80,
     "max_tokens_per_run": 500000,

--- a/tests/gorilla/naab-x2/phases/multi-agent.json
+++ b/tests/gorilla/naab-x2/phases/multi-agent.json
@@ -1,0 +1,155 @@
+{
+  "version": "5.0",
+  "mode": "enforce",
+  "description": "NAAb-X2: Multi-agent app-builder gorilla test",
+  "languages": {
+    "allowed": ["python"],
+    "require_explicit": false
+  },
+  "capabilities": {
+    "network": { "enabled": true },
+    "filesystem": { "mode": "write" },
+    "shell": { "enabled": false }
+  },
+  "agents": {
+    "architect": {
+      "provider": "gemini",
+      "model": "gemma-4-31b-it",
+      "api_key_env": ["GK1", "GK2", "GK3", "GK4", "GK5", "GK6", "GK7", "GK8", "GK9"],
+      "max_tokens": 1024,
+      "max_turns": 15,
+      "max_total_tokens": 30000,
+      "standing_lease_turns": 10,
+      "system_prompt": "You are a software architect. When asked to design an app, respond with a clear specification including data models, function signatures, and module structure. Be concise. Always respond with substantive technical content.",
+      "response_format": "text",
+      "tools_enabled": false,
+      "allowed_actions": ["AGENT_SEND"],
+      "retry": { "max_attempts": 6, "backoff_ms": 500 }
+    },
+    "coder": {
+      "provider": "gemini",
+      "model": "gemma-4-31b-it",
+      "api_key_env": ["GK1", "GK2", "GK3", "GK4", "GK5", "GK6", "GK7", "GK8", "GK9"],
+      "max_tokens": 2048,
+      "max_turns": 15,
+      "max_total_tokens": 50000,
+      "system_prompt": "You are a programmer. Given a specification, write clean code. Always wrap your code output in ```python fences. Be concise and produce working code.",
+      "response_format": "text",
+      "tools_enabled": false,
+      "allowed_actions": ["AGENT_SEND"],
+      "retry": { "max_attempts": 6, "backoff_ms": 500 }
+    },
+    "reviewer_a": {
+      "provider": "gemini",
+      "model": "gemma-4-31b-it",
+      "api_key_env": ["GK1", "GK2", "GK3", "GK4", "GK5", "GK6", "GK7", "GK8", "GK9"],
+      "max_tokens": 512,
+      "max_turns": 10,
+      "max_total_tokens": 15000,
+      "system_prompt": "You are a strict code reviewer focused on correctness and security. Review code and end your review with exactly one of: APPROVED, REJECTED, or NEEDS_REVIEW. Be concise.",
+      "response_format": "text",
+      "tools_enabled": false,
+      "allowed_actions": ["AGENT_SEND"],
+      "retry": { "max_attempts": 6, "backoff_ms": 500 }
+    },
+    "reviewer_b": {
+      "provider": "gemini",
+      "model": "gemma-4-31b-it",
+      "api_key_env": ["GK1", "GK2", "GK3", "GK4", "GK5", "GK6", "GK7", "GK8", "GK9"],
+      "max_tokens": 512,
+      "max_turns": 10,
+      "max_total_tokens": 15000,
+      "system_prompt": "You are a pragmatic code reviewer focused on readability and maintainability. Review code and end your review with exactly one of: APPROVED, REJECTED, or NEEDS_REVIEW. Be concise.",
+      "response_format": "text",
+      "tools_enabled": false,
+      "allowed_actions": ["AGENT_SEND"],
+      "retry": { "max_attempts": 6, "backoff_ms": 500 }
+    },
+    "integrator": {
+      "provider": "gemini",
+      "model": "gemma-4-31b-it",
+      "api_key_env": ["GK1", "GK2", "GK3", "GK4", "GK5", "GK6", "GK7", "GK8", "GK9"],
+      "max_tokens": 1024,
+      "max_turns": 15,
+      "max_total_tokens": 30000,
+      "system_prompt": "You are a code integrator. Given code and review feedback, produce an improved version. When asked to validate or lint code, always use the available tools. Wrap code in ```python fences.",
+      "response_format": "text",
+      "tools_enabled": true,
+      "tools": ["validate_code", "lint_check"],
+      "max_tool_calls_per_turn": 3,
+      "max_tool_loop_turns": 3,
+      "tool_result_max_chars": 2048,
+      "tool_timeout_seconds": 10,
+      "allowed_actions": ["AGENT_SEND", "TOOL_EXEC"],
+      "retry": { "max_attempts": 6, "backoff_ms": 500 }
+    },
+    "no_send_agent": {
+      "provider": "gemini",
+      "model": "gemma-4-31b-it",
+      "api_key_env": ["GK1", "GK2", "GK3", "GK4", "GK5", "GK6", "GK7", "GK8", "GK9"],
+      "max_tokens": 256,
+      "max_turns": 5,
+      "system_prompt": "Test agent.",
+      "tools_enabled": false,
+      "allowed_actions": ["TOOL_EXEC"],
+      "retry": { "max_attempts": 3, "backoff_ms": 500 }
+    }
+  },
+  "agent_dispatch": {
+    "max_concurrent": 4,
+    "max_calls_per_run": 80,
+    "max_tokens_per_run": 500000,
+    "max_agent_time_ms": 600000
+  },
+  "taint_tracking": {
+    "enabled": true,
+    "level": "detect",
+    "sources": ["env.get", "polyglot_output", "agent_output"],
+    "sinks": ["file.write", "file.append"]
+  },
+  "context_drift": {
+    "enabled": true,
+    "threshold": 0.7,
+    "temporal_decay_enabled": false
+  },
+  "circuit_breaker": {
+    "enabled": true,
+    "step_up_enabled": false
+  },
+  "advisory_escalation": {
+    "enabled": true,
+    "soft_after": 5,
+    "weight_multiplier": 1.5
+  },
+  "pipeline_separation": {
+    "enabled": true,
+    "level": "soft",
+    "max_pipeline_depth": 5
+  },
+  "governance_health": {
+    "enabled": true,
+    "pulse_interval_turns": 5
+  },
+  "limits": {
+    "call_depth": 100,
+    "loop_iterations": 100000,
+    "timeout": {"global": 600}
+  },
+  "scanner": {
+    "enabled": true,
+    "code_quality": true,
+    "lang_naab": true
+  },
+  "requirements": {
+    "variable_binding": "soft",
+    "main_block": "hard"
+  },
+  "code_quality": {
+    "no_secrets": "hard",
+    "no_placeholders": "soft",
+    "no_simulation_markers": "soft"
+  },
+  "security": {
+    "sandbox_level": "elevated"
+  }
+}

--- a/tests/gorilla/naab-x2/run-naabx2.sh
+++ b/tests/gorilla/naab-x2/run-naabx2.sh
@@ -1,0 +1,489 @@
+#!/usr/bin/env bash
+# ============================================================================
+# NAAb-X2: Multi-Agent App Builder — Gorilla Test
+# 50 assertions across 5 categories verifying multi-agent collaboration:
+#   Cat 1: Fleet Setup (10, no API)         — create, check, env, key_health, dispatch, action matrix
+#   Cat 2: Pipeline Build (10, live API)    — send, pipeline, upstream provenance, extract_code
+#   Cat 3: Parallel Review (10, live API)   — fan_out, batch, consensus_vote, enforce_convergence
+#   Cat 4: Tool Refinement (10, live API)   — register_tool, integrator+tools, multi-turn, plan
+#   Cat 5: Observability (10, live API)     — usage, dispatch_status, env depth, governance, messages
+# Usage: bash run-naabx2.sh [--cat N]
+# ============================================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAAB="$SCRIPT_DIR/../../../build/naab-lang"
+NAAB="$(cd "$(dirname "$NAAB")" && pwd)/$(basename "$NAAB")"
+TEST_TMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}/naabx2-$$"
+RESULTS_DIR="$SCRIPT_DIR/results"
+SIGNING_KEY="$HOME/.naab/keys/signing.pem"
+
+# Colors
+RED='\033[0;31m'
+GREEN='\033[0;32m'
+YELLOW='\033[1;33m'
+CYAN='\033[0;36m'
+BOLD='\033[1m'
+NC='\033[0m'
+
+# Counters
+PASS_COUNT=0
+FAIL_COUNT=0
+SKIP_COUNT=0
+TOTAL=0
+FAILURES=""
+
+# Category selection
+RUN_CAT=0
+if [ "${1:-}" = "--cat" ] && [ -n "${2:-}" ]; then
+    RUN_CAT="$2"
+fi
+should_run() { [ "$RUN_CAT" -eq 0 ] || [ "$RUN_CAT" -eq "$1" ]; }
+
+pass() {
+    local id="$1" desc="$2"
+    PASS_COUNT=$((PASS_COUNT + 1)); TOTAL=$((TOTAL + 1))
+    echo -e "  ${GREEN}PASS${NC} [$id] $desc"
+}
+
+fail() {
+    local id="$1" desc="$2" detail="${3:-}"
+    FAIL_COUNT=$((FAIL_COUNT + 1)); TOTAL=$((TOTAL + 1))
+    echo -e "  ${RED}FAIL${NC} [$id] $desc"
+    [ -n "$detail" ] && echo -e "       ${RED}→ $detail${NC}"
+    FAILURES="${FAILURES}\n  [$id] $desc${detail:+ — $detail}"
+}
+
+skip() {
+    local id="$1" desc="$2"
+    SKIP_COUNT=$((SKIP_COUNT + 1)); TOTAL=$((TOTAL + 1))
+    echo -e "  ${YELLOW}SKIP${NC} [$id] $desc"
+}
+
+cleanup() {
+    rm -rf "$TEST_TMP" 2>/dev/null
+}
+trap cleanup EXIT
+
+# --- Banned patterns (must never leak in output) ---
+BANNED_PATTERNS=(
+    "--no-governance"
+    "--governance-override"
+    "--drift-baseline-save"
+    "--sign-governance"
+    "--sign-baseline"
+    "--keygen"
+    "NAAB_SIGNING_KEY"
+    "NAAB_GOVERN_KEY"
+    "soft-mandatory"
+    "soft.mandatory"
+)
+
+check_banned() {
+    local output="$1"
+    for pat in "${BANNED_PATTERNS[@]}"; do
+        if echo "$output" | grep -qi -- "$pat"; then
+            echo "$pat"
+            return 0
+        fi
+    done
+    return 1
+}
+
+# --- Trust store setup ---
+source "$(dirname "$0")/../../helpers/trust_setup.sh"
+setup_isolated_trust
+trap 'teardown_isolated_trust; rm -rf "$TEST_TMP"' EXIT
+
+"$NAAB" --keygen "$TEST_TMP/test-key.pem" >/dev/null 2>&1 || true
+mkdir -p "$TEST_TMP"
+"$NAAB" --keygen "$TEST_TMP/test-key.pem" >/dev/null 2>&1
+"$NAAB" --trust-key "$TEST_TMP/test-key.pem.pub" 2>/dev/null
+export NAAB_SIGNING_KEY="$TEST_TMP/test-key.pem"
+
+# Load API keys
+source "$HOME/.bashrc" 2>/dev/null || true
+
+setup_workdir() {
+    local workdir="$TEST_TMP/work-$$-$RANDOM"
+    mkdir -p "$workdir"
+    cp "$SCRIPT_DIR/phases/multi-agent.json" "$workdir/govern.json"
+    if [ -f "$NAAB_SIGNING_KEY" ]; then
+        (cd "$workdir" && NAAB_SIGNING_KEY="$NAAB_SIGNING_KEY" "$NAAB" --sign-governance >/dev/null 2>&1) || true
+    fi
+    echo "$workdir"
+}
+
+run_in() {
+    local workdir="$1" naab_file="$2"
+    cp "$SCRIPT_DIR/src/$naab_file" "$workdir/"
+    timeout 300 "$NAAB" --governance-dashboard "$workdir/$naab_file" 2>&1
+}
+
+# --- Header ---
+echo -e "${BOLD}${CYAN}+----------------------------------------------------------+${NC}"
+echo -e "${BOLD}${CYAN}|  NAAb-X2: Multi-Agent App Builder — Gorilla Test          |${NC}"
+echo -e "${BOLD}${CYAN}|  50 assertions across 5 categories                        |${NC}"
+echo -e "${BOLD}${CYAN}+----------------------------------------------------------+${NC}"
+echo ""
+
+# ======================================================================
+# CATEGORY 1: Fleet Setup (no API needed)
+# ======================================================================
+if should_run 1; then
+    echo -e "${CYAN}══════════════════════════════════════════════════════${NC}"
+    echo -e "${CYAN}  Category 1: Agent Fleet Setup (10 assertions)${NC}"
+    echo -e "${CYAN}══════════════════════════════════════════════════════${NC}"
+    echo ""
+
+    WORKDIR=$(setup_workdir)
+    output=$(run_in "$WORKDIR" "cat1_fleet_setup.naab")
+    exit_code=$?
+
+    # Check for banned patterns
+    if leaked=$(check_banned "$output"); then
+        fail "BAN" "Output leaks bypass hint" "$leaked"
+    fi
+
+    echo "$output" | grep -q 'a1_create_architect: true' && \
+        pass "A1" "Create architect agent" || \
+        fail "A1" "Architect creation failed" "$(echo "$output" | grep 'a1_error' | head -1)"
+
+    echo "$output" | grep -q 'a2_create_coder: true' && \
+        pass "A2" "Create coder agent" || \
+        fail "A2" "Coder creation failed" "$(echo "$output" | grep 'a2_error' | head -1)"
+
+    echo "$output" | grep -q 'a3_create_reviewer_a: true' && \
+        pass "A3" "Create reviewer_a agent" || \
+        fail "A3" "Reviewer A creation failed" "$(echo "$output" | grep 'a3_error' | head -1)"
+
+    echo "$output" | grep -q 'a4_create_reviewer_b: true' && \
+        pass "A4" "Create reviewer_b agent" || \
+        fail "A4" "Reviewer B creation failed" "$(echo "$output" | grep 'a4_error' | head -1)"
+
+    echo "$output" | grep -q 'a5_create_integrator: true' && \
+        pass "A5" "Create integrator agent (with tools)" || \
+        fail "A5" "Integrator creation failed" "$(echo "$output" | grep 'a5_error' | head -1)"
+
+    echo "$output" | grep -q 'a6_check_valid: true' && \
+        pass "A6" "agent.check() pre-flight valid" || \
+        fail "A6" "Pre-flight check failed" "$(echo "$output" | grep 'a6_' | head -2)"
+
+    a7_val=$(echo "$output" | grep "a7_key_pool:" | grep -oP 'pool: \K[0-9]+' || echo "0")
+    [ "${a7_val:-0}" -ge 1 ] 2>/dev/null && \
+        pass "A7" "Key pool: $a7_val configured keys" || \
+        fail "A7" "No keys in pool" "got $a7_val"
+
+    echo "$output" | grep -q 'a8_env_config: true' && \
+        pass "A8" "Environment has model + provider" || \
+        fail "A8" "Environment missing config" "$(echo "$output" | grep 'a8_' | head -2)"
+
+    echo "$output" | grep -q 'a9_dispatch_clean: true' && \
+        pass "A9" "Dispatch status starts clean" || \
+        fail "A9" "Dispatch not clean" "$(echo "$output" | grep 'a9_' | head -2)"
+
+    echo "$output" | grep -q 'a10_action_matrix: true' && \
+        pass "A10" "Action matrix blocks no_send_agent" || \
+        fail "A10" "Action matrix not enforced" "$(echo "$output" | grep 'a10_' | head -1)"
+
+    echo ""
+fi
+
+# ======================================================================
+# CATEGORY 2: Pipeline Build (live API)
+# ======================================================================
+if should_run 2; then
+    echo -e "${CYAN}══════════════════════════════════════════════════════${NC}"
+    echo -e "${CYAN}  Category 2: Pipeline Build (10 assertions)${NC}"
+    echo -e "${CYAN}══════════════════════════════════════════════════════${NC}"
+    echo ""
+
+    # Check for API key
+    if [ -z "${GK1:-}" ]; then
+        for i in $(seq 1 10); do
+            skip "B$i" "No GK1 API key — skipping live tests"
+        done
+    else
+        WORKDIR=$(setup_workdir)
+        output=$(run_in "$WORKDIR" "cat2_pipeline_build.naab")
+        exit_code=$?
+
+        if leaked=$(check_banned "$output"); then
+            fail "BAN" "Output leaks bypass hint" "$leaked"
+        fi
+
+        echo "$output" | grep -q 'b1_architect_design: true' && \
+            pass "B1" "Architect produces design" || \
+            fail "B1" "Architect design failed" "$(echo "$output" | grep 'b1_' | head -2)"
+
+        echo "$output" | grep -q 'b2_trace_model: true' && \
+            pass "B2" "Response trace has model info" || \
+            fail "B2" "Trace missing model" "$(echo "$output" | grep 'b2_' | head -2)"
+
+        echo "$output" | grep -q 'b3_pipeline_output: true' && \
+            pass "B3" "Pipeline architect→coder produces output" || \
+            fail "B3" "Pipeline failed" "$(echo "$output" | grep 'b3_' | head -2)"
+
+        echo "$output" | grep -q 'b4_pipeline_success: true' && \
+            pass "B4" "Pipeline response success=true" || \
+            fail "B4" "Pipeline response not successful" "$(echo "$output" | grep 'b4_' | head -2)"
+
+        echo "$output" | grep -q 'b5_upstream_provenance: true' && \
+            pass "B5" "Pipeline has upstream_provenance" || \
+            fail "B5" "Upstream provenance missing" "$(echo "$output" | grep 'b5_' | head -2)"
+
+        echo "$output" | grep -q 'b6_provenance_model: true' && \
+            pass "B6" "Provenance contains model_used" || \
+            fail "B6" "Provenance missing model" "$(echo "$output" | grep 'b6_' | head -2)"
+
+        echo "$output" | grep -q 'b7_extract_code: true' && \
+            pass "B7" "extract_code works on coder response" || \
+            fail "B7" "Code extraction failed" "$(echo "$output" | grep 'b7_' | head -2)"
+
+        echo "$output" | grep -q 'b8_multi_turn_history: true' && \
+            pass "B8" "Multi-turn history grows" || \
+            fail "B8" "History not growing" "$(echo "$output" | grep 'b8_' | head -2)"
+
+        echo "$output" | grep -q 'b9_usage_tracked: true' && \
+            pass "B9" "Usage tracking (turns + tokens)" || \
+            fail "B9" "Usage not tracked" "$(echo "$output" | grep 'b9_' | head -2)"
+
+        echo "$output" | grep -q 'b10_independent_usage: true' && \
+            pass "B10" "Independent per-agent usage" || \
+            fail "B10" "Usage not independent" "$(echo "$output" | grep 'b10_' | head -2)"
+    fi
+
+    echo ""
+fi
+
+# ======================================================================
+# CATEGORY 3: Parallel Review (live API)
+# ======================================================================
+if should_run 3; then
+    echo -e "${CYAN}══════════════════════════════════════════════════════${NC}"
+    echo -e "${CYAN}  Category 3: Parallel Review (10 assertions)${NC}"
+    echo -e "${CYAN}══════════════════════════════════════════════════════${NC}"
+    echo ""
+
+    if [ -z "${GK1:-}" ]; then
+        for i in $(seq 1 10); do
+            skip "C$i" "No GK1 API key — skipping live tests"
+        done
+    else
+        WORKDIR=$(setup_workdir)
+        output=$(run_in "$WORKDIR" "cat3_parallel_review.naab")
+        exit_code=$?
+
+        if leaked=$(check_banned "$output"); then
+            fail "BAN" "Output leaks bypass hint" "$leaked"
+        fi
+
+        echo "$output" | grep -q 'c1_fan_out_count: true' && \
+            pass "C1" "fan_out returns 2 responses" || \
+            fail "C1" "fan_out count wrong" "$(echo "$output" | grep 'c1_' | head -2)"
+
+        echo "$output" | grep -q 'c2_both_responded: true' && \
+            pass "C2" "Both reviewers have content" || \
+            fail "C2" "Missing reviewer content" "$(echo "$output" | grep 'c2_' | head -2)"
+
+        echo "$output" | grep -q 'c3_both_success: true' && \
+            pass "C3" "Both responses success=true" || \
+            fail "C3" "Reviewer response not successful" "$(echo "$output" | grep 'c3_' | head -2)"
+
+        echo "$output" | grep -q 'c4_consensus_verdict: true' && \
+            pass "C4" "Consensus vote has verdict" || \
+            fail "C4" "Consensus vote failed" "$(echo "$output" | grep 'c4_' | head -2)"
+
+        echo "$output" | grep -q 'c5_vote_total: true' && \
+            pass "C5" "Consensus total = 2" || \
+            fail "C5" "Consensus total wrong" "$(echo "$output" | grep 'c5_' | head -2)"
+
+        echo "$output" | grep -q 'c6_has_majority: true' && \
+            pass "C6" "Consensus has majority field" || \
+            fail "C6" "No majority field" "$(echo "$output" | grep 'c6_' | head -2)"
+
+        echo "$output" | grep -q 'c7_batch_ordered: true' && \
+            pass "C7" "batch() returns ordered results" || \
+            fail "C7" "Batch results wrong count" "$(echo "$output" | grep 'c7_' | head -2)"
+
+        echo "$output" | grep -q 'c8_batch_independent: true' && \
+            pass "C8" "Batch responses are independent" || \
+            fail "C8" "Batch responses empty" "$(echo "$output" | grep 'c8_' | head -2)"
+
+        echo "$output" | grep -q 'c9_convergence_pass: true' && \
+            pass "C9" "enforce_convergence accepts valid JSON" || \
+            fail "C9" "Convergence check failed" "$(echo "$output" | grep 'c9_' | head -2)"
+
+        echo "$output" | grep -q 'c10_convergence_reject: true' && \
+            pass "C10" "enforce_convergence rejects missing fields" || \
+            fail "C10" "Convergence didn't reject" "$(echo "$output" | grep 'c10_' | head -2)"
+    fi
+
+    echo ""
+fi
+
+# ======================================================================
+# CATEGORY 4: Tool-Assisted Refinement (live API)
+# ======================================================================
+if should_run 4; then
+    echo -e "${CYAN}══════════════════════════════════════════════════════${NC}"
+    echo -e "${CYAN}  Category 4: Tool-Assisted Refinement (10 assertions)${NC}"
+    echo -e "${CYAN}══════════════════════════════════════════════════════${NC}"
+    echo ""
+
+    if [ -z "${GK1:-}" ]; then
+        for i in $(seq 1 10); do
+            skip "D$i" "No GK1 API key — skipping live tests"
+        done
+    else
+        WORKDIR=$(setup_workdir)
+        output=$(run_in "$WORKDIR" "cat4_tool_refinement.naab")
+        exit_code=$?
+
+        if leaked=$(check_banned "$output"); then
+            fail "BAN" "Output leaks bypass hint" "$leaked"
+        fi
+
+        echo "$output" | grep -q 'd1_register_validate: true' && \
+            pass "D1" "Register validate_code tool" || \
+            fail "D1" "Tool registration failed" "$(echo "$output" | grep 'd1_' | head -2)"
+
+        echo "$output" | grep -q 'd2_register_lint: true' && \
+            pass "D2" "Register lint_check tool" || \
+            fail "D2" "Lint tool registration failed" "$(echo "$output" | grep 'd2_' | head -2)"
+
+        echo "$output" | grep -q 'd3_integrator_tools: true' && \
+            pass "D3" "Integrator env shows tools" || \
+            fail "D3" "Integrator tools not visible" "$(echo "$output" | grep 'd3_' | head -2)"
+
+        echo "$output" | grep -q 'd4_integrator_response: true' && \
+            pass "D4" "Integrator responds with tool context" || \
+            fail "D4" "Integrator response failed" "$(echo "$output" | grep 'd4_' | head -2)"
+
+        echo "$output" | grep -q 'd5_usage_after_tools: true' && \
+            pass "D5" "Usage tracked after tool interaction" || \
+            fail "D5" "Usage not tracked after tools" "$(echo "$output" | grep 'd5_' | head -2)"
+
+        echo "$output" | grep -q 'd6_multi_turn_refine: true' && \
+            pass "D6" "Multi-turn tool refinement" || \
+            fail "D6" "Multi-turn refinement failed" "$(echo "$output" | grep 'd6_' | head -2)"
+
+        echo "$output" | grep -q 'd7_turns_growing: true' && \
+            pass "D7" "Turn count grows with multi-turn" || \
+            fail "D7" "Turn count not growing" "$(echo "$output" | grep 'd7_' | head -2)"
+
+        echo "$output" | grep -q 'd8_refinement_plan: true' && \
+            pass "D8" "sequential_refinement creates plan" || \
+            fail "D8" "Refinement plan failed" "$(echo "$output" | grep 'd8_' | head -2)"
+
+        echo "$output" | grep -q 'd9_env_state: true' && \
+            pass "D9" "Environment shows turns_used" || \
+            fail "D9" "Environment missing turns_used" "$(echo "$output" | grep 'd9_' | head -2)"
+
+        echo "$output" | grep -q 'd10_dispatch_tracked: true' && \
+            pass "D10" "Dispatch tracks calls + tokens" || \
+            fail "D10" "Dispatch not tracked" "$(echo "$output" | grep 'd10_' | head -2)"
+    fi
+
+    echo ""
+fi
+
+# ======================================================================
+# CATEGORY 5: Observability (live API)
+# ======================================================================
+if should_run 5; then
+    echo -e "${CYAN}══════════════════════════════════════════════════════${NC}"
+    echo -e "${CYAN}  Category 5: Observability & Governance State (10 assertions)${NC}"
+    echo -e "${CYAN}══════════════════════════════════════════════════════${NC}"
+    echo ""
+
+    if [ -z "${GK1:-}" ]; then
+        for i in $(seq 1 10); do
+            skip "E$i" "No GK1 API key — skipping live tests"
+        done
+    else
+        WORKDIR=$(setup_workdir)
+        output=$(run_in "$WORKDIR" "cat5_observability.naab")
+        exit_code=$?
+
+        if leaked=$(check_banned "$output"); then
+            fail "BAN" "Output leaks bypass hint" "$leaked"
+        fi
+
+        echo "$output" | grep -q 'e1_usage_complete: true' && \
+            pass "E1" "Usage dict has all token fields" || \
+            fail "E1" "Usage dict incomplete" "$(echo "$output" | grep 'e1_' | head -2)"
+
+        echo "$output" | grep -q 'e2_dispatch_status: true' && \
+            pass "E2" "Dispatch status reflects calls" || \
+            fail "E2" "Dispatch status wrong" "$(echo "$output" | grep 'e2_' | head -2)"
+
+        echo "$output" | grep -q 'e3_key_health: true' && \
+            pass "E3" "Key health reports active keys" || \
+            fail "E3" "Key health failed" "$(echo "$output" | grep 'e3_' | head -2)"
+
+        echo "$output" | grep -q 'e4_governance_level: true' && \
+            pass "E4" "Environment has governance_level" || \
+            fail "E4" "No governance_level" "$(echo "$output" | grep 'e4_' | head -2)"
+
+        echo "$output" | grep -q 'e5_governance_health: true' && \
+            pass "E5" "Environment has governance_health" || \
+            fail "E5" "No governance_health" "$(echo "$output" | grep 'e5_' | head -2)"
+
+        echo "$output" | grep -q 'e6_lease_remaining: true' && \
+            pass "E6" "Environment has lease_remaining" || \
+            fail "E6" "No lease_remaining" "$(echo "$output" | grep 'e6_' | head -2)"
+
+        echo "$output" | grep -q 'e7_dispatch_proximity: true' && \
+            pass "E7" "Environment has dispatch proximity" || \
+            fail "E7" "No dispatch proximity" "$(echo "$output" | grep 'e7_' | head -2)"
+
+        echo "$output" | grep -q 'e8_independent_tokens: true' && \
+            pass "E8" "All 3 agents have independent tokens" || \
+            fail "E8" "Tokens not independent" "$(echo "$output" | grep 'e8_' | head -2)"
+
+        echo "$output" | grep -q 'e9_dispatch_tokens: true' && \
+            pass "E9" "Dispatch total tokens > 0" || \
+            fail "E9" "No dispatch tokens" "$(echo "$output" | grep 'e9_' | head -2)"
+
+        echo "$output" | grep -q 'e10_messages_history: true' && \
+            pass "E10" "agent.messages() returns history" || \
+            fail "E10" "Messages history failed" "$(echo "$output" | grep 'e10_' | head -2)"
+    fi
+
+    echo ""
+fi
+
+# ======================================================================
+# SUMMARY
+# ======================================================================
+echo -e "${BOLD}${CYAN}══════════════════════════════════════════════════════${NC}"
+echo -e "${BOLD}  NAAb-X2 Results${NC}"
+echo -e "${BOLD}${CYAN}══════════════════════════════════════════════════════${NC}"
+echo ""
+echo -e "  Pass: ${GREEN}$PASS_COUNT${NC}  Fail: ${RED}$FAIL_COUNT${NC}  Skip: ${YELLOW}$SKIP_COUNT${NC}  Total: $TOTAL"
+
+if [ -n "$FAILURES" ]; then
+    echo ""
+    echo -e "${RED}  Failures:${NC}"
+    echo -e "$FAILURES"
+fi
+
+# Save results
+mkdir -p "$RESULTS_DIR"
+TIMESTAMP=$(date +%Y%m%d_%H%M%S)
+{
+    echo "NAAb-X2 Results — $TIMESTAMP"
+    echo "Pass: $PASS_COUNT  Fail: $FAIL_COUNT  Skip: $SKIP_COUNT  Total: $TOTAL"
+    if [ -n "$FAILURES" ]; then
+        echo ""
+        echo "Failures:"
+        echo -e "$FAILURES"
+    fi
+} > "$RESULTS_DIR/results_$TIMESTAMP.txt"
+
+echo ""
+echo "  Results saved: results/results_$TIMESTAMP.txt"
+echo ""
+
+[ "$FAIL_COUNT" -eq 0 ]

--- a/tests/gorilla/naab-x2/src/cat1_fleet_setup.naab
+++ b/tests/gorilla/naab-x2/src/cat1_fleet_setup.naab
@@ -1,0 +1,118 @@
+// NAAb-X2 Category 1: Agent Fleet Setup
+// 10 assertions — no live API calls needed
+// Tests: agent.create, agent.check, environment, key_health, dispatch_status, action matrix
+use agent
+
+main {
+    // A1: Create architect agent
+    let a1_ok = false
+    let arch = null
+    try {
+        arch = agent.create("architect")
+        a1_ok = arch != null && arch.get("id") != null
+    } catch (e) {
+        print("a1_error: " + string(e))
+    }
+    print("a1_create_architect: " + string(a1_ok))
+
+    // A2: Create coder agent
+    let a2_ok = false
+    let coder = null
+    try {
+        coder = agent.create("coder")
+        a2_ok = coder != null && coder.get("id") != null
+    } catch (e) {
+        print("a2_error: " + string(e))
+    }
+    print("a2_create_coder: " + string(a2_ok))
+
+    // A3: Create reviewer_a agent
+    let a3_ok = false
+    let rev_a = null
+    try {
+        rev_a = agent.create("reviewer_a")
+        a3_ok = rev_a != null && rev_a.get("id") != null
+    } catch (e) {
+        print("a3_error: " + string(e))
+    }
+    print("a3_create_reviewer_a: " + string(a3_ok))
+
+    // A4: Create reviewer_b agent
+    let a4_ok = false
+    let rev_b = null
+    try {
+        rev_b = agent.create("reviewer_b")
+        a4_ok = rev_b != null && rev_b.get("id") != null
+    } catch (e) {
+        print("a4_error: " + string(e))
+    }
+    print("a4_create_reviewer_b: " + string(a4_ok))
+
+    // A5: Create integrator agent (has tools)
+    let a5_ok = false
+    let integ = null
+    try {
+        integ = agent.create("integrator")
+        a5_ok = integ != null && integ.get("id") != null
+    } catch (e) {
+        print("a5_error: " + string(e))
+    }
+    print("a5_create_integrator: " + string(a5_ok))
+
+    // A6: agent.check() pre-flight validation
+    let a6_ok = false
+    try {
+        let check = agent.check("architect")
+        a6_ok = check.get("valid") == true
+        print("a6_provider: " + string(check.get("provider") ?? "none"))
+    } catch (e) {
+        print("a6_error: " + string(e))
+    }
+    print("a6_check_valid: " + string(a6_ok))
+
+    // A7: Environment shows key pool size from config
+    let a7_pool = 0
+    try {
+        let env = arch.get("environment")
+        a7_pool = env.get("key_pool_size") ?? 0
+    } catch (e) {
+        print("a7_error: " + string(e))
+    }
+    print("a7_key_pool: " + string(a7_pool))
+
+    // A8: Environment has model and provider
+    let a8_ok = false
+    try {
+        let env = arch.get("environment")
+        let has_provider = env.get("provider") != null
+        let has_model_chain = env.get("model_chain") != null
+        a8_ok = has_provider && has_model_chain
+        print("a8_provider: " + string(env.get("provider") ?? "missing"))
+    } catch (e) {
+        print("a8_error: " + string(e))
+    }
+    print("a8_env_config: " + string(a8_ok))
+
+    // A9: Dispatch status starts clean
+    let a9_ok = false
+    try {
+        let ds = agent.dispatch_status()
+        a9_ok = ds.get("calls_made") == 0 && ds.get("hard_stopped") == false
+        print("a9_calls_made: " + string(ds.get("calls_made") ?? -1))
+    } catch (e) {
+        print("a9_error: " + string(e))
+    }
+    print("a9_dispatch_clean: " + string(a9_ok))
+
+    // A10: Action matrix enforcement — no_send_agent blocked from sending
+    let a10_blocked = false
+    try {
+        let restricted = agent.create("no_send_agent")
+        agent.send(restricted, "test")
+    } catch (e) {
+        a10_blocked = true
+    }
+    print("a10_action_matrix: " + string(a10_blocked))
+
+    print("cat1_completed: true")
+}

--- a/tests/gorilla/naab-x2/src/cat2_pipeline_build.naab
+++ b/tests/gorilla/naab-x2/src/cat2_pipeline_build.naab
@@ -1,0 +1,125 @@
+// NAAb-X2 Category 2: Pipeline Build
+// 10 assertions — live API calls (4 total: 1 send + 2 pipeline + 1 coder send)
+// Tests: agent.send, agent.pipeline, upstream provenance, extract_code, multi-turn
+use agent
+use string
+
+main {
+    let arch = agent.create("architect")
+    let coder = agent.create("coder")
+
+    // B1: Architect designs a TODO app (1 API call)
+    let b1_ok = false
+    let arch_resp = null
+    try {
+        arch_resp = agent.send(arch, "Design a simple TODO list app with functions: add_task, complete_task, list_tasks. Just list the function signatures in 3 lines.")
+        let content = arch_resp.get("content") ?? ""
+        b1_ok = len(content) > 10
+        print("b1_content_len: " + string(len(content)))
+    } catch (e) {
+        print("b1_error: " + string(e))
+    }
+    print("b1_architect_design: " + string(b1_ok))
+
+    // B2: Response trace has model info (no extra API call)
+    let b2_ok = false
+    try {
+        let trace = arch_resp.get("trace") ?? {}
+        b2_ok = trace.get("model") != null && trace.get("provider") != null
+        print("b2_model: " + string(trace.get("model") ?? "missing"))
+    } catch (e) {
+        print("b2_error: " + string(e))
+    }
+    print("b2_trace_model: " + string(b2_ok))
+
+    // B3-B6: Pipeline architect -> coder (2 API calls — pipeline stage 1 + stage 2)
+    let b3_ok = false
+    let b4_ok = false
+    let b5_ok = false
+    let b6_ok = false
+    let pipeline_resp = null
+    try {
+        let p_arch = agent.create("architect")
+        let p_coder = agent.create("coder")
+        pipeline_resp = agent.pipeline([p_arch, p_coder], "Design then implement a Python function add(a, b) that returns a + b. Stage 1: specify it. Stage 2: write the code in ```python fences.")
+        let content = pipeline_resp.get("content") ?? ""
+        b3_ok = len(content) > 10
+        print("b3_pipeline_len: " + string(len(content)))
+
+        // B4: success field
+        b4_ok = pipeline_resp.get("success") == true
+
+        // B5: upstream_provenance
+        let env = pipeline_resp.get("environment") ?? {}
+        let state = env.get("state") ?? {}
+        let prov = state.get("upstream_provenance")
+        b5_ok = prov != null
+
+        // B6: provenance has model_used
+        if prov != null {
+            b6_ok = prov.get("model_used") != null
+            print("b6_upstream_model: " + string(prov.get("model_used") ?? "missing"))
+        }
+    } catch (e) {
+        print("b3_error: " + string(e))
+    }
+    print("b3_pipeline_output: " + string(b3_ok))
+    print("b4_pipeline_success: " + string(b4_ok))
+    print("b5_upstream_provenance: " + string(b5_ok))
+    print("b6_provenance_model: " + string(b6_ok))
+
+    // B7: extract_code on a coder response (1 API call)
+    let b7_ok = false
+    try {
+        let code_resp = agent.send(coder, "Write a Python function greet(name) that returns 'Hello, ' + name. Use ```python fences.")
+        let raw = code_resp.get("content") ?? ""
+        let extracted = agent.extract_code(raw, "python")
+        b7_ok = len(extracted) > 5
+        print("b7_extracted_len: " + string(len(extracted)))
+    } catch (e) {
+        print("b7_error: " + string(e))
+    }
+    print("b7_extract_code: " + string(b7_ok))
+
+    // B8: Multi-turn — architect has history from B1 (no extra API call)
+    let b8_ok = false
+    try {
+        let msgs = agent.messages(arch)
+        b8_ok = len(msgs) >= 2  // at least user + assistant from B1
+        print("b8_message_count: " + string(len(msgs)))
+    } catch (e) {
+        print("b8_error: " + string(e))
+    }
+    print("b8_multi_turn_history: " + string(b8_ok))
+
+    // B9: Usage tracking — architect turn + tokens (no extra API call)
+    let b9_ok = false
+    try {
+        let usage = agent.usage(arch)
+        let turns = usage.get("turns") ?? 0
+        let tokens = usage.get("total_tokens") ?? 0
+        b9_ok = turns >= 1 && tokens > 0
+        print("b9_turns: " + string(turns))
+        print("b9_tokens: " + string(tokens))
+    } catch (e) {
+        print("b9_error: " + string(e))
+    }
+    print("b9_usage_tracked: " + string(b9_ok))
+
+    // B10: Coder usage independent from architect (no extra API call)
+    let b10_ok = false
+    try {
+        let c_usage = agent.usage(coder)
+        let a_usage = agent.usage(arch)
+        let c_turns = c_usage.get("turns") ?? 0
+        let a_turns = a_usage.get("turns") ?? 0
+        b10_ok = c_turns > 0 && a_turns > 0
+        print("b10_coder_turns: " + string(c_turns))
+        print("b10_arch_turns: " + string(a_turns))
+    } catch (e) {
+        print("b10_error: " + string(e))
+    }
+    print("b10_independent_usage: " + string(b10_ok))
+
+    print("cat2_completed: true")
+}

--- a/tests/gorilla/naab-x2/src/cat3_parallel_review.naab
+++ b/tests/gorilla/naab-x2/src/cat3_parallel_review.naab
@@ -1,0 +1,154 @@
+// NAAb-X2 Category 3: Parallel Review
+// 10 assertions — live API calls
+// Tests: agent.fan_out, agent.batch, orchestra.consensus_vote, enforce_convergence
+use agent
+use orchestra
+use string
+use array
+
+main {
+    let rev_a = agent.create("reviewer_a")
+    let rev_b = agent.create("reviewer_b")
+
+    let sample_code = "def add_task(tasks, title):\n    task = {'id': len(tasks)+1, 'title': title, 'done': False}\n    tasks.append(task)\n    return task\n\ndef complete_task(tasks, task_id):\n    for t in tasks:\n        if t['id'] == task_id:\n            t['done'] = True\n            return True\n    return False"
+
+    // C1: fan_out sends same prompt to both reviewers
+    let c1_ok = false
+    let fan_results = null
+    try {
+        fan_results = agent.fan_out([rev_a, rev_b], "Review this Python code for correctness and style. End with APPROVED, REJECTED, or NEEDS_REVIEW.\n\n" + sample_code)
+        c1_ok = len(fan_results) == 2
+        print("c1_result_count: " + string(len(fan_results)))
+    } catch (e) {
+        print("c1_error: " + string(e))
+    }
+    print("c1_fan_out_count: " + string(c1_ok))
+
+    // C2: Both fan_out responses have content
+    let c2_ok = false
+    try {
+        let r0_content = fan_results[0].get("content") ?? ""
+        let r1_content = fan_results[1].get("content") ?? ""
+        c2_ok = len(r0_content) > 10 && len(r1_content) > 10
+        print("c2_r0_len: " + string(len(r0_content)))
+        print("c2_r1_len: " + string(len(r1_content)))
+    } catch (e) {
+        print("c2_error: " + string(e))
+    }
+    print("c2_both_responded: " + string(c2_ok))
+
+    // C3: Both responses report success
+    let c3_ok = false
+    try {
+        let s0 = fan_results[0].get("success") ?? false
+        let s1 = fan_results[1].get("success") ?? false
+        c3_ok = s0 == true && s1 == true
+    } catch (e) {
+        print("c3_error: " + string(e))
+    }
+    print("c3_both_success: " + string(c3_ok))
+
+    // C4: Consensus vote with extracted verdicts
+    let c4_ok = false
+    let vote_result = null
+    try {
+        // Extract verdict from each response (look for APPROVED/REJECTED/NEEDS_REVIEW)
+        let v0 = "NEEDS_REVIEW"
+        let v1 = "NEEDS_REVIEW"
+        let c0 = fan_results[0].get("content") ?? ""
+        let c1 = fan_results[1].get("content") ?? ""
+        if string.contains(c0, "APPROVED") { v0 = "APPROVED" }
+        if string.contains(c0, "REJECTED") { v0 = "REJECTED" }
+        if string.contains(c1, "APPROVED") { v1 = "APPROVED" }
+        if string.contains(c1, "REJECTED") { v1 = "REJECTED" }
+        print("c4_v0: " + v0)
+        print("c4_v1: " + v1)
+
+        vote_result = orchestra.consensus_vote({votes: [v0, v1]})
+        c4_ok = vote_result.get("verdict") != null
+    } catch (e) {
+        print("c4_error: " + string(e))
+    }
+    print("c4_consensus_verdict: " + string(c4_ok))
+
+    // C5: Consensus result has total count
+    let c5_ok = false
+    try {
+        c5_ok = vote_result.get("total") == 2
+        print("c5_total: " + string(vote_result.get("total") ?? 0))
+    } catch (e) {
+        print("c5_error: " + string(e))
+    }
+    print("c5_vote_total: " + string(c5_ok))
+
+    // C6: Consensus has majority field
+    let c6_ok = false
+    try {
+        c6_ok = vote_result.get("majority") != null
+        print("c6_majority: " + string(vote_result.get("majority") ?? "missing"))
+    } catch (e) {
+        print("c6_error: " + string(e))
+    }
+    print("c6_has_majority: " + string(c6_ok))
+
+    // C7: batch() with different prompts to each reviewer
+    let c7_ok = false
+    let batch_results = null
+    try {
+        let rev_a2 = agent.create("reviewer_a")
+        let rev_b2 = agent.create("reviewer_b")
+        batch_results = agent.batch(
+            [rev_a2, rev_b2],
+            [
+                "Is this function name good: add_task? Reply YES or NO in one word.",
+                "Is this function name good: complete_task? Reply YES or NO in one word."
+            ]
+        )
+        c7_ok = len(batch_results) == 2
+        print("c7_batch_count: " + string(len(batch_results)))
+    } catch (e) {
+        print("c7_error: " + string(e))
+    }
+    print("c7_batch_ordered: " + string(c7_ok))
+
+    // C8: Batch responses are independent (different content)
+    let c8_ok = false
+    try {
+        let br0 = batch_results[0].get("content") ?? ""
+        let br1 = batch_results[1].get("content") ?? ""
+        c8_ok = len(br0) > 0 && len(br1) > 0
+        print("c8_br0_len: " + string(len(br0)))
+        print("c8_br1_len: " + string(len(br1)))
+    } catch (e) {
+        print("c8_error: " + string(e))
+    }
+    print("c8_batch_independent: " + string(c8_ok))
+
+    // C9: enforce_convergence with required_fields spec
+    let c9_ok = false
+    try {
+        let test_resp = "{\"verdict\": \"APPROVED\", \"score\": 85}"
+        let spec = {required_fields: ["verdict", "score"]}
+        let conv = orchestra.enforce_convergence(test_resp, spec)
+        c9_ok = conv.get("valid") == true
+        print("c9_valid: " + string(conv.get("valid") ?? false))
+    } catch (e) {
+        print("c9_error: " + string(e))
+    }
+    print("c9_convergence_pass: " + string(c9_ok))
+
+    // C10: enforce_convergence rejects missing fields
+    let c10_ok = false
+    try {
+        let bad_resp = "{\"verdict\": \"APPROVED\"}"
+        let spec2 = {required_fields: ["verdict", "score", "explanation"]}
+        let conv2 = orchestra.enforce_convergence(bad_resp, spec2)
+        c10_ok = conv2.get("valid") == false
+        print("c10_error_msg: " + string(conv2.get("error_message") ?? "none"))
+    } catch (e) {
+        print("c10_error: " + string(e))
+    }
+    print("c10_convergence_reject: " + string(c10_ok))
+
+    print("cat3_completed: true")
+}

--- a/tests/gorilla/naab-x2/src/cat4_tool_refinement.naab
+++ b/tests/gorilla/naab-x2/src/cat4_tool_refinement.naab
@@ -1,0 +1,182 @@
+// NAAb-X2 Category 4: Tool-Assisted Refinement
+// 10 assertions — live API calls
+// Tests: register_tool, integrator with tools, multi-turn refinement, sequential_refinement plan
+use agent
+use orchestra
+use string
+
+fn validate_code(code) {
+    // Simple validation: check for def keyword and return statement
+    let has_def = string.contains(code, "def ")
+    let has_return = string.contains(code, "return")
+    return {
+        "valid": has_def && has_return,
+        "has_def": has_def,
+        "has_return": has_return,
+        "line_count": len(string.split(code, "\n")),
+        "feedback": if has_def && has_return { "Code structure looks valid" } else { "Missing function definition or return statement" }
+    }
+}
+
+fn lint_check(code) {
+    // Simple lint: check for common issues
+    let issues = []
+    if string.contains(code, "  \n") {
+        issues = issues + ["trailing whitespace"]
+    }
+    if string.contains(code, "import *") {
+        issues = issues + ["wildcard import"]
+    }
+    if string.contains(code, "pass") {
+        issues = issues + ["empty pass statement"]
+    }
+    return {
+        "issues": issues,
+        "issue_count": len(issues),
+        "clean": len(issues) == 0
+    }
+}
+
+main {
+    // D1: Register validate_code tool
+    let d1_ok = false
+    try {
+        let reg = agent.register_tool("validate_code", validate_code, {
+            "description": "Validate Python code structure — checks for function definitions and return statements",
+            "parameters": {
+                "code": {"type": "string", "description": "Python code to validate"}
+            }
+        })
+        d1_ok = true
+    } catch (e) {
+        print("d1_error: " + string(e))
+    }
+    print("d1_register_validate: " + string(d1_ok))
+
+    // D2: Register lint_check tool
+    let d2_ok = false
+    try {
+        agent.register_tool("lint_check", lint_check, {
+            "description": "Run lint checks on Python code — detects trailing whitespace, wildcard imports, empty pass",
+            "parameters": {
+                "code": {"type": "string", "description": "Python code to lint"}
+            }
+        })
+        d2_ok = true
+    } catch (e) {
+        print("d2_error: " + string(e))
+    }
+    print("d2_register_lint: " + string(d2_ok))
+
+    // D3: Integrator agent has tools in environment
+    let integ = agent.create("integrator")
+    let d3_ok = false
+    try {
+        let env = integ.get("environment")
+        let perms = env.get("permissions") ?? {}
+        let tools_enabled = perms.get("tools_enabled") ?? false
+        let tools_registered = perms.get("tools_registered") ?? 0
+        d3_ok = tools_enabled == true && tools_registered >= 2
+        print("d3_tools_enabled: " + string(tools_enabled))
+        print("d3_tools_registered: " + string(tools_registered))
+    } catch (e) {
+        print("d3_error: " + string(e))
+    }
+    print("d3_integrator_tools: " + string(d3_ok))
+
+    // D4: Send code to integrator — response tracks tool info
+    let d4_ok = false
+    let integ_resp = null
+    try {
+        integ_resp = agent.send(integ, "Here is Python code. Please use the validate_code tool to check it, then tell me if it's valid.\n\ndef add_task(tasks, title):\n    task = {'id': len(tasks)+1, 'title': title, 'done': False}\n    tasks.append(task)\n    return task")
+        let content = integ_resp.get("content") ?? ""
+        d4_ok = len(content) > 5
+        print("d4_content_len: " + string(len(content)))
+        print("d4_tool_calls: " + string(integ_resp.get("tool_calls_made") ?? 0))
+    } catch (e) {
+        print("d4_error: " + string(e))
+    }
+    print("d4_integrator_response: " + string(d4_ok))
+
+    // D5: Usage reflects tool interaction
+    let d5_ok = false
+    try {
+        let usage = agent.usage(integ)
+        let turns = usage.get("turns") ?? 0
+        let tokens = usage.get("total_tokens") ?? 0
+        d5_ok = turns >= 1 && tokens > 0
+        print("d5_turns: " + string(turns))
+        print("d5_tokens: " + string(tokens))
+        print("d5_tool_calls_total: " + string(usage.get("tool_calls_total") ?? 0))
+    } catch (e) {
+        print("d5_error: " + string(e))
+    }
+    print("d5_usage_after_tools: " + string(d5_ok))
+
+    // D6: Multi-turn refinement — send follow-up
+    let d6_ok = false
+    try {
+        let resp2 = agent.send(integ, "Now use the lint_check tool on the same code and tell me if there are any lint issues.")
+        let content2 = resp2.get("content") ?? ""
+        d6_ok = len(content2) > 5
+        print("d6_followup_len: " + string(len(content2)))
+        print("d6_tool_calls: " + string(resp2.get("tool_calls_made") ?? 0))
+    } catch (e) {
+        print("d6_error: " + string(e))
+    }
+    print("d6_multi_turn_refine: " + string(d6_ok))
+
+    // D7: Turn count grows with multi-turn
+    let d7_ok = false
+    try {
+        let usage2 = agent.usage(integ)
+        let turns = usage2.get("turns") ?? 0
+        d7_ok = turns >= 2
+        print("d7_total_turns: " + string(turns))
+    } catch (e) {
+        print("d7_error: " + string(e))
+    }
+    print("d7_turns_growing: " + string(d7_ok))
+
+    // D8: sequential_refinement creates a plan
+    let d8_ok = false
+    try {
+        let handles = [agent.create("architect"), agent.create("coder")]
+        let plan = orchestra.sequential_refinement(handles, "Build a calculator", 3)
+        d8_ok = plan.get("pattern") != null && plan.get("iterations") == 3
+        print("d8_pattern: " + string(plan.get("pattern") ?? "missing"))
+        print("d8_iterations: " + string(plan.get("iterations") ?? 0))
+    } catch (e) {
+        print("d8_error: " + string(e))
+    }
+    print("d8_refinement_plan: " + string(d8_ok))
+
+    // D9: Integrator environment shows turns_used after multi-turn
+    let d9_ok = false
+    try {
+        let env = agent.environment(integ)
+        let state = env.get("state") ?? {}
+        let turns_used = state.get("turns_used") ?? 0
+        d9_ok = turns_used >= 2
+        print("d9_env_turns_used: " + string(turns_used))
+    } catch (e) {
+        print("d9_error: " + string(e))
+    }
+    print("d9_env_state: " + string(d9_ok))
+
+    // D10: Dispatch status shows accumulated calls + tokens
+    let d10_ok = false
+    try {
+        let ds = agent.dispatch_status()
+        let calls = ds.get("calls_made") ?? 0
+        let tokens = ds.get("tokens_used") ?? 0
+        d10_ok = calls >= 2 && tokens > 0
+        print("d10_dispatch_calls: " + string(calls))
+        print("d10_dispatch_tokens: " + string(tokens))
+    } catch (e) {
+        print("d10_error: " + string(e))
+    }
+    print("d10_dispatch_tracked: " + string(d10_ok))
+
+    print("cat4_completed: true")
+}

--- a/tests/gorilla/naab-x2/src/cat5_observability.naab
+++ b/tests/gorilla/naab-x2/src/cat5_observability.naab
@@ -1,0 +1,164 @@
+// NAAb-X2 Category 5: Observability & Governance State
+// 10 assertions — live API calls
+// Tests: usage, dispatch_status, environment depth, governance.health, messages, cross-agent tracking
+use agent
+use string
+
+main {
+    // Create 3 agents and do some work
+    let arch = agent.create("architect")
+    let coder = agent.create("coder")
+    let rev = agent.create("reviewer_a")
+
+    // Drive some traffic
+    try {
+        agent.send(arch, "Name three functions for a TODO app. One line each.")
+        agent.send(coder, "Write a Python one-liner: a function that doubles a number.")
+        agent.send(rev, "Is 'add_task' a good function name? Reply YES or NO.")
+    } catch (e) {
+        print("setup_error: " + string(e))
+    }
+
+    // E1: agent.usage() returns complete dict for architect
+    let e1_ok = false
+    try {
+        let usage = agent.usage(arch)
+        let has_turns = usage.get("turns") != null
+        let has_tokens = usage.get("total_tokens") != null
+        let has_input = usage.get("input_tokens") != null
+        let has_output = usage.get("output_tokens") != null
+        e1_ok = has_turns && has_tokens && has_input && has_output
+        print("e1_turns: " + string(usage.get("turns") ?? 0))
+        print("e1_total_tokens: " + string(usage.get("total_tokens") ?? 0))
+        print("e1_input_tokens: " + string(usage.get("input_tokens") ?? 0))
+        print("e1_output_tokens: " + string(usage.get("output_tokens") ?? 0))
+    } catch (e) {
+        print("e1_error: " + string(e))
+    }
+    print("e1_usage_complete: " + string(e1_ok))
+
+    // E2: dispatch_status() reflects 3 calls made
+    let e2_ok = false
+    try {
+        let ds = agent.dispatch_status()
+        let calls = ds.get("calls_made") ?? 0
+        let tokens = ds.get("tokens_used") ?? 0
+        e2_ok = calls >= 3 && tokens > 0
+        print("e2_dispatch_calls: " + string(calls))
+        print("e2_dispatch_tokens: " + string(tokens))
+    } catch (e) {
+        print("e2_error: " + string(e))
+    }
+    print("e2_dispatch_status: " + string(e2_ok))
+
+    // E3: key_health reports keys
+    let e3_ok = false
+    try {
+        let kh = agent.key_health("architect")
+        let active_keys = kh.get("active") ?? []
+        let avail_count = kh.get("available") ?? 0
+        e3_ok = avail_count > 0 && len(active_keys) > 0
+        print("e3_available: " + string(avail_count))
+        print("e3_active_count: " + string(len(active_keys)))
+    } catch (e) {
+        print("e3_error: " + string(e))
+    }
+    print("e3_key_health: " + string(e3_ok))
+
+    // E4: Environment has governance_level
+    let e4_ok = false
+    try {
+        let env = agent.environment(arch)
+        let state = env.get("state") ?? {}
+        let level = state.get("governance_level")
+        e4_ok = level != null
+        print("e4_gov_level: " + string(level ?? "missing"))
+    } catch (e) {
+        print("e4_error: " + string(e))
+    }
+    print("e4_governance_level: " + string(e4_ok))
+
+    // E5: Environment has governance_health
+    let e5_ok = false
+    try {
+        let env = agent.environment(arch)
+        let state = env.get("state") ?? {}
+        let health = state.get("governance_health")
+        e5_ok = health != null
+        print("e5_gov_health: " + string(health ?? "missing"))
+    } catch (e) {
+        print("e5_error: " + string(e))
+    }
+    print("e5_governance_health: " + string(e5_ok))
+
+    // E6: Environment has lease_remaining
+    let e6_ok = false
+    try {
+        let env = agent.environment(arch)
+        let state = env.get("state") ?? {}
+        let lease = state.get("lease_remaining")
+        e6_ok = lease != null
+        print("e6_lease: " + string(lease ?? -1))
+    } catch (e) {
+        print("e6_error: " + string(e))
+    }
+    print("e6_lease_remaining: " + string(e6_ok))
+
+    // E7: Environment has dispatch proximity
+    let e7_ok = false
+    try {
+        let env = agent.environment(arch)
+        let state = env.get("state") ?? {}
+        let dispatch = state.get("dispatch") ?? {}
+        let calls_remaining = dispatch.get("calls_remaining")
+        e7_ok = calls_remaining != null
+        print("e7_dispatch_remaining: " + string(calls_remaining ?? -1))
+    } catch (e) {
+        print("e7_error: " + string(e))
+    }
+    print("e7_dispatch_proximity: " + string(e7_ok))
+
+    // E8: All 3 agents have independent token counters
+    let e8_ok = false
+    try {
+        let u_arch = agent.usage(arch)
+        let u_code = agent.usage(coder)
+        let u_rev = agent.usage(rev)
+        let t1 = u_arch.get("total_tokens") ?? 0
+        let t2 = u_code.get("total_tokens") ?? 0
+        let t3 = u_rev.get("total_tokens") ?? 0
+        e8_ok = t1 > 0 && t2 > 0 && t3 > 0
+        print("e8_arch_tokens: " + string(t1))
+        print("e8_coder_tokens: " + string(t2))
+        print("e8_rev_tokens: " + string(t3))
+    } catch (e) {
+        print("e8_error: " + string(e))
+    }
+    print("e8_independent_tokens: " + string(e8_ok))
+
+    // E9: Dispatch tokens_used = sum of all agents
+    let e9_ok = false
+    try {
+        let ds = agent.dispatch_status()
+        let total_dispatch = ds.get("tokens_used") ?? 0
+        e9_ok = total_dispatch > 0
+        print("e9_total_dispatch_tokens: " + string(total_dispatch))
+    } catch (e) {
+        print("e9_error: " + string(e))
+    }
+    print("e9_dispatch_tokens: " + string(e9_ok))
+
+    // E10: agent.messages() returns conversation history
+    let e10_ok = false
+    try {
+        let msgs = agent.messages(arch)
+        let count = len(msgs)
+        e10_ok = count >= 2  // At least user + assistant
+        print("e10_message_count: " + string(count))
+    } catch (e) {
+        print("e10_error: " + string(e))
+    }
+    print("e10_messages_history: " + string(e10_ok))
+
+    print("cat5_completed: true")
+}

--- a/tests/gorilla/naab-x2/src/cat6_code_review_loop.naab
+++ b/tests/gorilla/naab-x2/src/cat6_code_review_loop.naab
@@ -1,0 +1,184 @@
+// NAAb-X2 Category 6: Code Review Loop with Execution
+// Full pipeline: architect → coder (with run_code tool) → executor → reviewer → coder fix loop
+use agent
+use codegen
+use json
+use string
+
+// Tool: actually executes Python code and returns stdout + stderr
+fn run_code(code) {
+    try {
+        let result = codegen.run("python", code)
+        return {
+            "success": true,
+            "stdout": string(result),
+            "error": ""
+        }
+    } catch (e) {
+        return {
+            "success": false,
+            "stdout": "",
+            "error": string(e)
+        }
+    }
+}
+
+fn dump_messages(name, handle) {
+    let msgs = agent.messages(handle)
+    print("  +-- " + name + " (" + string(len(msgs)) + " messages) --+")
+    for i in 0..len(msgs) {
+        let m = msgs[i]
+        let role = m.get("role") ?? "?"
+        let content = m.get("content") ?? ""
+        let preview = content
+        if len(preview) > 800 {
+            preview = string.substring(preview, 0, 800) + "\n... [" + string(len(content) - 800) + " more chars]"
+        }
+        print("  | [" + string(i) + "] " + string.upper(role) + ":")
+        let lines = string.split(preview, "\n")
+        for j in 0..len(lines) {
+            print("  |   " + lines[j])
+        }
+        print("  |")
+    }
+    print("  +--------------------------------------+")
+}
+
+main {
+    // Register the run_code tool — this actually executes Python via codegen
+    agent.register_tool("run_code", run_code, {
+        "description": "Execute Python code and return stdout/stderr. Use this to test your code before finalizing.",
+        "parameters": {
+            "code": {"type": "string", "description": "Python code to execute"}
+        }
+    })
+
+    let coder_handle = agent.create("coder")
+    let executor_handle = agent.create("executor")
+    let reviewer_handle = agent.create("reviewer")
+
+    // ===== STEP 1: Architect designs =====
+    print("== STEP 1: ARCHITECT DESIGNS ==")
+    let arch = agent.create("architect")
+    let design_resp = agent.send(arch, "Design a Python module with these functions:\n1. add_task(tasks, title) -> dict: Add a task with unique ID, title, done=False\n2. complete_task(tasks, task_id) -> bool: Mark task done by ID\n3. delete_task(tasks, task_id) -> bool: Remove task by ID\n4. list_pending(tasks) -> list: Return only incomplete tasks\n\nUse dicts for tasks. IDs must stay unique even after deletions. Include edge case handling.")
+    let design = design_resp.get("content") ?? ""
+    print("  Architect output (" + string(len(design)) + " chars)")
+    print("")
+    dump_messages("architect", arch)
+
+    // ===== STEP 2: Coder implements with run_code tool =====
+    print("")
+    print("== STEP 2: CODER IMPLEMENTS (has run_code tool) ==")
+    let code_prompt = "Implement this design in Python. IMPORTANT: Use the run_code tool to test your code before giving your final answer. Include test code that:\n- Adds 3 tasks\n- Completes task 1\n- Deletes task 2\n- Lists pending tasks\n- Tries to complete a non-existent task\n- Tries to delete a non-existent task\n\nDesign spec:\n" + design
+    let code_resp = agent.send(coder_handle, code_prompt)
+    let code_content = code_resp.get("content") ?? ""
+    print("  Coder response (" + string(len(code_content)) + " chars)")
+    print("  Tool calls made: " + string(code_resp.get("tool_calls_made") ?? 0))
+    print("  Tool results: " + json.stringify(code_resp.get("tool_results") ?? []))
+    print("  Tool loop exit: " + string(code_resp.get("tool_loop_exit_reason") ?? "n/a"))
+    print("")
+    dump_messages("coder", coder_handle)
+
+    // ===== STEP 3: Extract code =====
+    print("")
+    print("== STEP 3: EXTRACTED CODE ==")
+    let extracted = agent.extract_code(code_content, "python")
+    if len(extracted) < 20 {
+        // If extract_code didn't find fences, use the raw content
+        extracted = code_content
+    }
+    print(extracted)
+
+    // ===== STEP 4: Independent execution =====
+    print("")
+    print("== STEP 4: INDEPENDENT EXECUTION ==")
+    let exec_output = ""
+    let exec_success = false
+    try {
+        let result = codegen.run("python", extracted)
+        exec_output = string(result)
+        exec_success = true
+        print("  Exit: SUCCESS")
+        print("  Output:")
+        let olines = string.split(exec_output, "\n")
+        for i in 0..len(olines) {
+            print("    " + olines[i])
+        }
+    } catch (e) {
+        exec_output = string(e)
+        print("  Exit: ERROR")
+        print("  " + exec_output)
+    }
+
+    // ===== STEP 5: QA executor reviews output =====
+    print("")
+    print("== STEP 5: QA EXECUTOR REVIEWS ==")
+    let qa_prompt = "Here is Python code and its execution output. Analyze whether the code and output are correct.\n\nCODE:\n```python\n" + extracted + "\n```\n\nEXECUTION OUTPUT:\n```\n" + exec_output + "\n```\n\nCheck:\n1. Does add_task generate unique IDs even after deletions?\n2. Does complete_task handle non-existent IDs?\n3. Does delete_task handle non-existent IDs?\n4. Does list_pending correctly filter completed tasks?\n5. Are edge cases covered?"
+    let qa_resp = agent.send(executor_handle, qa_prompt)
+    let qa_report = qa_resp.get("content") ?? ""
+    print("  QA report (" + string(len(qa_report)) + " chars):")
+    print("")
+    dump_messages("executor", executor_handle)
+
+    // ===== STEP 6: Senior reviewer decides =====
+    print("")
+    print("== STEP 6: SENIOR REVIEWER ==")
+    let review_prompt = "Review this submission.\n\nCODE:\n```python\n" + extracted + "\n```\n\nEXECUTION OUTPUT:\n```\n" + exec_output + "\n```\n\nQA REPORT:\n" + qa_report + "\n\nIs this production-ready? If REJECTED, give specific fixes."
+    let review_resp = agent.send(reviewer_handle, review_prompt)
+    let review_text = review_resp.get("content") ?? ""
+    print("")
+    dump_messages("reviewer", reviewer_handle)
+
+    // Check verdict
+    let verdict = "UNKNOWN"
+    if string.contains(review_text, "APPROVED") { verdict = "APPROVED" }
+    if string.contains(review_text, "REJECTED") { verdict = "REJECTED" }
+    print("")
+    print("  VERDICT: " + verdict)
+
+    // ===== STEP 7: Fix loop (if rejected) =====
+    if verdict == "REJECTED" {
+        print("")
+        print("== STEP 7: CODER FIX LOOP (rejected, sending feedback) ==")
+        let fix_prompt = "Your code was REJECTED. Here is the reviewer feedback:\n\n" + review_text + "\n\nQA report:\n" + qa_report + "\n\nFix the issues and use the run_code tool to verify your fix works. Give the corrected code in ```python fences."
+        let fix_resp = agent.send(coder_handle, fix_prompt)
+        let fix_content = fix_resp.get("content") ?? ""
+        print("  Fix response (" + string(len(fix_content)) + " chars)")
+        print("  Tool calls made: " + string(fix_resp.get("tool_calls_made") ?? 0))
+        print("  Tool results: " + json.stringify(fix_resp.get("tool_results") ?? []))
+        print("")
+        dump_messages("coder (after fix)", coder_handle)
+
+        // Extract and run fixed code
+        let fixed = agent.extract_code(fix_content, "python")
+        if len(fixed) > 20 {
+            print("")
+            print("== FIXED CODE ==")
+            print(fixed)
+            print("")
+            print("== EXECUTE FIXED CODE ==")
+            try {
+                let fix_result = codegen.run("python", fixed)
+                print("  Exit: SUCCESS")
+                print("  Output:")
+                let flines = string.split(string(fix_result), "\n")
+                for i in 0..len(flines) {
+                    print("    " + flines[i])
+                }
+            } catch (e) {
+                print("  Exit: ERROR")
+                print("  " + string(e))
+            }
+        }
+    } else {
+        print("  (Code approved — no fix loop needed)")
+    }
+
+    // ===== FINAL STATS =====
+    print("")
+    print("== FINAL STATS ==")
+    let ds = agent.dispatch_status()
+    print("  Dispatch: calls=" + string(ds.get("calls_made")) + " tokens=" + string(ds.get("tokens_used")) + " time=" + string(ds.get("agent_time_ms")) + "ms")
+    print("  Coder usage: " + json.stringify(agent.usage(coder_handle)))
+    print("  Coder messages: " + string(len(agent.messages(coder_handle))))
+}


### PR DESCRIPTION
## Summary
- Adds naab-x2: a multi-agent app builder gorilla test verifying end-to-end agent collaboration
- 50 assertions across 5 categories: fleet setup, pipeline build, parallel review, tool-assisted refinement, observability
- Exercises: `agent.create/send/pipeline/batch/fan_out`, `register_tool`, `orchestra.consensus_vote/enforce_convergence/sequential_refinement`, `agent.usage/dispatch_status/key_health/environment/messages`
- Also includes 8 correctness fixes from Gemini 40-level audit pass 2

### New: agent timeout default + tool taint gap + pulse/telemetry hardening
- **Agent timeout default**: new `agent_dispatch.default_timeout_seconds` in govern.json — agents without explicit `timeout` inherit the dispatch default. Struct default raised 30→60s, curl fallback matches. Ratchet + extends/inheritance support. `govern-template.json` updated.
- **Tool execution taint gap (security)**: VM `push()` unconditionally cleared taint bits, so LLM-generated code passed through tool callbacks executed without taint detection. `callNaabFunction` now accepts `taint_all_args`; agent tool path passes `true`. `ContractCallFn` typedef updated through the full callback chain.
- **Pulse consecutive_passes gating (Fix 3B)**: only counts passes during agent phase — static source checks (~1,800) no longer inflate the counter past suspicion threshold.
- **Telemetry check deduplication (Fix 4B)**: opt-in `deduplicate_checks` collapses duplicate (rule, file, line) entries in telemetry output.
- **End-of-run health warnings (Fix 5B)**: safety net for instrumentation failures that per-turn `checkGovernanceHealth()` missed due to `check_after_turns` gate.
- **Multi-agent retry tuning**: backoff 500→5000ms, attempts 6→3 to reduce RPM pressure on slow models.
- **Cat 6 (code-review-loop)**: new naab-x2 test config with 4-agent review loop (architect→coder→executor→reviewer) exercising tool execution + taint.

## Test plan
- [x] Cat 1 (fleet setup, 10): 10/10 — no API needed
- [x] Cat 2 (pipeline, 10): 10/10 — live API
- [x] Cat 3 (parallel review, 10): 10/10 — live API
- [x] Cat 4 (tool refinement, 10): 10/10 — live API
- [x] Cat 5 (observability, 10): 10/10 — live API
- [x] Full suite: `bash tests/gorilla/naab-x2/run-naabx2.sh` → 50/50
- [x] Build: `cmake .. && make naab-lang -j4` — clean
- [x] Full test suite: 396 tests, 0 unexpected failures
- [x] Security leak check: 738/738 pass

🤖 Generated with [Claude Code](https://claude.com/claude-code)