### PR TITLE
test: fix CI portability in three test suites

### DIFF
--- a/tests/agent/test_agent_governance_unification.sh
+++ b/tests/agent/test_agent_governance_unification.sh
@@ -102,8 +102,8 @@ fi
 echo ""
 echo "=== Behavioral Tests ==="
 
-# Create temp test files for scanner
-TMPDIR="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
+# Create temp test files for scanner (Termux sets TMPDIR; fall back to /tmp elsewhere)
+TMPDIR="${TMPDIR:-/tmp}"
 TEST_UNCHECKED="$TMPDIR/test_unchecked_send.naab"
 TEST_FROMFILE="$TMPDIR/test_prompt_from_file.naab"
 

--- a/tests/agent/test_execution_governance.sh
+++ b/tests/agent/test_execution_governance.sh
@@ -127,6 +127,11 @@ TMPDIR="${TMPDIR:-/tmp}"
 TEST_DIR="$TMPDIR/test_exec_gov_$$"
 mkdir -p "$TEST_DIR/.naab"
 
+# Isolate the trust store: the --trust-key fallback below must not install
+# keys into the global ~/.naab/trusted-keys — trusted keys there make every
+# later suite's unsigned govern.json fail with INTEGRITY BLOCK
+export NAAB_TRUST_STORE_DIR="$TEST_DIR/trusted-keys"
+
 # T12: --approve generates valid JSON
 NAAB_SIGNING_KEY="$SCRIPT_DIR/../../tests/security/test_signing_key.pem"
 if [[ ! -f "$NAAB_SIGNING_KEY" ]]; then

--- a/tests/agent/test_execution_governance.sh
+++ b/tests/agent/test_execution_governance.sh
@@ -122,7 +122,8 @@ fi
 echo ""
 echo "=== Behavioral Tests ==="
 
-TMPDIR="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
+# Termux sets TMPDIR; fall back to /tmp elsewhere
+TMPDIR="${TMPDIR:-/tmp}"
 TEST_DIR="$TMPDIR/test_exec_gov_$$"
 mkdir -p "$TEST_DIR/.naab"
 

--- a/tests/governance_v4/test_rate_limiter.sh
+++ b/tests/governance_v4/test_rate_limiter.sh
@@ -145,12 +145,19 @@ EOF
 # Create a test file to read
 echo "test content" > "$WORKDIR/testfile.txt"
 
+# The native Windows binary can't resolve MSYS-style absolute paths embedded
+# in .naab sources; convert to a mixed (C:/...) path under MSYS/Git Bash
+NAAB_WORKDIR="$WORKDIR"
+if command -v cygpath &>/dev/null; then
+    NAAB_WORKDIR=$(cygpath -m "$WORKDIR")
+fi
+
 cat > "$WORKDIR/test_file_rate.naab" << NAABEOF
 use file
 main {
-  let a = file.read("$WORKDIR/testfile.txt")
-  let b = file.read("$WORKDIR/testfile.txt")
-  let c = file.read("$WORKDIR/testfile.txt")
+  let a = file.read("$NAAB_WORKDIR/testfile.txt")
+  let b = file.read("$NAAB_WORKDIR/testfile.txt")
+  let c = file.read("$NAAB_WORKDIR/testfile.txt")
   print(a)
 }
 NAABEOF


### PR DESCRIPTION
- test_agent_governance_unification.sh, test_execution_governance.sh:
  TMPDIR fell back to the Termux path /data/data/com.termux/files/usr/tmp,
  which doesn't exist on GitHub runners (TMPDIR is unset there). Fall back
  to /tmp instead — Termux always sets TMPDIR itself.
- test_rate_limiter.sh (T4): the .naab script embedded an MSYS-style
  absolute path that the native Windows binary can't open, so the run
  failed before the rate limiter fired. Convert with cygpath -m, matching
  the existing convention in other suites.

Co-Authored-By: Claude Fable 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01CTTnz6kyPy2J5sGJvqidUo