### PR TITLE
Update CLI binary name to naab-lang and refresh documentation

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -1,30 +1,31 @@
 # NAAb Language — Internal Reference
 
-Reference for Claude Code when working on the NAAb language source at `~/.naab/language/`.
+Reference for Claude Code when working on the NAAb language source (this repository).
 
 ## Build
 
 ```bash
-cd ~/.naab/language/build && cmake .. && make naab-lang -j4
+# from the repo root
+mkdir -p build && cd build && cmake .. && make naab-lang -j4
 ```
 
 - Debug (default): `cmake ..`
 - Release: `cmake .. -DCMAKE_BUILD_TYPE=Release`
 - After modifying CMakeLists.txt: `cmake ..` again before `make`
 
-Binary lands at `build/naab-lang`.
+Binary lands at `build/naab-lang`. A second CLI, `naab-gov` (`src/cli/gov_main.cpp`), builds via `make naab-gov` for standalone govern.json work.
 
 ## Test
 
 ```bash
 # Full suite — 396 tests, 0 unexpected failures
-cd ~/.naab/language && bash run-all-tests.sh
+bash run-all-tests.sh   # from the repo root
 
 # Security leak check — 874 checks, 0 failures
 bash tests/security/test_error_msg_leaks.sh
 ```
 
-Test categories in `tests/`: governance_v4, security, stdlib, vm, cli, e2e, integration, bugs, gorilla, scanner, polyglot, formatter, lsp, platform, chaos, robustness.
+Test categories in `tests/` (non-exhaustive — 40+ directories total): governance_v4, security, stdlib, vm, cli, e2e, integration, bugs, gorilla, scanner, formatter, lsp, platform, chaos, robustness, agent, unit, property.
 
 Expected breakdown: ~334 pass, ~51 error-behavior (intentional failures), ~11 needs-tree-walk (VM-unsupported features).
 
@@ -43,9 +44,9 @@ src/
 │                   dict, path, env, time, regex, crypto, http, log, uuid, validate,
 │                   process, debug, bolo, agent, codegen, orchestra, governance
 ├── cli/            main.cpp entry point — CLI flag parsing, subcommands
