### PR TITLE
feat: self-calibrating scoring & scanner improvements

### DIFF
--- a/govern-template.json
+++ b/govern-template.json
@@ -1426,6 +1426,7 @@
       "wrapper_classes":        { "enabled": true, "level": "advisory" },
       "unused_imports":         { "enabled": true, "level": "soft" },
       "missing_imports":        { "enabled": true, "level": "soft" },
+      "phantom_imports":        { "enabled": true, "level": "soft" },
       "single_use_variable":    { "enabled": false, "level": "advisory" },
       "copy_paste_signatures":  { "enabled": true, "level": "advisory" },
       "excessive_type_checks":  { "enabled": true, "level": "advisory" },
@@ -1919,6 +1920,14 @@
     "soft_after": 3,
     "weight_multiplier": 1.5,
     "rationale": "Repeated advisories harden — persistent issues must be addressed"
+  },
+
+  "_comment_scoring_calibration": "Scoring Calibration — operator-driven weight overrides. Persists calibration to .naab/scoring-calibration.json. Use governance.calibrate(rule, weight, reason) to set overrides. governance.calibration() returns current overrides.",
+  "scoring_calibration": {
+    "enabled": false,
+    "path": ".naab/scoring-calibration.json",
+    "auto_save": true,
+    "rationale": "Operator-driven weight overrides — tune scoring weights based on project experience"
   },
 
   "_comment_governance_health": "Governance Health Monitoring — verify BSD/CDD instrumentation is operational. Detects: BSD received 0 events after N turns, CDD analyzed 0 turns after N turns, perfect coherence (1.0) after 10+ turns. governance_entropy_warning flags suspiciously uniform governance check result distributions. Pulse thresholds: consecutive_passes_suspicion (flag if all checks pass N+ times), impaired_degraded_turns/impaired_signal_count (IMPAIRED verdict conditions), pulse_cooldown_turns (min turns between verdict transitions). Nuclear safety system exercising analog.",

--- a/include/naab/governance.h
+++ b/include/naab/governance.h
@@ -1236,6 +1236,24 @@ struct ScoringConfig {
 };
 
 // ============================================================================
+// Scoring Calibration — operator-driven weight overrides
+// ============================================================================
+
+struct ScoringCalibrationEntry {
+    int weight_override = -1;       // -1 = no override, use config weight
+    std::string reason;              // operator's rationale
+    std::string updated_at;          // ISO timestamp
+    int observation_count = 0;       // times operator reviewed this rule
+};
+
+struct ScoringCalibrationConfig {
+    bool enabled = false;
+    std::string rationale;
+    std::string path = ".naab/scoring-calibration.json";
+    bool auto_save = true;
+};
+
+// ============================================================================
 // Behavioral Sequence Detection — config structs
 // ============================================================================
 
@@ -2143,6 +2161,7 @@ struct GovernanceRules {
 
     // --- Cumulative risk scoring ---
     ScoringConfig scoring;
+    ScoringCalibrationConfig scoring_calibration;
 
     // --- Governance baseline (Feature 4) ---
     GovernanceBaselineConfig governance_baseline;
@@ -2629,6 +2648,11 @@ public:
     std::string formatScoreBreakdown() const;
     bool verifyScoreIntegrity() const;
 
+    // --- Scoring Calibration (operator-driven weight overrides) ---
+    bool calibrateRule(const std::string& rule_name, int weight_override, const std::string& reason);
+    bool resetCalibration(const std::string& rule_name);
+    std::unordered_map<std::string, ScoringCalibrationEntry> getCalibrationOverrides() const;
+
     // --- Environment Attestation ---
     std::vector<AttestationResult> runAttestation();
 
@@ -2974,6 +2998,13 @@ private:
     static constexpr int SCORE_SATURATION_LIMIT = 100000;
     int cumulative_score_ = 0;
     std::unordered_map<std::string, int> score_contributions_;
+
+    // Scoring calibration — operator-driven weight overrides
+    mutable std::unordered_map<std::string, ScoringCalibrationEntry> scoring_calibration_;
+    mutable bool scoring_calibration_loaded_ = false;
+    bool scoring_calibration_dirty_ = false;
+    void loadScoringCalibration() const;
+    void saveScoringCalibration() const;
 
     // Evidence Epoch — monotonic counter incremented on state transitions
     // Prior-epoch evidence is discounted (database MVCC / court jurisdiction analog)

--- a/src/runtime/governance_config.cpp
+++ b/src/runtime/governance_config.cpp
@@ -46,6 +46,9 @@ GovernanceEngine::~GovernanceEngine() {
     if (baselines_dirty_) {
         saveBaselines();
     }
+    if (scoring_calibration_dirty_ && rules().scoring_calibration.auto_save) {
+        saveScoringCalibration();
+    }
     if (baselines_data_) {
         delete static_cast<nlohmann::json*>(baselines_data_);
         baselines_data_ = nullptr;
@@ -2462,6 +2465,16 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
                        rules_.scoring.yellow_threshold, rules_.scoring.red_threshold);
             rules_.scoring.yellow_threshold = rules_.scoring.red_threshold;
         }
+    }
+
+    // --- Scoring Calibration (operator-driven weight overrides) ---
+    if (j.contains("scoring_calibration") && j["scoring_calibration"].is_object()) {
+        auto& sc = j["scoring_calibration"];
+        rules_.scoring_calibration.enabled = sc.value("enabled", false);
+        if (sc.contains("path") && sc["path"].is_string())
+            rules_.scoring_calibration.path = sc["path"].get<std::string>();
+        rules_.scoring_calibration.auto_save = sc.value("auto_save", true);
+        parseRationale(sc, rules_.scoring_calibration.rationale);
     }
 
     // --- Agent Review (LLM-based governance phase) ---

