### PR TITLE
fix: checkPrivilegeEscalation dead on stripped code

### DIFF
--- a/src/runtime/governance_checks.cpp
+++ b/src/runtime/governance_checks.cpp
@@ -6434,6 +6434,11 @@ std::string GovernanceEngine::checkPolyglotBlock(
     if (!err.empty()) return err;
     err = checkPrivilegeEscalation(stripped, line);
     if (!err.empty()) return err;
+    // Privilege escalation commands (sudo, chmod +s) appear inside string args to
+    // execution functions (os.system("sudo ..."), subprocess.run(["chmod", "+s", ...])).
+    // Check normalized code to catch commands inside string literals.
+    err = checkPrivilegeEscalation(normalized, line);
+    if (!err.empty()) return err;
     err = checkDataExfiltration(stripped, line);
     if (!err.empty()) return err;
     err = checkResourceAbuse(stripped, line);


### PR DESCRIPTION
## Summary
- Audited all 12 governance check functions receiving `stripped` code for the same class of bug fixed in PR #47 (string stripping kills patterns that match inside string literals)
- Found 1 bug: `checkPrivilegeEscalation` patterns (`sudo`, `su -`, `chmod +s`, `setuid`) appear inside string arguments to execution functions like `os.system("sudo ...")` — after `stripStringLiterals()`, the command names are removed entirely
- Fix: add second `checkPrivilegeEscalation` call with `normalized` code (same double-call pattern as `checkDangerousCall`)

## Audit results (11 OK, 1 BUG)

| Function | Receives | Verdict |
|----------|----------|---------|
| checkUnsafeDeserialization | stripped | OK |
| checkPathTraversal | stripped | OK (intentional FIX 16 tradeoff) |
| checkDataExfiltration | stripped | OK |
| **checkPrivilegeEscalation** | **stripped** | **BUG — fixed** |
| checkShellInjection | stripped | OK |
| checkEncoding | stripped | OK |
| checkInfoDisclosure | stripped | OK |
| checkResourceAbuse | stripped | OK |
| checkSecrets | code (raw) | OK |
| checkDebugArtifacts | stripped | OK |
| checkDangerousCall | stripped + normalized | OK |
| checkBannedFunctions | stripped | OK |

## Test plan
- [x] 396/396 tests pass (0 regressions)
- [x] 874/0 security leak checks pass
- [x] Clean build

🤖 Generated with [Claude Code](https://claude.com/claude-code)