-├── scanner/        C++ security scanner (SARIF output, 18 code quality checks)
-├── libnaab-governance/  C API for external agent framework integration (Go, Rust, Java, C# bindings)
-├── api/            REST API (rest_api.cpp)
+├── scanner/        C++ security scanner (SARIF output, 19 code quality checks)
+├── api/            REST API (rest_api.cpp) + governance C API (governance_c_api.cpp,
+│                   built as naab_governance static lib; Go/Rust/Java/C#/Python bindings in bindings/)
 ├── repl/           REPL with readline support
 ├── linter/         Static analysis
 ├── formatter/      Code formatter
@@ -82,7 +83,7 @@ include/naab/       All headers
 - `global_env_` — global scope
 - `current_file_` — current source file (NOT `filename_`)
 - Control flow: `returning_`, `breaking_`, `loop_depth_`
-- Environment class is at `interpreter.h:371` — NOT `environment.h` (unused)
+- Environment class: `class Environment` in `include/naab/interpreter.h` (~line 413)
 
 ### Bytecode VM
 - `include/naab/vm.h` + `src/vm/vm.cpp` — stack-based dispatch
@@ -103,7 +104,7 @@ include/naab/       All headers
 - Module governance: VM compiler skips function-body governance checks during module loading (`!skip_main_` guard in `compiler.cpp`), matching tree-walker's `module_loading_depth_ == 0` guard
 - Enforcement tiers: HARD (block, exit 3), SOFT (block unless `--governance-override`, exit 3 without override), ADVISORY (warn, continue), DETECT (block but catchable by NAAb try/catch — for test configs only)
 - Exit codes: 0=success, 1=runtime, 2=quality gate, 3=HARD governance block, 4=config error
-- **GovernanceHardError** (`governance.h:2157`): `enforce()` throws `GovernanceHardError` (inherits `std::runtime_error`) for all HARD-level blocks. NAAb `try/catch` cannot catch it — both tree-walker (`interpreter.cpp`: `visit(TryCatchExpr)`, `visit(TryStmt)` outer+inner) and VM (`vm.cpp`: dispatch loop + 3 inner catches) explicitly re-throw before generic handlers. `main.cpp` catches it and calls `_exit(3)`. When adding new catch sites that could intercept stdlib/governance exceptions, always add `catch (const governance::GovernanceHardError&) { throw; }` BEFORE `catch (const std::exception&)`. ADVISORY (non-escalated) and SOFT-with-override remain catchable.
+- **GovernanceHardError** (`class GovernanceHardError` in `governance.h`, ~line 2467): `enforce()` throws `GovernanceHardError` (inherits `std::runtime_error`) for all HARD-level blocks. NAAb `try/catch` cannot catch it — both tree-walker (`interpreter.cpp`: `visit(TryCatchExpr)`, `visit(TryStmt)` outer+inner) and VM (`vm.cpp`: dispatch loop + 3 inner catches) explicitly re-throw before generic handlers. `main.cpp` catches it and calls `_exit(3)`. When adding new catch sites that could intercept stdlib/governance exceptions, always add `catch (const governance::GovernanceHardError&) { throw; }` BEFORE `catch (const std::exception&)`. ADVISORY (non-escalated) and SOFT-with-override remain catchable.
 - **env_vars enforcement**: `capabilities.env_vars` in govern.json — `blocked_read` (HARD), `allowed_read` (SOFT allowlist), `blocked_write`/`allowed_write`. Enforced in all 9 env stdlib access points via `checkEnvVarRead()`/`checkEnvVarWrite()` in `governance_engine.cpp`. blocked_read prevents value from ever entering memory (check fires before `std::getenv`).
 - Decision rationale: govern.json sections accept optional `rationale` field; engine generates `decision_trace` per check. Both flow into all 5 report formats + audit trail via `CheckResult.rationale` and `CheckResult.decision_trace`
 - Decision trace storage: `t_current_decision_trace` is `static thread_local` in `governance_engine.cpp` (NOT a class member) — thread-safe for concurrent polyglot/agent threads
@@ -202,17 +203,17 @@ include/naab/       All headers
   - `orchestra.enforce_convergence(response, spec)` — validates response against spec (regex `pattern` or `required_fields`). Returns `{valid, error_message}`. No retry loop — caller implements retries.
 - **Governance module** (`src/stdlib/governance_impl.cpp`): `governance.health()` — returns pulse verdict and instrumentation status without API call.
 
-### Scanner Code Quality Checks (18 checks in `checks_code_quality.cpp`)
-- Checks 1-15: original checks (empty_catch, magic_numbers, dead_code_after_return, god_functions, deep_nesting, etc.)
-- Check 16: `null_coalesce_non_nullable` — flags `??` on comparisons/bool literals that can never be null
-- Check 17: `assigned_never_read` — detects `let`-assigned variables never referenced after declaration, with special `sort()` mutation hint
-- Check 18: `hash_sanitize_mismatch` — one-level data flow tracing: finds `crypto.sha256(X)`, traces X back through `let` assignments, checks if any component variable is also passed to `sanitize_*()`/`validate_*()`
+### Scanner Code Quality Checks (19 checks in `checks_code_quality.cpp`)
+- Baseline checks (16): empty_catch, catch_and_ignore, magic_numbers, magic_strings, dead_code_after_return, dead_conditional, dead_conditional_dataflow, god_functions, god_classes, deep_nesting, boolean_function_returns, complex_boolean_expr, long_parameter_list, mutable_global_state, recursive_no_base_case, string_concat_in_loop
+- `null_coalesce_non_nullable` — flags `??` on comparisons/bool literals that can never be null
+- `assigned_never_read` — detects `let`-assigned variables never referenced after declaration, with special `sort()` mutation hint
+- `hash_sanitize_mismatch` — one-level data flow tracing: finds `crypto.sha256(X)`, traces X back through `let` assignments, checks if any component variable is also passed to `sanitize_*()`/`validate_*()`
 - Pattern: guard on `isEnabled(CAT, "check_name")`, use `findFuncEnd()` for function scope, `addIssue()` to report
 
 ### Telemetry
 - `GovernanceEngine::writeTelemetry()` in `governance_reports.cpp` writes JSONL events
 - Each event includes `run_id` (timestamp-pid, generated once in `loadFromFile()`) for separating runs in shared output files
-- Agent telemetry event types (31): `ADMISSION_EVAL`, `AGENT_CHALLENGE_FAIL`, `AGENT_CHALLENGE_PASS`, `AGENT_FALLBACK`, `AGENT_HARD_STOP`, `AGENT_KEY_DISABLED`, `AGENT_KEY_REVIVED`, `AGENT_RESPONSE`, `AGENT_RETRY`, `AGENT_TOOL_BLOCKED`, `AGENT_TOOL_CALL`, `AGENT_TOOL_LOOP_END`, `AGENT_TOOL_LOOP_START`, `AGENT_TOOL_REGISTERED`, `AGENT_TOOL_RESULT`, `AGENT_TOOL_SCAN_HIT`, `BSD_MATCH`, `CDD_TURN`, `CODEGEN_EXEC`, `CONTRACT_VIOLATION`, `GOVERNANCE_HEALTH_WARNING`, `GOVERNANCE_LEVEL_CHANGE`, `OUTPUT_ADMISSIBILITY_EVAL`, `OUTPUT_INADMISSIBLE`, `POLYGLOT_EXEC`, `PROMPT_SCAN`, `RECONCILIATION_TURN`, `RESPONSE_SCAN`, `RESPONSE_SUPPRESSED`, `RESPONSE_TRUNCATED`, `SEMANTIC_TURN`
+- Agent telemetry event types (32): `ADMISSION_EVAL`, `AGENT_CHALLENGE_FAIL`, `AGENT_CHALLENGE_PASS`, `AGENT_FALLBACK`, `AGENT_HARD_STOP`, `AGENT_KEY_DISABLED`, `AGENT_KEY_REVIVED`, `AGENT_RESPONSE`, `AGENT_RETRY`, `AGENT_TOOL_BLOCKED`, `AGENT_TOOL_CALL`, `AGENT_TOOL_LOOP_END`, `AGENT_TOOL_LOOP_START`, `AGENT_TOOL_REGISTERED`, `AGENT_TOOL_RESULT`, `AGENT_TOOL_SCAN_HIT`, `BSD_MATCH`, `CDD_TURN`, `CODEGEN_EXEC`, `CONTRACT_VIOLATION`, `GOVERNANCE_HEALTH_WARNING`, `GOVERNANCE_LEVEL_CHANGE`, `MANDATE_INJECTION`, `OUTPUT_ADMISSIBILITY_EVAL`, `OUTPUT_INADMISSIBLE`, `POLYGLOT_EXEC`, `PROMPT_SCAN`, `RECONCILIATION_TURN`, `RESPONSE_SCAN`, `RESPONSE_SUPPRESSED`, `RESPONSE_TRUNCATED`, `SEMANTIC_TURN`
 - Telemetry forwarding: `telemetry.forwarding` config enables webhook/SIEM push of events
 - Tamper-evident hash chain: each telemetry event includes `prev_hash` linking to previous event, creating an immutable audit trail
 
@@ -292,7 +293,6 @@ Always run `bash tests/security/test_error_msg_leaks.sh` after changing any erro
 
 ## Gotchas
 
-- **Two Environment classes exist** — use `interpreter.h:371`, not `environment.h`
 - **nlohmann/json.hpp** — keep in .cpp only, never in headers
 - **`result_`** is NaabVal — use `.isNull()` not `if (result_)`
 - **CLI flags must be in BOTH** global pre-scan AND run command flag loop in main.cpp

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -18,7 +18,7 @@ Binary lands at `build/naab-lang`. A second CLI, `naab-gov` (`src/cli/gov_main.c
 ## Test
 
 ```bash
-# Full suite — 396 tests, 0 unexpected failures
+# Full suite — 438 tests, 0 unexpected failures
 bash run-all-tests.sh   # from the repo root
 
 # Security leak check — 874 checks, 0 failures
@@ -27,7 +27,7 @@ bash tests/security/test_error_msg_leaks.sh
 
 Test categories in `tests/` (non-exhaustive — 40+ directories total): governance_v4, security, stdlib, vm, cli, e2e, integration, bugs, gorilla, scanner, formatter, lsp, platform, chaos, robustness, agent, unit, property.
 
-Expected breakdown: ~334 pass, ~51 error-behavior (intentional failures), ~11 needs-tree-walk (VM-unsupported features).
+Expected breakdown: ~374 pass, ~51 error-behavior (intentional failures), ~12 needs-tree-walk (VM-unsupported features), plus a platform-dependent missing-executor count (tests whose compilers are absent on the platform).
 
 Run a single test: `./build/naab-lang tests/path/to/test.naab`
 

--- a/README.md
+++ b/README.md
@@ -10,7 +10,7 @@
 AI agents can read your secrets, encode them, and send them to an external API — all in three steps. NAAb blocks the sequence **before the network call fires.**
 
 ```
-$ naab agent_task.naab
+$ naab-lang agent_task.naab
 
 [governance] Behavioral sequence 'credential_exfiltration' blocked before execution.
 
@@ -74,9 +74,9 @@ The patterns are yours to define. The engine tracks event sequences across your 
 Rules live in `govern.json`, not in prompts. A signed govern.json with Ed25519 means the agent can't modify its own constraints mid-run. A one-way ratchet ensures mid-run reloads can only tighten rules, never loosen them.
 
 ```bash
-naab --keygen ./keys/governance
-naab --sign-governance                    # Sign govern.json
-naab --trust-key ./keys/governance.pub   # Install on CI
+naab-lang --keygen ./keys/governance
+naab-lang --sign-governance                    # Sign govern.json
+naab-lang --trust-key ./keys/governance.pub   # Install on CI
 ```
 
 ---
@@ -121,7 +121,7 @@ Prompts are suggestions. **`govern.json` is policy.** NAAb checks every polyglot
 | **Governance Engine** | 50+ checks, 4-tier policy engine (hard / soft / advisory / detect), `govern.json` config |
 | **Polyglot Execution** | 12 languages in one file — Python, JavaScript, Rust, C++, Go, C#, Ruby, PHP, Shell, Nim, Zig, Julia |
 | **Smart Error Messages** | "Did you mean?" suggestions via Levenshtein distance, detailed fixes with examples |
-| **Standard Library** | 24 modules — array, string, math, json, http, file, path, time, debug, env, csv, regex, crypto, log, uuid, validate, process, io, bolo, agent, governance, codegen, orchestra |
+| **Standard Library** | 24 registered modules — array, string, math, json, http, file, path, time, debug, dict, env, csv, regex, crypto, log, uuid, validate, process, io, bolo, agent, governance, codegen, orchestra |
 | **Language Features** | Generators/yield, interfaces, pattern matching with guards, f-strings, async/await, lambdas, closures, pipeline, destructuring |
 | **CI/CD Integration** | SARIF (GitHub Code Scanning), JUnit XML (Jenkins/GitLab), JSON reports |
 | **Project Context** | Auto-reads CLAUDE.md, .editorconfig, .eslintrc, package.json to supplement governance |
@@ -155,6 +155,8 @@ ninja naab-lang -j$(nproc)
 # Start interactive REPL
 ./naab-lang
 ```
+
+Detailed build instructions: [INSTALL.md](INSTALL.md) · Language guide: [USER_GUIDE.md](USER_GUIDE.md) · Release history: [CHANGELOG.md](CHANGELOG.md)
 
 ### Hello World
 
@@ -253,13 +255,13 @@ Define your own regex-based governance rules:
 
 ```bash
 # GitHub Code Scanning (SARIF)
-naab app.naab --governance-report sarif > results.sarif
+naab-lang app.naab --governance-report sarif > results.sarif
 
 # Jenkins / GitLab CI (JUnit XML)
-naab app.naab --governance-report junit > results.xml
+naab-lang app.naab --governance-report junit > results.xml
 
 # Custom tooling (JSON)
-naab app.naab --governance-report json > results.json
+naab-lang app.naab --governance-report json > results.json
 ```
 
 > **[Build your govern.json interactively](https://b-macker.github.io/NAAb/governance.html)** | [Full governance reference (Chapter 21)](docs/book/chapter21.md)
@@ -296,10 +298,10 @@ NAAb supports multi-agent environments where different AI agents have different 
 
 ```bash
 # Run with agent identity
-naab --agent-id analyzer app.naab
+naab-lang --agent-id analyzer app.naab
 
 # View governance dashboard
-naab --agent-id analyzer --governance-dashboard app.naab
+naab-lang --agent-id analyzer --governance-dashboard app.naab
 ```
 
 **Agent features:**
@@ -328,13 +330,13 @@ Trust-anchored signing ensures govern.json integrity:
 
 ```bash
 # Generate keypair
-naab --keygen ./keys/governance
+naab-lang --keygen ./keys/governance
 
 # Sign govern.json
-naab --signing-key ./keys/governance.key --sign-governance
+naab-lang --signing-key ./keys/governance.key --sign-governance
 
 # Install public key on CI/team machines
-naab --trust-key ./keys/governance.pub
+naab-lang --trust-key ./keys/governance.pub
 ```
 
 Signed governance enforces a one-way ratchet — mid-run config reloads can only tighten restrictions, never loosen them.
@@ -346,6 +348,8 @@ Signed governance enforces a one-way ratchet — mid-run config reloads can only
 Use each language where it shines — Python for data science, Rust for performance, JavaScript for web, Go for concurrency, Shell for file ops. Variables flow between languages automatically. No FFI, no serialization, no microservices.
 
 **Supported languages:** Python · JavaScript · Rust · C++ · Go · C# · Ruby · PHP · Shell · Nim · Zig · Julia
+
+> Zig and Julia executors ship with the runtime but are disabled by default in `naab.toml` — flip `zig = true` / `julia = true` under `[polyglot]` to enable them.
 
 ```naab
 main {
@@ -597,6 +601,12 @@ main {
 | `csv` | parse, stringify |
 | `regex` | search, matches, find, find_all, replace, replace_first, split, groups, find_groups, escape, is_valid |
 | `crypto` | hash, sha256, sha512, md5, sha1, random_bytes, random_string, random_int, base64_encode, base64_decode, hex_encode, hex_decode, compare_digest, generate_token, hash_password |
+| `dict` | get, get_or, has_key, keys, values, entries, merge, size |
+| `io` | print, println, input, read_line, read_file, write_file, write_error, exists, list_dir |
+| `log` | debug, info, warn, error, set_level, get_level, set_format, set_output |
+| `process` | run, exit, getpid, kill |
+| `uuid` | v4, v5, nil, is_valid |
+| `validate` | email, url, ip, ipv6, is_int, is_float, is_string, int_range, length, matches, not_empty |
 | `agent` | create, send, run, extract_code, register_tool, batch, fan_out, pipeline, check, key_health, dispatch_status, environment |
 | `codegen` | run, run_with_args, run_strict, supported_languages, is_enabled |
 | `orchestra` | sequential_refinement, consensus_vote, enforce_convergence |
@@ -641,6 +651,12 @@ NAAb accepts multiple keyword styles so AI-generated code works without manual e
 - Semicolons — optional (accepted but not required)
 - `return` — optional in single-expression functions
 
+### Tooling
+
+- **`naab-lsp`** — Language Server Protocol implementation (`tools/naab-lsp/`), built and installed alongside the main binary. Powers the [VS Code extension](vscode-naab/).
+- **`naab-gov`** — standalone governance CLI (`src/cli/gov_main.cpp`) for working with govern.json outside script execution.
+- **Governance C API bindings** — embed the governance engine in other agent frameworks via `bindings/` (C#, Go, Java, Python, Rust), backed by the C API in `src/api/governance_c_api.cpp`.
+
 ---
 
 ## NAAb Ecosystem
@@ -659,13 +675,13 @@ Three tools built with NAAb — code governance, performance optimization, and d
 
 ```bash
 # Scan for governance violations
-naab bolo.naab scan ./src --profile enterprise
+naab-lang bolo.naab scan ./src --profile enterprise
 
 # Generate SARIF report for CI
-naab bolo.naab report ./src --format sarif --output results.sarif
+naab-lang bolo.naab report ./src --format sarif --output results.sarif
 
 # AI governance validation
-naab bolo.naab ai-check ./ml-models
+naab-lang bolo.naab ai-check ./ml-models
 ```
 
 **50+ checks · 4 languages · 339 regression tests** → [Get started](https://github.com/b-macker/naab-bolo)
@@ -676,10 +692,10 @@ naab bolo.naab ai-check ./ml-models
 
 ```bash
 # Analyze hotspots (Python → Rust candidates)
-naab pivot.naab analyze app.py
+naab-lang pivot.naab analyze app.py
 
 # Rewrite with proof
-naab pivot.naab rewrite app.py:expensive_loop --target rust --prove
+naab-lang pivot.naab rewrite app.py:expensive_loop --target rust --prove
 
 # Result: 45x faster, semantically identical
 ```
@@ -692,7 +708,7 @@ naab pivot.naab rewrite app.py:expensive_loop --target rust --prove
 
 ```bash
 # Start secure gateway
-naab main.naab
+naab-lang main.naab
 
 # All requests validated, PII blocked
 curl -X POST http://localhost:8091/ -d '{"prompt": "SSN: 123-45-6789"}'

--- a/README.md
+++ b/README.md
@@ -745,7 +745,7 @@ Source Code (.naab)
 ```
 
 - **120,000+** lines of C++17
-- **396** regression tests, **331** mono test assertions
+- **438** regression tests
 - **24** standard library modules with **204** error messages
 - Bytecode VM default (~8x faster), tree-walker via `--tree-walk`
 - Built with Abseil, fmt, spdlog, nlohmann/json, QuickJS


### PR DESCRIPTION
## Summary
Updates all documentation and references to use the correct CLI binary name `naab-lang` instead of `naab`, and refreshes internal developer documentation with current project structure and tooling information.

## Changes
- **CLI references**: Updated all command examples in README.md to use `naab-lang` instead of `naab` (15+ occurrences across governance, reporting, agent, and ecosystem tool examples)
- **Standard library documentation**: Added `dict` module to the 24 registered modules list and clarified module registration status
- **Documentation links**: Added references to INSTALL.md, USER_GUIDE.md, and CHANGELOG.md in the build section
- **Polyglot language notes**: Added clarification that Zig and Julia executors are disabled by default and require explicit enablement in `naab.toml`
- **Standard library table**: Expanded module reference table to include full signatures for `dict`, `io`, `log`, `process`, `uuid`, and `validate` modules
- **Tooling section**: Added new "Tooling" section documenting `naab-lsp` (Language Server Protocol), `naab-gov` (standalone governance CLI), and C API bindings for external framework integration
- **CLAUDE.md updates**: 
  - Corrected build instructions to reference repo root instead of `~/.naab/language/`
  - Updated source layout to reflect current structure (governance C API moved to `src/api/`, bindings in `bindings/`)
  - Clarified scanner has 19 code quality checks (not 18) with detailed baseline check list
  - Updated telemetry event types count from 31 to 32 (added `MANDATE_INJECTION`)
  - Fixed Environment class location reference and removed duplicate gotcha
  - Expanded test categories documentation to note 40+ directories total
  - Updated governance engine documentation with current line numbers and class locations

## Test Plan
- [ ] Ran `bash run-all-tests.sh` with no new failures
- [ ] Verified all CLI command examples execute correctly with `naab-lang` binary
- [ ] Confirmed documentation links are accurate and reference correct files

https://claude.ai/code/session_01KW1Xyu81h1dMU3WFe4suGW