### PR TITLE
fix: self-audit v8 — JSON type guards, BSD matching, mutex

### DIFF
--- a/examples/self-audit/self-audit.naab
+++ b/examples/self-audit/self-audit.naab
@@ -141,40 +141,41 @@ main {
     print_section("Stage 1: LLM Suspicion Scan")
 
     // Audit manifest — files and targeted windows
+    // Manifest rotation v8: fresh files not covered by v4-v7 audits
     let manifest = [
-        {file: src + "/runtime/governance_checks.cpp",  lines: 6906, priority: "critical",
-         windows: [[3100, 3500], [4300, 4700], [6500, 6906]]},
-        {file: src + "/stdlib/agent_impl.cpp",          lines: 3587, priority: "critical",
-         windows: [[1700, 2100], [3000, 3400], [3400, 3587]]},
-        {file: src + "/runtime/governance_engine.cpp",  lines: 6594, priority: "critical",
-         windows: [[860, 1260], [2100, 2500], [5000, 5400]]},
-        {file: src + "/runtime/governance_config.cpp",  lines: 4424, priority: "high",
-         windows: [[2100, 2500], [4200, 4424]]},
-        {file: src + "/stdlib/codegen_impl.cpp",        lines: 593,  priority: "high",
-         windows: [[0, 593]]},
-        {file: src + "/vm/vm.cpp",                      lines: 5129, priority: "high",
-         windows: [[0, 400], [2400, 2800]]},
-        {file: src + "/cli/main.cpp",                   lines: 4752, priority: "medium",
-         windows: [[800, 1200], [2400, 2800]]}
+        {file: src + "/runtime/governance_reports.cpp",   lines: 2532, priority: "critical",
+         windows: [[0, 400], [800, 1200], [2100, 2532]]},
+        {file: src + "/runtime/behavioral_sequence.cpp",  lines: 1781, priority: "critical",
+         windows: [[0, 400], [800, 1200], [1400, 1781]]},
+        {file: src + "/interpreter/call_dispatch.cpp",    lines: 3351, priority: "critical",
+         windows: [[0, 400], [1400, 1800], [2900, 3351]]},
+        {file: src + "/runtime/agent_provider.cpp",       lines: 831,  priority: "high",
+         windows: [[0, 831]]},
+        {file: src + "/interpreter/interpreter.cpp",      lines: 3047, priority: "high",
+         windows: [[0, 400], [1400, 1800], [2600, 3047]]},
+        {file: src + "/vm/compiler.cpp",                  lines: 2161, priority: "high",
+         windows: [[0, 400], [1000, 1400], [1800, 2161]]},
+        {file: src + "/api/rest_api.cpp",                 lines: 728,  priority: "medium",
+         windows: [[0, 728]]}
     ]
 
     let boundaries = [
-        {name: "agent-governance", file_a: src + "/stdlib/agent_impl.cpp",
+        {name: "reports-engine", file_a: src + "/runtime/governance_reports.cpp",
          file_b: src + "/runtime/governance_engine.cpp",
-         window_a: [3100, 3400], window_b: [860, 1060],
-         focus: "GovernanceGuard lifecycle, tool callback taint, agentSend→enforce path"},
-        {name: "vm-governance", file_a: src + "/vm/vm.cpp",
+         window_a: [0, 400], window_b: [5800, 6100],
+         focus: "Telemetry write paths, hash chain integrity, transcript hooks, fwrite error handling"},
+        {name: "bsd-engine", file_a: src + "/runtime/behavioral_sequence.cpp",
          file_b: src + "/runtime/governance_engine.cpp",
-         window_a: [2400, 2700], window_b: [860, 1060],
-         focus: "VM taint stack↔governance taint, GovernanceHardError, callNaabFunction callback"},
-        {name: "codegen-governance", file_a: src + "/stdlib/codegen_impl.cpp",
-         file_b: src + "/runtime/governance_engine.cpp",
-         window_a: [0, 400], window_b: [860, 1060],
-         focus: "codegen.run→governance checks, HardError in codegen try/catch, taint_all_args"},
-        {name: "config-engine", file_a: src + "/runtime/governance_config.cpp",
-         file_b: src + "/runtime/governance_engine.cpp",
-         window_a: [4200, 4424], window_b: [2100, 2400],
-         focus: "Config reload→state consistency, ratchet enforcement, extends/inheritance"}
+         window_a: [800, 1100], window_b: [4800, 5100],
+         focus: "BSD pattern matching, cross-agent detection, event emission, mutex scope"},
+        {name: "dispatch-interpreter", file_a: src + "/interpreter/call_dispatch.cpp",
+         file_b: src + "/interpreter/interpreter.cpp",
+         window_a: [1400, 1700], window_b: [1400, 1700],
+         focus: "Function call routing, taint propagation through calls, GovernanceHardError in call paths"},
+        {name: "compiler-vm", file_a: src + "/vm/compiler.cpp",
+         file_b: src + "/vm/vm.cpp",
+         window_a: [1000, 1300], window_b: [2400, 2700],
+         focus: "Bytecode emission correctness, constant pool, polyglot block compilation, taint setup"}
     ]
 
     let suspicions = []

--- a/src/runtime/agent_provider.cpp
+++ b/src/runtime/agent_provider.cpp
@@ -360,9 +360,9 @@ static NormalizedResponse normalizeResponse(
         }
         if (response.contains("usageMetadata")) {
             auto& usage = response["usageMetadata"];
-            if (usage.contains("promptTokenCount"))
+            if (usage.contains("promptTokenCount") && usage["promptTokenCount"].is_number_integer())
                 result.input_tokens = usage["promptTokenCount"].get<int>();
-            if (usage.contains("candidatesTokenCount"))
+            if (usage.contains("candidatesTokenCount") && usage["candidatesTokenCount"].is_number_integer())
                 result.output_tokens = usage["candidatesTokenCount"].get<int>();
             if (usage.contains("thoughtsTokenCount") && usage["thoughtsTokenCount"].is_number_integer())
                 result.thinking_tokens = usage["thoughtsTokenCount"].get<int>();
@@ -396,9 +396,9 @@ static NormalizedResponse normalizeResponse(
             result.truncated = true;
         if (response.contains("usage") && response["usage"].is_object()) {
             auto& usage = response["usage"];
-            if (usage.contains("input_tokens"))
+            if (usage.contains("input_tokens") && usage["input_tokens"].is_number_integer())
                 result.input_tokens = usage["input_tokens"].get<int>();
-            if (usage.contains("output_tokens"))
+            if (usage.contains("output_tokens") && usage["output_tokens"].is_number_integer())
                 result.output_tokens = usage["output_tokens"].get<int>();
         }
     }

--- a/src/runtime/behavioral_sequence.cpp
+++ b/src/runtime/behavioral_sequence.cpp
@@ -997,13 +997,14 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                 // Extract capability category from the detail string
                 // Detail typically contains the check name (e.g., "filesystem", "network")
                 std::string det = ev.detail;
-                if (det.find("file") != std::string::npos || det.find("File") != std::string::npos ||
+                std::transform(det.begin(), det.end(), det.begin(), ::tolower);
+                if (det.find("file") != std::string::npos ||
                     det.find("path") != std::string::npos) this_turn_blocked.insert("filesystem");
-                if (det.find("network") != std::string::npos || det.find("Network") != std::string::npos ||
+                if (det.find("network") != std::string::npos ||
                     det.find("http") != std::string::npos) this_turn_blocked.insert("network");
-                if (det.find("shell") != std::string::npos || det.find("Shell") != std::string::npos ||
+                if (det.find("shell") != std::string::npos ||
                     det.find("exec") != std::string::npos) this_turn_blocked.insert("execution");
-                if (det.find("env") != std::string::npos || det.find("Env") != std::string::npos)
+                if (det.find("env") != std::string::npos)
                     this_turn_blocked.insert("environment");
             } else {
                 std::string cap = capCategory(ev.type);

--- a/src/runtime/governance_engine.cpp
+++ b/src/runtime/governance_engine.cpp
@@ -5897,6 +5897,7 @@ std::string GovernanceEngine::computeCoverageReport() const {
 }
 
 void GovernanceEngine::printValidationReport() {
+    std::lock_guard<std::mutex> lock(results_mutex_);
     // Count pass 2 findings
     int pass2_checks = 0, pass2_findings = 0;
     std::vector<const CheckResult*> pass2_results;


### PR DESCRIPTION
## Summary
- **S-38 (real bug):** Add `.is_number_integer()` guards on 4 unguarded `.get<int>()` calls in `agent_provider.cpp` — Gemini (`promptTokenCount`, `candidatesTokenCount`) and Anthropic (`input_tokens`, `output_tokens`). Prevents `json::type_error` on non-integer API responses.
- **S-31 (defensive):** Normalize CHECK_FAILED detail strings to lowercase via `std::transform` before BSD capability categorization in `behavioral_sequence.cpp`. Removes 4 redundant case-variant `.find()` checks, catches all case combinations uniformly. Current detail strings are all lowercase in practice — fix is for architectural consistency.
- **S-9 (defensive):** Add `results_mutex_` lock in `printValidationReport()` in `governance_engine.cpp`. Every other `check_results_` access (19 sites) holds this mutex. Deadlock-safe — verified no nested lock attempts.

Self-audit v8: 39 suspicions from rotated manifest (7 fresh files), two-pass deep verification → 1 real bug + 2 defensive fixes, 36 false positives.

## Test plan
- [x] `make naab-lang -j4` — compiles clean
- [x] `bash run-all-tests.sh` — 396/396, 0 unexpected
- [x] `bash tests/security/test_error_msg_leaks.sh` — 874/874

🤖 Generated with [Claude Code](https://claude.com/claude-code)