### PR TITLE
fix: reload sig failure mtime + log dedup

### DIFF
--- a/examples/living-script/src/govern.json
+++ b/examples/living-script/src/govern.json
@@ -25,6 +25,7 @@
   "telemetry": {
     "enabled": true,
     "output_file": "telemetry.jsonl",
+    "deduplicate_checks": true,
     "tamper_evidence": {
       "enabled": true,
       "algorithm": "sha256",
@@ -276,7 +277,13 @@
     "mandate_reinforcement_interval": 5,
     "coherence_correction_enabled": true,
     "coherence_correction_threshold": 0.85,
-    "coherence_correction_cooldown_turns": 3
+    "coherence_correction_cooldown_turns": 3,
+    "output_admissibility": {
+      "enabled": true,
+      "threshold": 0.60,
+      "action": "quarantine",
+      "inadmissible_history": "commit"
+    }
   },
 
   "advisory_escalation": {

--- a/examples/living-script/src/living-script.naab
+++ b/examples/living-script/src/living-script.naab
@@ -93,7 +93,39 @@ fn apply_operator_adjustments(adjustments, current_phase) {
     let config = json.parse(read_result.stdout)
     let changes_made = false
 
+    // LLM sometimes sends flat adjustments ({"context_strategy": "recent"})
+    // instead of agent-wrapped ({"developer": {"context_strategy": "recent"}}).
+    // Auto-wrap flat fields as developer adjustments.
+    let all_known_fields = allowed_agent_fields + allowed_circuit_fields
     let adj_names = adjustments.keys()
+    let has_flat_fields = false
+    let fi = 0
+    while fi < adj_names.length() {
+        if array.contains(all_known_fields, adj_names[fi]) {
+            has_flat_fields = true
+        }
+        fi = fi + 1
+    }
+    if has_flat_fields {
+        let wrapped = {"developer": {}}
+        let wi = 0
+        while wi < adj_names.length() {
+            let k = adj_names[wi]
+            if array.contains(allowed_circuit_fields, k) {
+                if adjustments.get("circuit_breaker") == null {
+                    wrapped["circuit_breaker"] = {}
+                }
+                wrapped["circuit_breaker"][k] = adjustments[k]
+            } else if array.contains(allowed_agent_fields, k) {
+                wrapped["developer"][k] = adjustments[k]
+            }
+            wi = wi + 1
+        }
+        adjustments = wrapped
+        adj_names = adjustments.keys()
+        print("[operator] Auto-wrapped flat adjustments as developer fields")
+    }
+
     let i = 0
     while i < adj_names.length() {
         let agent_name = adj_names[i]

--- a/examples/living-script/src/living-script.naab
+++ b/examples/living-script/src/living-script.naab
@@ -71,6 +71,15 @@ fn apply_operator_adjustments(adjustments, current_phase) {
     // Use process.run() to read/write through shell (SYS_EXEC path).
     // system_prompt removed — rewrites fire persona_drift + entity_consistency in CDD,
     // cratering coherence. Operator uses message_prefix for tactical guidance instead.
+
+    // CRITICAL: cache env vars BEFORE modifying govern.json.
+    // env.get() triggers checkEnvVarRead() → reloadIfChanged(). If called after mv
+    // but before re-signing, the premature reload sees modified govern.json with
+    // stale .sig → rejects → caches mtime. After signing, mtime is unchanged,
+    // so future reloads skip — the valid .sig is never checked.
+    let signing_key_path = env.get("NAAB_SIGN_PATH", "")
+    let naab_binary = env.get("NAAB_BINARY", "naab-lang")
+
     let freely_adjustable = ["context_strategy", "max_tokens"]
     let tighten_only = ["context_window", "standing_lease_turns"]
     let allowed_agent_fields = ["context_window", "context_strategy", "max_tokens", "standing_lease_turns"]
@@ -130,18 +139,19 @@ fn apply_operator_adjustments(adjustments, current_phase) {
     }
 
     let new_json = json.stringify(config, 2)
-    let write_cmd = "import sys; open('govern.json','w').write(sys.argv[1])"
-    let write_result = process.run("python3", ["-c", write_cmd, new_json])
+    // file.write to govern.json is HARD-blocked (self-protection).
+    // Write to a temp file, then mv to replace — avoids argv truncation of 15KB+ JSON.
+    file.write("_govern_pending.json", new_json)
+    let write_result = process.run("mv", ["_govern_pending.json", "govern.json"])
     if write_result.exit_code != 0 {
         print("[operator] Failed to write govern.json: " + write_result.stderr)
         return false
     }
     let sign_args = ["--sign-governance"]
-    let signing_key = env.get("NAAB_SIGN_PATH", "")
-    if len(signing_key) > 0 {
-        sign_args = ["--signing-key", signing_key, "--sign-governance"]
+    if len(signing_key_path) > 0 {
+        sign_args = ["--signing-key", signing_key_path, "--sign-governance"]
     }
-    let sign_result = process.run(env.get("NAAB_BINARY", "naab-lang"), sign_args)
+    let sign_result = process.run(naab_binary, sign_args)
     if sign_result.exit_code != 0 {
         print("[operator] WARNING: re-signing failed: " + sign_result.stderr)
     }

--- a/examples/living-script/src/living-script.naab
+++ b/examples/living-script/src/living-script.naab
@@ -88,7 +88,7 @@ fn apply_operator_adjustments(adjustments, current_phase) {
     let read_result = process.run("cat", ["govern.json"])
     if read_result.exit_code != 0 {
         print("[operator] Failed to read govern.json via shell")
-        return false
+        return "read_failed"
     }
     let config = json.parse(read_result.stdout)
     let changes_made = false
@@ -167,7 +167,7 @@ fn apply_operator_adjustments(adjustments, current_phase) {
 
     if !changes_made {
         print("[operator] No valid changes to apply")
-        return false
+        return "no_valid_changes"
     }
 
     let new_json = json.stringify(config, 2)
@@ -177,7 +177,7 @@ fn apply_operator_adjustments(adjustments, current_phase) {
     let write_result = process.run("mv", ["_govern_pending.json", "govern.json"])
     if write_result.exit_code != 0 {
         print("[operator] Failed to write govern.json: " + write_result.stderr)
-        return false
+        return "write_failed"
     }
     let sign_args = ["--sign-governance"]
     if len(signing_key_path) > 0 {
@@ -186,8 +186,9 @@ fn apply_operator_adjustments(adjustments, current_phase) {
     let sign_result = process.run(naab_binary, sign_args)
     if sign_result.exit_code != 0 {
         print("[operator] WARNING: re-signing failed: " + sign_result.stderr)
+        return "sign_failed"
     }
-    return sign_result.exit_code == 0
+    return ""
 }
 
 fn validate_code(ops_code, main_code, test_code, ops_pattern) {
@@ -356,12 +357,12 @@ main {
         if action == "adjust" && decision.get("adjustments") != null {
             let adj = decision["adjustments"]
             let phase = context.get("phase") ?? ""
-            let ok = apply_operator_adjustments(adj, phase)
-            if ok {
+            let rejection = apply_operator_adjustments(adj, phase)
+            if rejection == "" {
                 tracking["adjustments_made"] = tracking["adjustments_made"] + 1
                 print("OPERATOR|adjustment_applied|count=" + string(tracking["adjustments_made"]))
             } else {
-                print("OPERATOR|adjustment_rejected|ratchet_or_sign_failure")
+                print("OPERATOR|adjustment_rejected|" + rejection)
             }
         }
 

--- a/include/naab/behavioral_sequence.h
+++ b/include/naab/behavioral_sequence.h
@@ -229,6 +229,9 @@ struct DriftState {
     int consecutive_high_pressure_turns = 0;
     int last_checkpoint_turn = -100;   // init negative for no initial cooldown
     int signals_fired_this_turn = 0;
+    std::array<int, NUM_CDD_SIGNALS> last_turn_fired = {};      // per-signal fire counts for most recent turn
+    std::array<double, NUM_CDD_SIGNALS> last_turn_penalties = {}; // penalty applied per signal most recent turn
+    double min_coherence_lifetime = 1.0;                         // lowest coherence ever seen for this agent
 
     // Recovery tracking (Phase 4a)
     int last_recovery_turn = -1;              // turn of last coherence recovery (-1 = never)
@@ -325,6 +328,9 @@ public:
     std::unordered_map<std::string, double> getAllAgentCoherences() const;
 
     bool isEnabled() const;
+
+    // Signal name lookup (index → human-readable name)
+    static const char* signalName(int idx);
 
     // Telemetry: total turns analyzed
     size_t totalTurnsAnalyzed() const;

--- a/include/naab/behavioral_sequence.h
+++ b/include/naab/behavioral_sequence.h
@@ -83,7 +83,7 @@ struct SequenceMatchResult {
 };
 
 // CDD signal indices for generic adaptive baseline
-static constexpr int NUM_CDD_SIGNALS = 20;
+static constexpr int NUM_CDD_SIGNALS = 21;
 enum CddSignalId : int {
     SIG_CIRCULAR = 0,              // S1
     SIG_REPEATED_FAILURES = 1,     // S2
@@ -104,7 +104,8 @@ enum CddSignalId : int {
     SIG_PERSONA_FINGERPRINT = 16,  // S17
     SIG_TOOL_CHAIN_INTEGRITY = 17, // S18
     SIG_CLAIM_RESULT = 18,         // S19
-    SIG_PROMPT_COMPLIANCE = 19     // S20 — off-topic prompt compliance
+    SIG_PROMPT_COMPLIANCE = 19,    // S20 — off-topic prompt compliance
+    SIG_RESPONSE_REPETITION = 20   // S21 — verbatim response repetition
 };
 
 struct SignalBaseline {
@@ -200,6 +201,10 @@ struct DriftState {
     std::unordered_set<std::string> turn_prompt_keywords;  // per-turn (set before CDD, cleared after)
     std::deque<double> prompt_alignment_history;            // rolling window of prompt-to-mandate overlap
     int prompt_compliance_count = 0;                        // turns where off-topic prompt was complied with
+
+    // Response repetition — detect verbatim duplicate responses
+    std::deque<std::string> response_fingerprints;  // recent content_fingerprint values
+    int response_repetition_count = 0;              // turns with exact duplicate response
 
     // Escalation effectiveness tracking — measure whether level changes improve behavior
     int escalation_turn = -1;                      // turn when last escalation occurred (-1 = never)
@@ -312,6 +317,12 @@ public:
 
     // Get drift state for decision_trace (returns copy — safe across threads)
     std::optional<DriftState> getDriftState(int handle_id) const;
+
+    // Get minimum coherence across all tracked agents
+    double getMinCoherence() const;
+
+    // Get per-agent coherence map (config_name → coherence_score)
+    std::unordered_map<std::string, double> getAllAgentCoherences() const;
 
     bool isEnabled() const;
 

--- a/include/naab/governance.h
+++ b/include/naab/governance.h
@@ -3301,6 +3301,7 @@ private:
 
     // --- Mid-run reload state (Governance Under Survivability) ---
     int64_t loaded_mtime_ns_ = 0;                 // govern.json mtime as nanoseconds (fs clock epoch)
+    int64_t last_sig_fail_mtime_ = 0;             // mtime of last signature-failed reload (suppress duplicate logs)
     int reload_count_ = 0;                        // reloads applied this run
     std::vector<std::string> pending_notices_;    // notices from last reload
     mutable std::mutex notices_mutex_;            // guards pending_notices_

--- a/include/naab/governance.h
+++ b/include/naab/governance.h
@@ -1340,6 +1340,7 @@ struct ContextDriftConfig {
         bool tool_chain_integrity = true;      // fire when agent misrepresents tool results
         bool claim_result_reconciliation = true; // fire when agent misrepresents tool success/failure status
         bool prompt_compliance = true;           // fire when agent complies with off-topic prompts
+        bool response_repetition = true;         // fire when agent produces verbatim duplicate responses
         bool exclude_infrastructure_errors = true; // exclude API/network errors from repeated_failures signal
     } signals;
     // Weights control how much each signal reduces coherence per occurrence.
@@ -1371,6 +1372,7 @@ struct ContextDriftConfig {
         double tool_chain_integrity = 0.08;   // moderate — misrepresenting tool results indicates hallucination
         double claim_result_reconciliation = 0.12; // moderate-high — status misrepresentation is unambiguous hallucination
         double prompt_compliance = 0.10;             // moderate-high — complying with off-topic prompts is unambiguous drift
+        double response_repetition = 0.15;           // moderate-high — verbatim repetition is a strong drift indicator
     } weights;
 
     // Signal detection thresholds — tune sensitivity of individual CDD signals.
@@ -1459,6 +1461,9 @@ struct ContextDriftConfig {
         // Short refusals ("I can only help with todo apps") are typically <50 tokens.
         // Full compliance ("Here's a fibonacci function...") is typically >100 tokens.
         int prompt_compliance_response_min_tokens = 50;
+        // 5 responses: check previous 5 responses for exact fingerprint match.
+        // Small window avoids stale matches while catching stuck-in-a-loop patterns.
+        int response_repetition_lookback = 5;
     } thresholds;
 
     // Reality Checkpoint: composite operational pressure detection
@@ -2981,6 +2986,9 @@ public:
 
     // Agent environment: get drift state for environment dict
     std::optional<governance::DriftState> getDriftState(int handle_id) const;
+
+    // Get minimum coherence across all tracked agents (for multi-agent dashboard/health)
+    double getMinAgentCoherence() const;
 
     // Initialize mandate keywords for semantic mandate alignment signal
     void initializeMandateKeywords(int handle_id, const std::unordered_set<std::string>& keywords);

--- a/src/runtime/behavioral_sequence.cpp
+++ b/src/runtime/behavioral_sequence.cpp
@@ -872,8 +872,9 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
 
     // Adaptive baselining: during baseline window, count signals but suppress penalties
     bool in_baseline = config_->adaptive_baseline_enabled && !state.baseline_complete;
-    // Per-turn signal counters (used for baseline accumulation)
+    // Per-turn signal counters (used for baseline accumulation + telemetry)
     std::array<int, NUM_CDD_SIGNALS> turn_fired = {};
+    std::array<double, NUM_CDD_SIGNALS> turn_penalties = {};
 
     // Signal 1: Circular actions (same fingerprint repeats)
     if (config_->signals.circular_actions && isCircular(state, fp)) {
@@ -883,6 +884,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
             double p = adaptive_penalty(config_->weights.circular, state.circular_action_count, SIG_CIRCULAR);
             if (p > 0.0) {
                 state.coherence_score -= p;
+                turn_penalties[SIG_CIRCULAR] += p;
                 state.signals_fired_this_turn++;
             }
         }
@@ -908,6 +910,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                     double p = adaptive_penalty(config_->weights.repeated_failure, state.repeated_failures, SIG_REPEATED_FAILURES);
                     if (p > 0.0) {
                         state.coherence_score -= p;
+                        turn_penalties[SIG_REPEATED_FAILURES] += p;
                         state.signals_fired_this_turn++;
                     }
                 }
@@ -956,6 +959,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                 double p = adaptive_penalty(config_->weights.scope_creep, state.scope_creep_count, SIG_SCOPE_CREEP);
                 if (p > 0.0) {
                     state.coherence_score -= p;
+                    turn_penalties[SIG_SCOPE_CREEP] += p;
                     state.signals_fired_this_turn++;
                 }
             }
@@ -1019,6 +1023,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                     double p = adaptive_penalty(config_->weights.vocabulary_contraction, state.vocabulary_contraction_count, SIG_VOCAB_CONTRACTION);
                     if (p > 0.0) {
                         state.coherence_score -= p;
+                        turn_penalties[SIG_VOCAB_CONTRACTION] += p;
                         state.signals_fired_this_turn++;
                     }
                 }
@@ -1077,6 +1082,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                     double p = adaptive_penalty(config_->weights.contradiction, state.contradictions, SIG_CONTRADICTIONS);
                     if (p > 0.0) {
                         state.coherence_score -= p;
+                        turn_penalties[SIG_CONTRADICTIONS] += p;
                         state.signals_fired_this_turn++;
                     }
                 }
@@ -1099,7 +1105,9 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
         if (state.coherence_velocity < config_->thresholds.velocity_drop) {
             turn_fired[SIG_COHERENCE_VELOCITY]++;
             if (!in_baseline) {
-                state.coherence_score -= base_penalty(config_->weights.coherence_velocity, 1);
+                double p_vel = base_penalty(config_->weights.coherence_velocity, 1);
+                state.coherence_score -= p_vel;
+                turn_penalties[SIG_COHERENCE_VELOCITY] += p_vel;
                 state.signals_fired_this_turn++;
             }
         }
@@ -1129,7 +1137,9 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                     turn_number - state.first_event_turn >= config_->thresholds.underutilization_delay) {
                     turn_fired[SIG_CAPABILITY_UNDERUTIL]++;
                     if (!in_baseline) {
-                        state.coherence_score -= base_penalty(config_->weights.capability_underutilization, 1);
+                        double p_cap = base_penalty(config_->weights.capability_underutilization, 1);
+                        state.coherence_score -= p_cap;
+                        turn_penalties[SIG_CAPABILITY_UNDERUTIL] += p_cap;
                         state.signals_fired_this_turn++;
                     }
                 }
@@ -1153,6 +1163,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                     state.response_quality_count, SIG_RESPONSE_QUALITY);
                         if (p > 0.0) {
                             state.coherence_score -= p;
+                            turn_penalties[SIG_RESPONSE_QUALITY] += p;
                             state.signals_fired_this_turn++;
                         }
                     }
@@ -1196,6 +1207,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                 state.thinking_collapse_count, SIG_THINKING_COLLAPSE);
                     if (p > 0.0) {
                         state.coherence_score -= p;
+                        turn_penalties[SIG_THINKING_COLLAPSE] += p;
                         state.signals_fired_this_turn++;
                     }
                 }
@@ -1252,6 +1264,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                 state.context_growth_count, SIG_CONTEXT_GROWTH);
                     if (p > 0.0) {
                         state.coherence_score -= p;
+                        turn_penalties[SIG_CONTEXT_GROWTH] += p;
                         state.signals_fired_this_turn++;
                     }
                 }
@@ -1287,6 +1300,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                         state.semantic_stability_count, SIG_SEMANTIC_STABILITY);
                             if (p > 0.0) {
                                 state.coherence_score -= p;
+                                turn_penalties[SIG_SEMANTIC_STABILITY] += p;
                                 state.signals_fired_this_turn++;
                             }
                         }
@@ -1318,6 +1332,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                     state.response_repetition_count, SIG_RESPONSE_REPETITION);
                         if (p > 0.0) {
                             state.coherence_score -= p;
+                            turn_penalties[SIG_RESPONSE_REPETITION] += p;
                             state.signals_fired_this_turn++;
                         }
                     }
@@ -1358,6 +1373,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                     state.mandate_drift_count, SIG_MANDATE_ALIGNMENT);
                         if (p > 0.0) {
                             state.coherence_score -= p;
+                            turn_penalties[SIG_MANDATE_ALIGNMENT] += p;
                             state.signals_fired_this_turn++;
                         }
                     }
