### PR TITLE
fix: recursive mutex deadlock in printDashboard()

### DIFF
--- a/src/runtime/governance_engine.cpp
+++ b/src/runtime/governance_engine.cpp
@@ -2842,10 +2842,17 @@ void GovernanceEngine::printDashboard() const {
             fprintf(stderr, "Exposure:   %d autonomous actions, %zu unique agents\n",
                     actions, unique);
             // F8: Show risk budget status per agent
+            // NOTE: getRemainingBudget() also acquires risk_budget_mutex_, so we
+            // must compute remaining budget inline to avoid recursive lock deadlock.
             {
                 std::lock_guard<std::mutex> lock(risk_budget_mutex_);
                 for (const auto& [name, consumed] : agent_risk_consumed_) {
-                    int remaining = getRemainingBudget(name);
+                    // Inline budget lookup (mirrors getRemainingBudget logic)
+                    const AgentConfig* ac = nullptr;
+                    for (const auto& a : rules().agents) {
+                        if (a.name == name) { ac = &a; break; }
+                    }
+                    int remaining = (ac && ac->risk_budget > 0) ? ac->risk_budget - consumed : -1;
                     if (remaining >= 0) {
                         fprintf(stderr, "Budget:     %s: %d remaining (consumed %d)\n",
                                 name.c_str(), remaining, consumed);


### PR DESCRIPTION
## Summary

- **Root cause**: `printDashboard()` acquired `risk_budget_mutex_` then called `getRemainingBudget()` which tried to acquire the same non-recursive `std::mutex`, deadlocking the main thread on `futex_wait`
- **Fix**: Inlined the budget lookup logic directly in `printDashboard()` since the mutex is already held
- **Impact**: Process hang after 60+ agent turns (naab-49) — only triggered when `agent_risk_consumed_` map is non-empty

## Test plan

- [x] naab-49 gorilla test: 11/11 PASS (was 10/11 — S01 now shows clean exit instead of SIGTERM 143)
- [x] Full test suite: 396/396, 0 regressions

🤖 Generated with [Claude Code](https://claude.com/claude-code)