--- a/src/runtime/governance_engine.cpp
+++ b/src/runtime/governance_engine.cpp
@@ -920,13 +920,48 @@ std::string GovernanceEngine::enforce(
         if (rules().scoring.enabled && level == EnforcementLevel::ADVISORY) {
             int weight = rules().scoring.default_weight;
             std::string weight_source = "default";
-            auto wit = rules().scoring.rule_weights.find(rule_name);
-            if (wit != rules().scoring.rule_weights.end()) {
-                weight = wit->second;
-                weight_source = "rule_weights";
-            } else if (rule_name == "code_quality.intent_validation.self_declared") {
-                weight = 1;  // supporting functions: reduced weight
-                weight_source = "self_declared reduction";
+            // Contextual weight waterfall: rule:category:severity → rule:category → rule
+            std::string ctx_cat, ctx_sev;
+            if (!check_results_.empty()) {
+                ctx_cat = check_results_.back().category;
+                ctx_sev = check_results_.back().severity;
+            }
+            // Level 1: rule:category:severity (most specific)
+            if (!ctx_cat.empty() && !ctx_sev.empty()) {
+                auto wit = rules().scoring.rule_weights.find(
+                    rule_name + ":" + ctx_cat + ":" + ctx_sev);
+                if (wit != rules().scoring.rule_weights.end()) {
+                    weight = wit->second;
+                    weight_source = "rule_weights:" + ctx_cat + ":" + ctx_sev;
+                }
+            }
+            // Level 2: rule:category
+            if (weight_source == "default" && !ctx_cat.empty()) {
+                auto wit = rules().scoring.rule_weights.find(rule_name + ":" + ctx_cat);
+                if (wit != rules().scoring.rule_weights.end()) {
+                    weight = wit->second;
+                    weight_source = "rule_weights:" + ctx_cat;
+                }
+            }
+            // Level 3: rule (existing exact match — backward compatible)
+            if (weight_source == "default") {
+                auto wit = rules().scoring.rule_weights.find(rule_name);
+                if (wit != rules().scoring.rule_weights.end()) {
+                    weight = wit->second;
+                    weight_source = "rule_weights";
+                } else if (rule_name == "code_quality.intent_validation.self_declared") {
+                    weight = 1;  // supporting functions: reduced weight
+                    weight_source = "self_declared reduction";
+                }
+            }
+            // Scoring calibration: operator weight override takes precedence over config
+            if (rules().scoring_calibration.enabled) {
+                loadScoringCalibration();
+                auto cit = scoring_calibration_.find(rule_name);
+                if (cit != scoring_calibration_.end() && cit->second.weight_override >= 0) {
+                    weight = cit->second.weight_override;
+                    weight_source = "calibration";
+                }
             }
             weight = std::max(0, weight);
             // Advisory Escalation: multiply weight on 2nd+ occurrence
@@ -2979,11 +3014,42 @@ bool GovernanceEngine::verifyScoreIntegrity() const {
         // Escalated advisories return before scoring in enforce() — exclude
         if (r.escalated) continue;
         int weight = rules().scoring.default_weight;
-        auto wit = rules().scoring.rule_weights.find(r.rule_name);
-        if (wit != rules().scoring.rule_weights.end()) {
-            weight = wit->second;
-        } else if (r.rule_name == "code_quality.intent_validation.self_declared") {
-            weight = 1;  // supporting functions: reduced weight
+        // Mirror contextual weight waterfall from enforce()
+        std::string v_cat = r.category;
+        std::string v_sev = r.severity;
+        bool v_found = false;
+        // Level 1: rule:category:severity
+        if (!v_cat.empty() && !v_sev.empty()) {
+            auto wit = rules().scoring.rule_weights.find(
+                r.rule_name + ":" + v_cat + ":" + v_sev);
+            if (wit != rules().scoring.rule_weights.end()) {
+                weight = wit->second;
+                v_found = true;
+            }
+        }
+        // Level 2: rule:category
+        if (!v_found && !v_cat.empty()) {
+            auto wit = rules().scoring.rule_weights.find(r.rule_name + ":" + v_cat);
+            if (wit != rules().scoring.rule_weights.end()) {
+                weight = wit->second;
+                v_found = true;
+            }
+        }
+        // Level 3: rule (existing exact match)
+        if (!v_found) {
+            auto wit = rules().scoring.rule_weights.find(r.rule_name);
+            if (wit != rules().scoring.rule_weights.end()) {
+                weight = wit->second;
+            } else if (r.rule_name == "code_quality.intent_validation.self_declared") {
+                weight = 1;  // supporting functions: reduced weight
+            }
+        }
+        // Mirror calibration override from enforce()
+        if (rules().scoring_calibration.enabled) {
+            auto cit = scoring_calibration_.find(r.rule_name);
+            if (cit != scoring_calibration_.end() && cit->second.weight_override >= 0) {
+                weight = cit->second.weight_override;
+            }
         }
         weight = std::max(0, weight);
         // Advisory Escalation: mirror enforce() weight multiplier
@@ -2999,6 +3065,133 @@ bool GovernanceEngine::verifyScoreIntegrity() const {
         }
     }
     return recomputed == cumulative_score_;
+}
+
+// ============================================================================
+// Scoring Calibration — operator-driven weight overrides
+// ============================================================================
+
+void GovernanceEngine::loadScoringCalibration() const {
+    if (scoring_calibration_loaded_) return;
+    scoring_calibration_loaded_ = true;
+    if (!rules().scoring_calibration.enabled) return;
+
+    std::string path = rules().scoring_calibration.path;
+    if (!path.empty() && path[0] != '/') {
+        // Resolve relative to govern.json directory
+        std::string dir = rules().telemetry_output.output_file;
+        auto slash = dir.find_last_of('/');
+        if (slash != std::string::npos) {
+            path = dir.substr(0, slash + 1) + path;
+        }
+        // If no directory context, use path as-is (relative to cwd)
+    }
+
+    std::ifstream in(path);
+    if (!in.is_open()) return;  // No calibration file yet — normal for first run
+
+    try {
+        nlohmann::json j = nlohmann::json::parse(in);
+        if (!j.contains("overrides") || !j["overrides"].is_object()) return;
+        for (auto& [rule, data] : j["overrides"].items()) {
+            if (!data.is_object()) continue;
+            ScoringCalibrationEntry entry;
+            if (data.contains("weight") && data["weight"].is_number_integer())
+                entry.weight_override = data["weight"].get<int>();
+            if (data.contains("reason") && data["reason"].is_string())
+                entry.reason = data["reason"].get<std::string>();
+            if (data.contains("updated_at") && data["updated_at"].is_string())
+                entry.updated_at = data["updated_at"].get<std::string>();
+            if (data.contains("observation_count") && data["observation_count"].is_number_integer())
+                entry.observation_count = data["observation_count"].get<int>();
+            scoring_calibration_[rule] = entry;
+        }
+    } catch (...) {
+        fprintf(stderr, "[governance] Warning: scoring calibration file corrupt, ignoring\n");
+    }
+}
+
+void GovernanceEngine::saveScoringCalibration() const {
+    if (scoring_calibration_.empty()) return;
+
+    std::string path = rules().scoring_calibration.path;
+
+    std::filesystem::path p(path);
+    if (p.has_parent_path())
+        std::filesystem::create_directories(p.parent_path());
+
+    auto now = std::chrono::system_clock::now();
+    auto t = std::chrono::system_clock::to_time_t(now);
+    std::tm tm_buf;
+#ifdef _WIN32
+    localtime_s(&tm_buf, &t);
+#else
+    localtime_r(&t, &tm_buf);
+#endif
+    char ts[32];
+    std::strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", &tm_buf);
+
+    nlohmann::json j;
+    j["version"] = 1;
+    j["updated_at"] = std::string(ts);
+    j["overrides"] = nlohmann::json::object();
+    for (const auto& [rule, entry] : scoring_calibration_) {
+        nlohmann::json e;
+        e["weight"] = entry.weight_override;
+        e["reason"] = entry.reason;
+        e["updated_at"] = entry.updated_at;
+        e["observation_count"] = entry.observation_count;
+        j["overrides"][rule] = e;
+    }
+
+    std::ofstream ofs(path);
+    if (ofs.is_open()) {
+        ofs << j.dump(2) << "\n";
+        fprintf(stderr, "[governance] Scoring calibration saved to %s\n", path.c_str());
+    }
+}
+
+bool GovernanceEngine::calibrateRule(const std::string& rule_name,
+                                      int weight_override,
+                                      const std::string& reason) {
+    if (!rules().scoring_calibration.enabled) return false;
+    loadScoringCalibration();
+
+    auto& entry = scoring_calibration_[rule_name];
+    entry.weight_override = std::max(0, weight_override);
+    entry.reason = reason;
+    entry.observation_count++;
+
+    auto now = std::chrono::system_clock::now();
+    auto t = std::chrono::system_clock::to_time_t(now);
+    std::tm tm_buf;
+#ifdef _WIN32
+    localtime_s(&tm_buf, &t);
+#else
+    localtime_r(&t, &tm_buf);
+#endif
+    char ts[32];
+    std::strftime(ts, sizeof(ts), "%Y-%m-%dT%H:%M:%S", &tm_buf);
+    entry.updated_at = std::string(ts);
+
+    scoring_calibration_dirty_ = true;
+    return true;
+}
+
+bool GovernanceEngine::resetCalibration(const std::string& rule_name) {
+    if (!rules().scoring_calibration.enabled) return false;
+    loadScoringCalibration();
+    auto it = scoring_calibration_.find(rule_name);
+    if (it == scoring_calibration_.end()) return false;
+    scoring_calibration_.erase(it);
+    scoring_calibration_dirty_ = true;
+    return true;
+}
+
+std::unordered_map<std::string, ScoringCalibrationEntry>
+GovernanceEngine::getCalibrationOverrides() const {
+    loadScoringCalibration();
+    return scoring_calibration_;
 }
 
 // ============================================================================

--- a/src/runtime/governance_reports.cpp
+++ b/src/runtime/governance_reports.cpp
@@ -900,6 +900,14 @@ void GovernanceEngine::writeTelemetry() const {
         ev["category"] = r.category;
         ev["severity"] = r.severity;
         ev["level"] = levelToString(r.level);
+        // Scoring enrichment: include weight and escalation data for advisory violations
+        if (rules().scoring.enabled && !r.passed && r.level == EnforcementLevel::ADVISORY) {
+            auto sit = score_contributions_.find(r.rule_name);
+            if (sit != score_contributions_.end()) {
+                ev["score_contribution"] = sit->second;
+            }
+            ev["escalated"] = r.escalated;
+        }
         if (!r.cwe_ids.empty()) {
             ev["cwe"] = nlohmann::json::array();
             for (const auto& c : r.cwe_ids) ev["cwe"].push_back(c);
@@ -958,6 +966,38 @@ void GovernanceEngine::writeTelemetry() const {
     // Fix 5B: emit end-of-run health warnings (catches instrumentation failures
     // that per-turn checkGovernanceHealth() missed due to check_after_turns gate)
     emitEndOfRunHealthWarnings(fp.get(), timestamp);
+
+    // End-of-run scoring snapshot for cross-run analysis
+    if (rules().scoring.enabled && cumulative_score_ > 0) {
+        nlohmann::json snap;
+        snap["run_id"] = run_id_;
+        snap["event_type"] = "ScoringSnapshot";
+        snap["timestamp"] = timestamp;
+        snap["cumulative_score"] = cumulative_score_;
+        snap["risk_zone"] = cumulative_score_ >= rules().scoring.red_threshold ? "RED" :
+                            cumulative_score_ >= rules().scoring.yellow_threshold ? "YELLOW" : "GREEN";
+        nlohmann::json breakdown = nlohmann::json::object();
+        for (const auto& [rule, total] : score_contributions_) {
+            breakdown[rule] = total;
+        }
+        snap["score_breakdown"] = breakdown;
+        if (rules().telemetry_output.tamper_evidence.enabled) {
+            std::lock_guard<std::mutex> hlock(telemetry_hash_mutex_);
+            snap["prev_hash"] = last_telemetry_hash_.empty()
+                ? rules().telemetry_output.tamper_evidence.chain_genesis
+                : last_telemetry_hash_;
+            last_telemetry_hash_ = computeHash(snap.dump(),
+                rules().telemetry_output.tamper_evidence);
+            snap["hash"] = last_telemetry_hash_;
+        }
+        std::string sline = snap.dump() + "\n";
+        fwrite(sline.c_str(), 1, sline.size(), fp.get());
+        {
+            std::shared_ptr<TelemetryForwarder> fwd;
+            { std::lock_guard<std::mutex> lock(telemetry_fwd_mutex_); fwd = telemetry_forwarder_; }
+            if (fwd) fwd->enqueue(snap.dump());
+        }
+    }
 
     // fp_deleter handles flock(LOCK_UN) + fclose automatically.
 

--- a/src/scanner/checks_redundancy.cpp
+++ b/src/scanner/checks_redundancy.cpp
@@ -523,7 +523,8 @@ void ScannerEngine::checkRedundancy(const std::string& filepath,
         static const std::vector<std::string> known_modules = {
             "math", "string", "json", "csv", "file", "time", "regex",
             "env", "io", "crypto", "log", "uuid", "validate", "process",
-            "path", "http", "array", "dict", "agent"
+            "path", "http", "array", "dict", "agent", "debug",
+            "bolo", "collections", "codegen", "governance", "orchestra"
         };
         // Collect imported modules
         std::unordered_set<std::string> imported;
@@ -547,6 +548,29 @@ void ScannerEngine::checkRedundancy(const std::string& filepath,
                         trim(lines[i]),
                         fmt::format("Add 'use {}' at the top of the file", mod));
                     break; // one issue per missing module
+                }
+            }
+        }
+    }
+
+    // 11d. phantom_imports (NAAb) — detect `use X` where X is not a known stdlib module
+    if (isEnabled(CAT, "phantom_imports") && language == "naab") {
+        static const std::unordered_set<std::string> known_stdlib = {
+            "io", "json", "http", "collections", "string", "array", "math",
+            "time", "env", "csv", "regex", "crypto", "file", "debug",
+            "bolo", "path", "dict", "log", "uuid", "validate", "process",
+            "agent", "codegen", "governance", "orchestra"
+        };
+        static const std::regex ph_use_pat(R"(^\s*use\s+(\w+)\s*$)");
+        for (size_t i = 0; i < lines.size(); ++i) {
+            std::smatch m;
+            if (std::regex_search(lines[i], m, ph_use_pat)) {
+                std::string mod = m[1].str();
+                if (!known_stdlib.count(mod)) {
+                    addIssue(issues, filepath, i + 1, "phantom_imports", CAT,
+                        fmt::format("'{}' is not a known stdlib module", mod),
+                        trim(lines[i]),
+                        "Check spelling or ensure this is a valid file-based module");
                 }
             }
         }

--- a/src/stdlib/governance_impl.cpp
+++ b/src/stdlib/governance_impl.cpp
@@ -346,13 +346,71 @@ static NaabVal governanceHealth(std::vector<NaabVal>& /*args*/) {
 }
 
 // ============================================================================
+// governance.calibrate(rule_name, weight, reason) — set operator weight override
+// ============================================================================
+
+static NaabVal governanceCalibrate(std::vector<NaabVal>& args) {
+    if (args.size() < 3 || !args[0].isString() || !args[1].isInt() || !args[2].isString()) {
+        throw std::runtime_error(
+            "Runtime error: governance.calibrate() requires (rule_name, weight, reason)\n\n"
+            "  Help:\n"
+            "  - rule_name: string — the governance rule to calibrate\n"
+            "  - weight: int — new weight override (0 = suppress)\n"
+            "  - reason: string — why this weight was chosen\n");
+    }
+    auto* engine = GovernanceEngine::getCurrent();
+    if (!engine) {
+        throw std::runtime_error(
+            "Governance error: governance.calibrate() requires an active governance engine\n\n"
+            "  Help:\n"
+            "  - Ensure govern.json is present in the project directory\n");
+    }
+    std::string rule = args[0].asString();
+    int weight = static_cast<int>(args[1].asInt());
+    std::string reason = args[2].asString();
+    bool ok = engine->calibrateRule(rule, weight, reason);
+
+    std::unordered_map<std::string, NaabVal> result;
+    result["success"] = NaabVal::makeBool(ok);
+    result["rule"] = NaabVal::makeString(rule);
+    result["weight"] = NaabVal::makeInt(weight);
+    return NaabVal::makeDict(std::move(result));
+}
+
+// ============================================================================
+// governance.calibration() — get all calibration overrides
+// ============================================================================
+
+static NaabVal governanceCalibration(std::vector<NaabVal>& args) {
+    (void)args;
+    auto* engine = GovernanceEngine::getCurrent();
+    if (!engine) {
+        throw std::runtime_error(
+            "Governance error: governance.calibration() requires an active governance engine\n\n"
+            "  Help:\n"
+            "  - Ensure govern.json is present in the project directory\n");
+    }
+    auto overrides = engine->getCalibrationOverrides();
+    std::unordered_map<std::string, NaabVal> result;
+    for (const auto& [rule, entry] : overrides) {
+        std::unordered_map<std::string, NaabVal> e;
+        e["weight"] = NaabVal::makeInt(entry.weight_override);
+        e["reason"] = NaabVal::makeString(entry.reason);
+        e["updated_at"] = NaabVal::makeString(entry.updated_at);
+        e["observation_count"] = NaabVal::makeInt(entry.observation_count);
+        result[rule] = NaabVal::makeDict(std::move(e));
+    }
+    return NaabVal::makeDict(std::move(result));
+}
+
+// ============================================================================
 // Module interface
 // ============================================================================
 
 bool GovernanceModule::hasFunction(const std::string& name) const {
     return name == "scorer" || name == "finding" || name == "evaluate" ||
            name == "findings" || name == "score" || name == "parse_findings" ||
-           name == "health";
+           name == "health" || name == "calibrate" || name == "calibration";
 }
 
 NaabVal GovernanceModule::call(
@@ -365,11 +423,14 @@ NaabVal GovernanceModule::call(
     if (function_name == "score") return governanceScore(args);
     if (function_name == "parse_findings") return governanceParseFindings(args);
     if (function_name == "health") return governanceHealth(args);
+    if (function_name == "calibrate") return governanceCalibrate(args);
+    if (function_name == "calibration") return governanceCalibration(args);
 
     throw std::runtime_error(
         "Runtime error: governance module has no function '" + function_name + "'\n\n"
         "  Help:\n"
-        "  - Available: scorer, finding, evaluate, findings, score, parse_findings, health\n");
+        "  - Available: scorer, finding, evaluate, findings, score, parse_findings, "
+        "health, calibrate, calibration\n");
 }
 
 } // namespace stdlib


### PR DESCRIPTION
## Summary

- **Telemetry scoring enrichment**: `writeTelemetry()` now includes `score_contribution` and `escalated` per advisory event + `ScoringSnapshot` end-of-run event with per-rule breakdown. Foundation for external calibration tooling.
- **Phantom import detection**: New scanner check `phantom_imports` (11d) catches `use nonexistent_module` statically. Also fixes `missing_imports` (11c) module list from 19 to 25 modules.
- **Operator-driven weight calibration**: `governance.calibrate(rule, weight, reason)` persists weight overrides to `.naab/scoring-calibration.json`. Overrides apply in `enforce()` and `verifyScoreIntegrity()`. Auto-saves on engine destruction.
- **Contextual weight lookup**: `rule_weights` supports composite keys (`rule:category:severity` → `rule:category` → `rule` → default). Zero struct changes, backward compatible.

Inspired by AI-SLOP-Detector pattern/math analysis. Features requiring git integration (Bayesian Beta, diff-targeted attribution, time-to-fix decay) intentionally excluded — no VCS coupling exists in the codebase.

## Test plan

- [x] Build clean (only pre-existing warnings)
- [x] 874/874 security leak checks pass
- [x] 396/396 tests accounted (3 pre-existing failures unrelated to changes)
- [ ] Verify telemetry JSONL contains `ScoringSnapshot` event when scoring enabled
- [ ] Verify `use nonexistent` triggers phantom_imports scanner issue
- [ ] Verify `governance.calibrate()` persists overrides and affects scoring
- [ ] Verify contextual `rule_weights` waterfall in decision trace

🤖 Generated with [Claude Code](https://claude.com/claude-code)