@@ -1385,6 +1401,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                     state.instruction_recall_count, SIG_INSTRUCTION_RECALL);
                         if (p > 0.0) {
                             state.coherence_score -= p;
+                            turn_penalties[SIG_INSTRUCTION_RECALL] += p;
                             state.signals_fired_this_turn++;
                         }
                     }
@@ -1444,6 +1461,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                         state.plan_drift_count, SIG_PLAN_DRIFT);
                             if (p > 0.0) {
                                 state.coherence_score -= p;
+                                turn_penalties[SIG_PLAN_DRIFT] += p;
                                 state.signals_fired_this_turn++;
                             }
                         }
@@ -1489,6 +1507,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                     state.entity_consistency_count, SIG_ENTITY_CONSISTENCY);
                         if (p > 0.0) {
                             state.coherence_score -= p;
+                            turn_penalties[SIG_ENTITY_CONSISTENCY] += p;
                             state.signals_fired_this_turn++;
                         }
                     }
@@ -1531,6 +1550,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                             state.instruction_conflict_count, SIG_INSTRUCTION_CONFLICT);
                 if (p > 0.0) {
                     state.coherence_score -= p;
+                    turn_penalties[SIG_INSTRUCTION_CONFLICT] += p;
                     state.signals_fired_this_turn++;
                 }
             }
