### PR TITLE
fix: cosmetic sanitizer comment bypass (self-audit v5 S-6)

### DIFF
--- a/src/runtime/governance_checks.cpp
+++ b/src/runtime/governance_checks.cpp
@@ -3120,14 +3120,19 @@ std::string GovernanceEngine::checkCosmeticSanitizer(
     }
     addTrace(fmt::format("body has {} lines", line_count));
 
+    // Strip comments — prevent // regex.match(...) from fooling sanitization detection.
+    // Input is already string-stripped (stripStringLiterals at call site line 4247),
+    // so stripComments won't be confused by // inside strings.
+    std::string body_clean = stripComments(body);
+
     // Check for real sanitization operations
     bool has_real_sanitization = false;
 
     // 1. Pattern validation (regex library usage)
-    if (body.find("regex.") != std::string::npos ||
-        body.find("regex_") != std::string::npos ||
-        body.find("re.match") != std::string::npos ||
-        body.find("re.search") != std::string::npos) {
+    if (body_clean.find("regex.") != std::string::npos ||
+        body_clean.find("regex_") != std::string::npos ||
+        body_clean.find("re.match") != std::string::npos ||
+        body_clean.find("re.search") != std::string::npos) {
         has_real_sanitization = true;
     }
 
@@ -3136,22 +3141,22 @@ std::string GovernanceEngine::checkCosmeticSanitizer(
         static const std::regex rejection(
             "if\\s+[^{]*\\{[^}]*(?:return\\s+(?:false|null|0|\"\"|\\[\\]|\\{\\})|throw\\s)",
             std::regex::icase);
-        if (std::regex_search(body, rejection)) has_real_sanitization = true;
+        if (std::regex_search(body_clean, rejection)) has_real_sanitization = true;
     }
 
     // 3. Type checking with rejection (type() + != or ==)
     if (!has_real_sanitization) {
-        if (body.find("type(") != std::string::npos &&
-            (body.find("!=") != std::string::npos || body.find("==") != std::string::npos) &&
-            (body.find("return") != std::string::npos || body.find("throw") != std::string::npos)) {
+        if (body_clean.find("type(") != std::string::npos &&
+            (body_clean.find("!=") != std::string::npos || body_clean.find("==") != std::string::npos) &&
+            (body_clean.find("return") != std::string::npos || body_clean.find("throw") != std::string::npos)) {
             has_real_sanitization = true;
         }
     }
 
     // 4. Numeric conversion with try/catch (real error handling)
     if (!has_real_sanitization) {
-        if ((body.find("int(") != std::string::npos || body.find("float(") != std::string::npos) &&
-            body.find("try") != std::string::npos && body.find("catch") != std::string::npos) {
+        if ((body_clean.find("int(") != std::string::npos || body_clean.find("float(") != std::string::npos) &&
+            body_clean.find("try") != std::string::npos && body_clean.find("catch") != std::string::npos) {
             has_real_sanitization = true;
         }
     }
@@ -3161,18 +3166,18 @@ std::string GovernanceEngine::checkCosmeticSanitizer(
         static const std::regex bounds_check(
             "(?:>=?|<=?|>|<)\\s*(?:\\d+|len\\(|length\\(|size\\()",
             std::regex::icase);
-        if (std::regex_search(body, bounds_check) &&
-            (body.find("return") != std::string::npos || body.find("throw") != std::string::npos)) {
+        if (std::regex_search(body_clean, bounds_check) &&
+            (body_clean.find("return") != std::string::npos || body_clean.find("throw") != std::string::npos)) {
             has_real_sanitization = true;
         }
     }
 
     // 6. Allowlist/blocklist check (.contains() or "in [")
     if (!has_real_sanitization) {
-        if ((body.find(".contains(") != std::string::npos ||
-             body.find(" in [") != std::string::npos ||
-             body.find(" not in ") != std::string::npos) &&
-            (body.find("return") != std::string::npos || body.find("throw") != std::string::npos)) {
+        if ((body_clean.find(".contains(") != std::string::npos ||
+             body_clean.find(" in [") != std::string::npos ||
+             body_clean.find(" not in ") != std::string::npos) &&
+            (body_clean.find("return") != std::string::npos || body_clean.find("throw") != std::string::npos)) {
             has_real_sanitization = true;
         }
     }


### PR DESCRIPTION
## Summary

- **S-6 fix:** `checkCosmeticSanitizer()` used `.find("regex.")` on code that had string literals stripped but comments preserved — a comment like `// regex.match(...)` fooled the check into thinking real sanitization existed, letting cosmetic-only sanitizer functions pass and clearing taint at 10 runtime sites with zero secondary validation
- **Fix:** strip comments via existing `stripComments()` before pattern matching (single variable rename `body` → `body_clean` across all 6 detection categories)
- **Also triaged 5 other unverified suspicions:** S-4 (FP — already guarded), S-8 (FP — already atomic), S-9 (FP — returns copy not reference), S-11 (FP — strings stripped first), S-12 (acceptable tradeoff — fail-safe)

## Security Impact

HIGH — exploitable taint bypass. Comments containing sanitization keywords (`regex.`, `type(`, `int(`, `.contains(`) let cosmetic sanitizers pass, clearing taint unconditionally at 10 call sites across VM and interpreter. Reachable sinks: `file.write`, `env.set_var`, `http.*`, all polyglot exec. LLM-exploitable via `codegen.run()`.

## Test plan

- [x] `make naab-lang -j4` — compiles clean
- [x] `bash run-all-tests.sh` — 396/396, 0 unexpected
- [x] `bash tests/security/test_error_msg_leaks.sh` — 874/874
- [x] Existing sanitizer tests (test_edge_03, test_edge_07, legit_04) unaffected — fix tightens detection (fewer false passes)

🤖 Generated with [Claude Code](https://claude.com/claude-code)