@@ -1577,6 +1597,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                         state.persona_drift_count, SIG_PERSONA_FINGERPRINT);
                             if (p > 0.0) {
                                 state.coherence_score -= p;
+                                turn_penalties[SIG_PERSONA_FINGERPRINT] += p;
                                 state.signals_fired_this_turn++;
                             }
                         }
@@ -1620,6 +1641,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                     state.tool_integrity_count, SIG_TOOL_CHAIN_INTEGRITY);
                         if (p > 0.0) {
                             state.coherence_score -= p;
+                            turn_penalties[SIG_TOOL_CHAIN_INTEGRITY] += p;
                             state.signals_fired_this_turn++;
                         }
                     }
@@ -1693,6 +1715,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                     state.claim_result_mismatch_count, SIG_CLAIM_RESULT);
                         if (p > 0.0) {
                             state.coherence_score -= p;
+                            turn_penalties[SIG_CLAIM_RESULT] += p;
                             state.signals_fired_this_turn++;
                         }
                     }
@@ -1752,6 +1775,7 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
                                                             SIG_PROMPT_COMPLIANCE);
                                 if (p > 0.0) {
                                     state.coherence_score -= p;
+                                    turn_penalties[SIG_PROMPT_COMPLIANCE] += p;
                                     state.signals_fired_this_turn++;
                                 }
                             }
@@ -1794,6 +1818,9 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
         }
     }
 
+    state.last_turn_fired = turn_fired;
+    state.last_turn_penalties = turn_penalties;
+
     // F15: Natural healing — proportional to signal cleanliness.
     // Full healing at 0 signals, half at 1, third at 2, etc.
     if (config_->coherence_natural_healing > 0.0) {
@@ -1803,6 +1830,8 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
 
     // Clamp coherence score to [0.0, 1.0]
     state.coherence_score = std::max(0.0, std::min(1.0, state.coherence_score));
+    if (state.coherence_score < state.min_coherence_lifetime)
+        state.min_coherence_lifetime = state.coherence_score;
 
     // Escalation effectiveness: accumulate post-escalation coherence readings
     if (state.escalation_turn >= 0 &&
@@ -1851,6 +1880,34 @@ std::unordered_map<std::string, double> ContextDriftAnalyzer::getAllAgentCoheren
         result[key] = st.coherence_score;
     }
     return result;
+}
+
+const char* ContextDriftAnalyzer::signalName(int idx) {
+    static const char* names[NUM_CDD_SIGNALS] = {
+        "circular",              // 0  S1
+        "repeated_failures",     // 1  S2
+        "scope_creep",           // 2  S3
+        "contradictions",        // 3  S4
+        "vocab_contraction",     // 4  S5
+        "coherence_velocity",    // 5  S6
+        "capability_underutil",  // 6  S7
+        "response_quality",      // 7  S8
+        "thinking_collapse",     // 8  S9
+        "semantic_stability",    // 9  S10
+        "mandate_alignment",     // 10 S11
+        "context_growth",        // 11 S12
+        "instruction_recall",    // 12 S13
+        "plan_drift",            // 13 S14
+        "entity_consistency",    // 14 S15
+        "instruction_conflict",  // 15 S16
+        "persona_fingerprint",   // 16 S17
+        "tool_chain_integrity",  // 17 S18
+        "claim_result",          // 18 S19
+        "prompt_compliance",     // 19 S20
+        "response_repetition"    // 20 S21
+    };
+    if (idx < 0 || idx >= NUM_CDD_SIGNALS) return "unknown";
+    return names[idx];
 }
 
 std::string ContextDriftAnalyzer::computeFingerprint(

--- a/src/runtime/behavioral_sequence.cpp
+++ b/src/runtime/behavioral_sequence.cpp
@@ -31,7 +31,7 @@ static const std::unordered_set<std::string> kStopWords = {
     "each", "more", "like", "just", "some", "when", "then",
     "into", "here", "been", "both", "want", "used", "them", "than",
     "what", "were", "they", "does", "done", "very", "much", "most",
-    "only", "over", "such", "should", "would", "could", "about",
+    "over", "such", "should", "would", "could", "about",
     "other", "their", "there", "which", "these", "those", "being",
     "after", "before",
     "sure", "great", "lets", "following", "below",
@@ -1298,6 +1298,40 @@ bool ContextDriftAnalyzer::recordTurn(int handle_id, int turn_number,
         }
     }
 
+    // Signal 21: Response repetition — detect verbatim duplicate responses via content fingerprint
+    if (config_->signals.response_repetition) {
+        for (const auto& ev : turn_events) {
+            if (ev.type == RuntimeEventType::AGENT_RESPONSE &&
+                !ev.content_fingerprint.empty()) {
+                bool duplicate = false;
+                for (const auto& prev_fp : state.response_fingerprints) {
+                    if (ev.content_fingerprint == prev_fp) {
+                        duplicate = true;
+                        break;
+                    }
+                }
+                if (duplicate) {
+                    state.response_repetition_count++;
+                    turn_fired[SIG_RESPONSE_REPETITION]++;
+                    if (!in_baseline) {
+                        double p = adaptive_penalty(config_->weights.response_repetition,
+                                                    state.response_repetition_count, SIG_RESPONSE_REPETITION);
+                        if (p > 0.0) {
+                            state.coherence_score -= p;
+                            state.signals_fired_this_turn++;
+                        }
+                    }
+                }
+                state.response_fingerprints.push_back(ev.content_fingerprint);
+                while (static_cast<int>(state.response_fingerprints.size()) >
+                       config_->thresholds.response_repetition_lookback) {
+                    state.response_fingerprints.pop_front();
+                }
+                break;  // one AGENT_RESPONSE per turn
+            }
+        }
+    }
+
     // Signal 11: Mandate alignment — continuous system_prompt keyword adherence
     if (config_->signals.mandate_alignment && !state.mandate_keywords.empty()) {
         for (const auto& ev : turn_events) {
@@ -1798,6 +1832,25 @@ std::optional<DriftState> ContextDriftAnalyzer::getDriftState(int handle_id) con
     auto it = drift_states_.find(handle_id);
     if (it == drift_states_.end()) return std::nullopt;
     return it->second;
+}
+
+double ContextDriftAnalyzer::getMinCoherence() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    double min_c = 1.0;
+    for (const auto& [hid, st] : drift_states_) {
+        if (st.coherence_score < min_c) min_c = st.coherence_score;
+    }
+    return min_c;
+}
+
+std::unordered_map<std::string, double> ContextDriftAnalyzer::getAllAgentCoherences() const {
+    std::lock_guard<std::mutex> lock(mutex_);
+    std::unordered_map<std::string, double> result;
+    for (const auto& [hid, st] : drift_states_) {
+        std::string key = st.config_name.empty() ? std::to_string(hid) : st.config_name;
+        result[key] = st.coherence_score;
+    }
+    return result;
 }
 
 std::string ContextDriftAnalyzer::computeFingerprint(

--- a/src/runtime/governance_config.cpp
+++ b/src/runtime/governance_config.cpp
@@ -2706,6 +2706,7 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
             if (th.contains("claim_accuracy_min") && th["claim_accuracy_min"].is_number()) cfg.thresholds.claim_accuracy_min = std::max(0.0, std::min(1.0, th["claim_accuracy_min"].get<double>()));
             if (th.contains("prompt_compliance_mandate_min") && th["prompt_compliance_mandate_min"].is_number()) cfg.thresholds.prompt_compliance_mandate_min = std::max(0.0, std::min(1.0, th["prompt_compliance_mandate_min"].get<double>()));
             if (th.contains("prompt_compliance_response_min_tokens") && th["prompt_compliance_response_min_tokens"].is_number_integer()) cfg.thresholds.prompt_compliance_response_min_tokens = std::max(0, th["prompt_compliance_response_min_tokens"].get<int>());
+            if (th.contains("response_repetition_lookback") && th["response_repetition_lookback"].is_number_integer()) cfg.thresholds.response_repetition_lookback = std::max(1, th["response_repetition_lookback"].get<int>());
         }
         parseRationale(cd, cfg.rationale);
         if (cd.contains("signals") && cd["signals"].is_object()) {
@@ -2730,6 +2731,7 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
             if (sig.contains("tool_chain_integrity") && sig["tool_chain_integrity"].is_boolean()) cfg.signals.tool_chain_integrity = sig["tool_chain_integrity"].get<bool>();
             if (sig.contains("claim_result_reconciliation") && sig["claim_result_reconciliation"].is_boolean()) cfg.signals.claim_result_reconciliation = sig["claim_result_reconciliation"].get<bool>();
             if (sig.contains("prompt_compliance") && sig["prompt_compliance"].is_boolean()) cfg.signals.prompt_compliance = sig["prompt_compliance"].get<bool>();
+            if (sig.contains("response_repetition") && sig["response_repetition"].is_boolean()) cfg.signals.response_repetition = sig["response_repetition"].get<bool>();
             if (sig.contains("exclude_infrastructure_errors") && sig["exclude_infrastructure_errors"].is_boolean()) cfg.signals.exclude_infrastructure_errors = sig["exclude_infrastructure_errors"].get<bool>();
         }
         if (cd.contains("weights") && cd["weights"].is_object()) {
@@ -2754,6 +2756,7 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
             if (w.contains("tool_chain_integrity") && w["tool_chain_integrity"].is_number()) cfg.weights.tool_chain_integrity = w["tool_chain_integrity"].get<double>();
             if (w.contains("claim_result_reconciliation") && w["claim_result_reconciliation"].is_number()) cfg.weights.claim_result_reconciliation = w["claim_result_reconciliation"].get<double>();
             if (w.contains("prompt_compliance") && w["prompt_compliance"].is_number()) cfg.weights.prompt_compliance = w["prompt_compliance"].get<double>();
+            if (w.contains("response_repetition") && w["response_repetition"].is_number()) cfg.weights.response_repetition = std::clamp(w["response_repetition"].get<double>(), 0.0, 1.0);
         }
         if (cd.contains("reality_checkpoint") && cd["reality_checkpoint"].is_object()) {
             auto& rc = cd["reality_checkpoint"];

--- a/src/runtime/governance_config.cpp
+++ b/src/runtime/governance_config.cpp
@@ -3577,16 +3577,29 @@ bool GovernanceEngine::reloadIfChanged() {
 
         // Verify signature — reject unsigned changes
         if (!verifyFileSignature(loaded_path_)) {
-            fmt::print(stderr, "[governance] Reload rejected: signature verification failed\n");
-            logAuditEvent("governance_reload_rejected", "governance_config",
-                "Signature verification failed on govern.json reload");
-            writeAgentTelemetry("CONFIG_ADJUSTMENT", {
-                {"accepted", "false"},
-                {"reason", "signature"},
-            });
-            loaded_mtime_ns_ = current_mtime;
+            // Suppress duplicate log/telemetry when the same mtime fails repeatedly.
+            // The retry is still attempted (verification re-runs each call) but
+            // we only emit diagnostics once per mtime to prevent log flooding.
+            if (current_mtime != last_sig_fail_mtime_) {
+                fmt::print(stderr, "[governance] Reload rejected: signature verification failed\n");
+                logAuditEvent("governance_reload_rejected", "governance_config",
+                    "Signature verification failed on govern.json reload");
+                writeAgentTelemetry("CONFIG_ADJUSTMENT", {
+                    {"accepted", "false"},
+                    {"reason", "signature"},
+                });
+                last_sig_fail_mtime_ = current_mtime;
+            }
+            // NOTE: intentionally NOT caching mtime on signature failure.
+            // The .sig sidecar can be updated (by a re-signing subprocess)
+            // without changing govern.json's mtime. Caching here would
+            // prevent future reloadIfChanged() calls from retrying after
+            // the signature becomes valid.
             return false;
         }
+
+        // Signature verified — clear the failure tracker
+        last_sig_fail_mtime_ = 0;
 
         // Apply minimum enforcement levels to new rules
         enforceMinimumLevelsOnRules(new_rules);

--- a/src/runtime/governance_engine.cpp
+++ b/src/runtime/governance_engine.cpp
@@ -2800,11 +2800,13 @@ std::string GovernanceEngine::formatSummaryOneLine() const {
 
 void GovernanceEngine::printDashboard() const {
     std::lock_guard<std::mutex> lock(results_mutex_);
-    int passed = 0, blocked = 0;
+    int passed = 0, blocked = 0, warned = 0;
     std::map<std::string, int> block_counts;
     for (const auto& r : check_results_) {
         if (r.passed) {
             passed++;
+        } else if (r.level == EnforcementLevel::ADVISORY) {
+            warned++;
         } else {
             blocked++;
             block_counts[r.rule_name]++;
@@ -2833,7 +2835,10 @@ void GovernanceEngine::printDashboard() const {
     fprintf(stderr, "%s\n", config_line.c_str());
     if (reload_count_ > 0)
         fprintf(stderr, "Reloads:    %d mid-run reload(s) applied\n", reload_count_);
-    fprintf(stderr, "Checks:     %d passed, %d blocked\n", passed, blocked);
+    if (warned > 0)
+        fprintf(stderr, "Checks:     %d passed, %d blocked, %d advisory\n", passed, blocked, warned);
+    else
+        fprintf(stderr, "Checks:     %d passed, %d blocked\n", passed, blocked);
     if (pulse_.refusal_count > 0)
         fprintf(stderr, "Refusals:   %d attested\n", pulse_.refusal_count);
     if (!top_rule.empty())
@@ -2910,6 +2915,20 @@ void GovernanceEngine::printDashboard() const {
             fprintf(stderr, "CDD:        coherence=%.2f vel=%.3f accel=%.3f (%zu turns analyzed)\n",
                     state->coherence_score, state->coherence_velocity,
                     state->coherence_acceleration, drift_analyzer_.totalTurnsAnalyzed());
+            // Per-agent coherence summary (multi-agent runs)
+            auto agent_coherences = drift_analyzer_.getAllAgentCoherences();
+            if (agent_coherences.size() > 1) {
+                double min_c = 1.0;
+                std::string agents_str;
+                for (const auto& [name, c] : agent_coherences) {
+                    if (!agents_str.empty()) agents_str += " ";
+                    char buf[64];
+                    snprintf(buf, sizeof(buf), "%s=%.2f", name.c_str(), c);
+                    agents_str += buf;
+                    if (c < min_c) min_c = c;
+                }
+                fprintf(stderr, "CDD agents: %s min=%.2f\n", agents_str.c_str(), min_c);
+            }
             if (rules().context_drift.reality_checkpoint.enabled &&
                 state->last_pressure_score > 0.0) {
                 fprintf(stderr, "Checkpoint: pressure=%.2f (%d consecutive)\n",
@@ -2939,6 +2958,10 @@ void GovernanceEngine::printDashboard() const {
                     fprintf(stderr, ", effectiveness=%+.2f (%d-turn window)", eff, eff_w);
                 }
                 fprintf(stderr, "\n");
+            }
+            if (state->response_repetition_count > 0) {
+                fprintf(stderr, "Repetition: %d verbatim duplicate(s) detected\n",
+                        state->response_repetition_count);
             }
             if (state->prompt_compliance_count > 0) {
                 fprintf(stderr, "Compliance: %d off-topic compliance events",
@@ -6538,24 +6561,30 @@ std::string GovernanceEngine::checkGovernanceHealth(int turn) {
     }
 
     // Check 3: Perfect coherence (1.0) after 10+ turns → suspicious
-    // Suppress during adaptive baseline (coherence hasn't been penalized yet)
-    // and for a few turns after recovery (recovery resets to 1.0)
-    int handle_id = current_agent_handle_.load(std::memory_order_relaxed);
-    auto state = drift_analyzer_.getDriftState(handle_id);
-    if (state && turn >= 10 && state->coherence_score >= 1.0) {
-        bool suppress = false;
-        // During baseline, coherence is expected to stay at 1.0
-        if (!state->baseline_complete) suppress = true;
-        // After recovery, coherence is reset to 1.0 — allow a cooldown window
-        if (state->last_recovery_turn >= 0 &&
-            turn - state->last_recovery_turn <= 3) suppress = true;
-        // Post-baseline grace: coherence 1.0 is expected right after baseline
-        // completes because penalties were suppressed during the window
-        if (state->baseline_completed_turn >= 0 &&
-            turn - state->baseline_completed_turn <= 3) suppress = true;
-        if (!suppress) {
-            warnings += fmt::format("WARNING: Perfect coherence (1.0) after {} turns "
-                "(possible detection bypass)\n", turn);
+    // Checks ALL agents — only warns if every agent is at 1.0.
+    // Suppress during adaptive baseline and post-recovery windows.
+    auto agent_coherences = drift_analyzer_.getAllAgentCoherences();
+    if (!agent_coherences.empty() && turn >= 10) {
+        bool all_perfect = true;
+        bool any_suppressed = false;
+        for (const auto& [name, c] : agent_coherences) {
+            if (c < 1.0) { all_perfect = false; break; }
+        }
+        if (all_perfect) {
+            // Suppress if any agent is in baseline or recovery window
+            int handle_id = current_agent_handle_.load(std::memory_order_relaxed);
+            auto state = drift_analyzer_.getDriftState(handle_id);
+            if (state) {
+                if (!state->baseline_complete) any_suppressed = true;
+                if (state->last_recovery_turn >= 0 &&
+                    turn - state->last_recovery_turn <= 3) any_suppressed = true;
+                if (state->baseline_completed_turn >= 0 &&
+                    turn - state->baseline_completed_turn <= 3) any_suppressed = true;
+            }
+            if (!any_suppressed) {
+                warnings += fmt::format("WARNING: Perfect coherence (1.0) after {} turns "
+                    "(possible detection bypass)\n", turn);
+            }
         }
     }
 
@@ -7190,6 +7219,10 @@ std::string GovernanceEngine::checkContextDrift(int handle_id, int turn,
 
 std::optional<governance::DriftState> GovernanceEngine::getDriftState(int handle_id) const {
     return drift_analyzer_.getDriftState(handle_id);
+}
+
+double GovernanceEngine::getMinAgentCoherence() const {
+    return drift_analyzer_.getMinCoherence();
 }
 
 void GovernanceEngine::initializeMandateKeywords(

--- a/src/stdlib/agent_impl.cpp
+++ b/src/stdlib/agent_impl.cpp
@@ -630,6 +630,7 @@ static NaabVal buildEnvironmentDict(int handle_id, const std::string& config_nam
         if (drift_opt) {
             state["coherence"] = NaabVal::makeDouble(drift_opt->coherence_score);
             state["coherence_velocity"] = NaabVal::makeDouble(drift_opt->coherence_velocity);
+            state["min_coherence"] = NaabVal::makeDouble(drift_opt->min_coherence_lifetime);
             state["contradictions"] = NaabVal::makeInt(drift_opt->contradictions);
             state["circular_actions"] = NaabVal::makeInt(drift_opt->circular_action_count);
             state["repeated_failures"] = NaabVal::makeInt(drift_opt->repeated_failures);
@@ -3572,14 +3573,33 @@ static NaabVal agentSend(std::vector<NaabVal>& args) {
                 snprintf(vel,  sizeof(vel),  "%.4f", drift_state->coherence_velocity);
                 snprintf(acc,  sizeof(acc),  "%.4f", drift_state->coherence_acceleration);
                 snprintf(pres, sizeof(pres), "%.4f", drift_state->last_pressure_score);
+                // Build per-signal fired + penalty detail strings
+                std::string fired_names, penalty_detail;
+                for (int i = 0; i < governance::NUM_CDD_SIGNALS; i++) {
+                    if (drift_state->last_turn_fired[i] > 0) {
+                        if (!fired_names.empty()) fired_names += ",";
+                        fired_names += governance::ContextDriftAnalyzer::signalName(i);
+                    }
+                    if (drift_state->last_turn_penalties[i] > 0.0) {
+                        if (!penalty_detail.empty()) penalty_detail += ",";
+                        char pbuf[64];
+                        snprintf(pbuf, sizeof(pbuf), "%s=%.4f",
+                                 governance::ContextDriftAnalyzer::signalName(i),
+                                 drift_state->last_turn_penalties[i]);
+                        penalty_detail += pbuf;
+                    }
+                }
                 gov_engine->writeAgentTelemetry("CDD_TURN", {
                     {"handle_id",        std::to_string(handle_id)},
+                    {"config_name",      config_name},
                     {"turn",             std::to_string(current_turn)},
                     {"coherence",        coh},
                     {"velocity",         vel},
                     {"acceleration",     acc},
                     {"pressure",         pres},
                     {"signals_fired",    std::to_string(drift_state->signals_fired_this_turn)},
+                    {"signals_detail",   fired_names},
+                    {"penalties_detail", penalty_detail},
                     {"response_repetition_count", std::to_string(drift_state->response_repetition_count)},
                     {"governance_level", level_str},
                     {"drift_detected",   drift_err.empty() ? "false" : "true"}
@@ -3588,6 +3608,7 @@ static NaabVal agentSend(std::vector<NaabVal>& args) {
                 // CDD ran but drift analyzer has no state yet (before first check_interval_turns)
                 gov_engine->writeAgentTelemetry("CDD_TURN", {
                     {"handle_id",        std::to_string(handle_id)},
+                    {"config_name",      config_name},
                     {"turn",             std::to_string(current_turn)},
                     {"governance_level", level_str},
                     {"drift_detected",   "false"},
@@ -3618,6 +3639,7 @@ static NaabVal agentSend(std::vector<NaabVal>& args) {
                 }
                 gov_engine->writeAgentTelemetry("SEMANTIC_TURN", {
                     {"handle_id",              std::to_string(handle_id)},
+                    {"config_name",            config_name},
                     {"turn",                   std::to_string(current_turn)},
                     {"semantic_stability",      ss_str},
                     {"semantic_stability_count", std::to_string(drift_state->semantic_stability_count)},
@@ -3664,6 +3686,7 @@ static NaabVal agentSend(std::vector<NaabVal>& args) {
                 }
                 gov_engine->writeAgentTelemetry("RECONCILIATION_TURN", {
                     {"handle_id",              std::to_string(handle_id)},
+                    {"config_name",            config_name},
                     {"turn",                   std::to_string(current_turn)},
                     {"tool_integrity_count",   std::to_string(drift_state->tool_integrity_count)},
                     {"claim_mismatch_count",   std::to_string(drift_state->claim_result_mismatch_count)},
@@ -3686,6 +3709,7 @@ static NaabVal agentSend(std::vector<NaabVal>& args) {
                          drift_state ? drift_state->coherence_score : 0.0);
                 gov_engine->writeAgentTelemetry("GOVERNANCE_LEVEL_CHANGE", {
                     {"handle_id",  std::to_string(handle_id)},
+                    {"config_name", config_name},
                     {"turn",       std::to_string(current_turn)},
                     {"from_level", from_str},
                     {"to_level",   level_str},
@@ -3825,6 +3849,21 @@ static NaabVal agentSend(std::vector<NaabVal>& args) {
                 for (double v : drift_st->prompt_alignment_history) pa_sum += v;
                 cdd["prompt_alignment"] = pa_sum / static_cast<double>(drift_st->prompt_alignment_history.size());
             }
+            // Per-signal fired names + penalty breakdown for this turn
+            {
+                nlohmann::json fired_arr = nlohmann::json::array();
+                nlohmann::json pen_obj = nlohmann::json::object();
+                for (int i = 0; i < governance::NUM_CDD_SIGNALS; i++) {
+                    if (drift_st->last_turn_fired[i] > 0)
+                        fired_arr.push_back(governance::ContextDriftAnalyzer::signalName(i));
+                    if (drift_st->last_turn_penalties[i] > 0.0)
+                        pen_obj[governance::ContextDriftAnalyzer::signalName(i)] = drift_st->last_turn_penalties[i];
+                }
+                cdd["signals_fired_names"] = fired_arr;
+                if (!pen_obj.empty())
+                    cdd["penalties"] = pen_obj;
+            }
+            cdd["min_coherence"] = drift_st->min_coherence_lifetime;
             transcript_entry["cdd"] = cdd;
         }
         // Governance context
@@ -3850,9 +3889,10 @@ static NaabVal agentSend(std::vector<NaabVal>& args) {
             std::string w = health_warnings;
             if (w.size() > 300) w = w.substr(0, 300) + "...";
             gov_engine->writeAgentTelemetry("GOVERNANCE_HEALTH_WARNING", {
-                {"handle_id", std::to_string(handle_id)},
-                {"turn",      std::to_string(current_turn)},
-                {"warning",   w}
+                {"handle_id",  std::to_string(handle_id)},
+                {"config_name", config_name},
+                {"turn",       std::to_string(current_turn)},
+                {"warning",    w}
             });
         }
     }
@@ -4616,13 +4656,36 @@ static NaabVal agentCommit(std::vector<NaabVal>& args) {
         {
             auto drift_state = gov_engine->getDriftState(handle_id);
             if (drift_state) {
+                // Build per-signal detail for commit-path CDD_TURN
+                std::string c_fired, c_penalty;
+                for (int i = 0; i < governance::NUM_CDD_SIGNALS; i++) {
+                    if (drift_state->last_turn_fired[i] > 0) {
+                        if (!c_fired.empty()) c_fired += ",";
+                        c_fired += governance::ContextDriftAnalyzer::signalName(i);
+                    }
+                    if (drift_state->last_turn_penalties[i] > 0.0) {
+                        if (!c_penalty.empty()) c_penalty += ",";
+                        char pb[64];
+                        snprintf(pb, sizeof(pb), "%s=%.4f",
+                                 governance::ContextDriftAnalyzer::signalName(i),
+                                 drift_state->last_turn_penalties[i]);
+                        c_penalty += pb;
+                    }
+                }
                 gov_engine->writeAgentTelemetry("CDD_TURN", {
-                    {"handle_id",      std::to_string(handle_id)},
-                    {"turn",           std::to_string(current_turn)},
-                    {"coherence",      fmt::format("{:.4f}", drift_state->coherence_score)},
-                    {"signals_fired",  std::to_string(drift_state->signals_fired_this_turn)},
-                    {"drift_detected", drift_err.empty() ? "false" : "true"},
-                    {"source",         "agent.commit"}
+                    {"handle_id",        std::to_string(handle_id)},
+                    {"config_name",      config_name},
+                    {"turn",             std::to_string(current_turn)},
+                    {"coherence",        fmt::format("{:.4f}", drift_state->coherence_score)},
+                    {"velocity",         fmt::format("{:.4f}", drift_state->coherence_velocity)},
+                    {"acceleration",     fmt::format("{:.4f}", drift_state->coherence_acceleration)},
+                    {"pressure",         fmt::format("{:.4f}", drift_state->last_pressure_score)},
+                    {"signals_fired",    std::to_string(drift_state->signals_fired_this_turn)},
+                    {"signals_detail",   c_fired},
+                    {"penalties_detail", c_penalty},
+                    {"response_repetition_count", std::to_string(drift_state->response_repetition_count)},
+                    {"drift_detected",   drift_err.empty() ? "false" : "true"},
+                    {"source",           "agent.commit"}
                 });
             }
         }

--- a/src/stdlib/agent_impl.cpp
+++ b/src/stdlib/agent_impl.cpp
@@ -207,7 +207,7 @@ static const std::unordered_set<std::string> kStopWords = {
     "each", "more", "like", "just", "some", "when", "then",
     "into", "here", "been", "both", "want", "used", "them", "than",
     "what", "were", "they", "does", "done", "very", "much", "most",
-    "only", "over", "such", "should", "would", "could", "about",
+    "over", "such", "should", "would", "could", "about",
     "other", "their", "there", "which", "these", "those", "being",
     "after", "before",
     "sure", "great", "lets", "following", "below",
@@ -658,6 +658,7 @@ static NaabVal buildEnvironmentDict(int handle_id, const std::string& config_nam
             state["tool_integrity_count"] = NaabVal::makeInt(drift_opt->tool_integrity_count);
             state["claim_mismatch_count"] = NaabVal::makeInt(drift_opt->claim_result_mismatch_count);
             state["prompt_compliance_count"] = NaabVal::makeInt(drift_opt->prompt_compliance_count);
+            state["response_repetition_count"] = NaabVal::makeInt(drift_opt->response_repetition_count);
             if (!drift_opt->claim_accuracy_history.empty()) {
                 double ca_sum = 0;
                 for (double v : drift_opt->claim_accuracy_history) ca_sum += v;
@@ -701,6 +702,7 @@ static NaabVal buildEnvironmentDict(int handle_id, const std::string& config_nam
             state["tool_integrity_count"] = NaabVal::makeInt(0);
             state["claim_mismatch_count"] = NaabVal::makeInt(0);
             state["prompt_compliance_count"] = NaabVal::makeInt(0);
+            state["response_repetition_count"] = NaabVal::makeInt(0);
             state["claim_accuracy"] = NaabVal::makeDouble(1.0);
             state["mandate_alignment"] = NaabVal::makeDouble(0.0);
             state["escalation_turn"] = NaabVal::makeInt(-1);
@@ -3578,6 +3580,7 @@ static NaabVal agentSend(std::vector<NaabVal>& args) {
                     {"acceleration",     acc},
                     {"pressure",         pres},
                     {"signals_fired",    std::to_string(drift_state->signals_fired_this_turn)},
+                    {"response_repetition_count", std::to_string(drift_state->response_repetition_count)},
                     {"governance_level", level_str},
                     {"drift_detected",   drift_err.empty() ? "false" : "true"}
                 });
@@ -3628,6 +3631,7 @@ static NaabVal agentSend(std::vector<NaabVal>& args) {
                     {"tool_integrity_count",    std::to_string(drift_state->tool_integrity_count)},
                     {"claim_mismatch_count",   std::to_string(drift_state->claim_result_mismatch_count)},
                     {"prompt_compliance_count", std::to_string(drift_state->prompt_compliance_count)},
+                    {"response_repetition_count", std::to_string(drift_state->response_repetition_count)},
                     {"mandate_alignment",       ma_str},
                     {"keywords_count",          std::to_string(response_keywords.size())}
                 });

--- a/src/stdlib/governance_impl.cpp
+++ b/src/stdlib/governance_impl.cpp
@@ -345,6 +345,19 @@ static NaabVal governanceHealth(std::vector<NaabVal>& /*args*/) {
     result["governance_epoch"] = NaabVal::makeInt(engine->getGovernanceEpoch());
     // Min coherence across all tracked agents
     result["coherence"] = NaabVal::makeDouble(engine->getMinAgentCoherence());
+
+    // T6: Telemetry for governance.health() queries
+    if (engine->getRules().telemetry_output.enabled) {
+        engine->writeAgentTelemetry("GOVERNANCE_HEALTH_QUERY", {
+            {"verdict", std::string(verdict_str)},
+            {"coherence", std::to_string(engine->getMinAgentCoherence())},
+            {"epoch", std::to_string(engine->getGovernanceEpoch())},
+            {"consecutive_passes", std::to_string(pulse.consecutive_passes)},
+            {"bsd_connected", pulse.bsd_connected ? "true" : "false"},
+            {"cdd_connected", pulse.cdd_connected ? "true" : "false"},
+        });
+    }
+
     return NaabVal::makeDict(std::move(result));
 }
 

--- a/src/stdlib/governance_impl.cpp
+++ b/src/stdlib/governance_impl.cpp
@@ -343,6 +343,8 @@ static NaabVal governanceHealth(std::vector<NaabVal>& /*args*/) {
     result["transcript_connected"] = NaabVal::makeBool(pulse.transcript_connected);
     // Evidence epoch — monotonic state transition counter
     result["governance_epoch"] = NaabVal::makeInt(engine->getGovernanceEpoch());
+    // Min coherence across all tracked agents
+    result["coherence"] = NaabVal::makeDouble(engine->getMinAgentCoherence());
     return NaabVal::makeDict(std::move(result));
 }
 

--- a/src/stdlib/orchestra_impl.cpp
+++ b/src/stdlib/orchestra_impl.cpp
@@ -4,6 +4,7 @@
 #include "naab/orchestra.h"
 #include "naab/naab_val.h"
 #include "naab/interpreter.h"
+#include "naab/governance.h"
 #include <fmt/core.h>
 #include <regex>
 #include <nlohmann/json.hpp>
@@ -244,6 +245,20 @@ interpreter::NaabVal orchestraEnforceConvergence(std::vector<interpreter::NaabVa
     result_dict["valid"] = interpreter::NaabVal::makeBool(is_valid);
     if (!validation_error.empty()) {
         result_dict["error"] = interpreter::NaabVal::makeString(validation_error);
+    }
+
+    // T5: Telemetry for convergence checks
+    auto* gov_engine = governance::GovernanceEngine::getCurrent();
+    if (gov_engine && gov_engine->getRules().telemetry_output.enabled) {
+        std::string pattern_str;
+        if (spec.find("pattern") != spec.end() && spec.at("pattern").isString())
+            pattern_str = spec.at("pattern").asString();
+        gov_engine->writeAgentTelemetry("CONVERGENCE_CHECK", {
+            {"valid", is_valid ? "true" : "false"},
+            {"pattern", pattern_str},
+            {"error", validation_error},
+            {"response_length", std::to_string(response.size())},
+        });
     }
 
     return interpreter::NaabVal::makeDict(std::move(result_dict));


### PR DESCRIPTION
## Summary

Three commits addressing governance reload reliability, critical audit findings, and living-script robustness:

1. **Reload mtime caching fix** — Don't cache mtime on signature verification failure; suppress duplicate reload log messages within the same turn
2. **Critical audit fixes (7 items)** — S21 response repetition signal, per-agent coherence dashboard/health, "only" stop word removal, dashboard advisory separation, output admissibility + telemetry dedup for living-script
3. **Flat adjustment auto-wrap** — LLM non-determinism causes operator to emit flat config adjustments instead of agent-wrapped; auto-detect and wrap before validation

### Audit fixes detail

| ID | Category | Fix |
|----|----------|-----|
| F1 | Per-agent coherence | `getMinCoherence()` + `getAllAgentCoherences()` on ContextDriftAnalyzer; dashboard `CDD agents:` line; `governance.health()` coherence field; perfect-coherence warning checks all agents |
| F2 | Response repetition (S21) | New CDD signal using content_fingerprint deque; config, parsing, dashboard, env dict, telemetry |
| F3 | Stop word "only" | Removed from kStopWords in both agent_impl.cpp and behavioral_sequence.cpp |
| G1 | Output admissibility | Enabled in living-script govern.json (threshold=0.60, action=quarantine) |
| C1 | Dashboard summary | Advisory count separated from blocked count |
| C2 | Telemetry dedup | `deduplicate_checks: true` in living-script govern.json |

### Living-script results (v8)

- **34 PASS, 0 FAIL, 0 SKIP** — best result in evolution history
- GovernanceCheck events: 222 → 16 (93% reduction from dedup)
- 9 OUTPUT_INADMISSIBLE events correctly quarantined (developer coherence drift)
- 4 mid-run config reloads applied (flat adjustment auto-wrap working)
- Risk score: 9 (green), down from 15 (yellow) in v6

## Test plan

- [x] `bash run-all-tests.sh` — 441/441 pass (377 + 52 error behavior + 12 needs tree-walk)
- [x] `bash tests/security/test_error_msg_leaks.sh` — 874/874 pass
- [x] Living-script v8 run — 34/34/0
- [x] Verify `CDD agents:` per-agent coherence line in stderr
- [x] Verify `governance.health()` includes coherence field
- [x] Verify dashboard separates advisory from blocked
- [x] Verify telemetry dedup (16 vs 222 GovernanceCheck events)
- [x] Verify OA gate fires on developer coherence drop (9 quarantined)
- [x] Verify S21 detects verbatim duplicate (1 detected)

🤖 Generated with [Claude Code](https://claude.com/claude-code)