### PR TITLE
living-script: FINAL_REVIEW sets final_verdict, disable S21 for developer

### DIFF
--- a/examples/living-script/src/govern.json
+++ b/examples/living-script/src/govern.json
@@ -98,7 +98,7 @@
       "standing_lease_turns": 20,
       "context_window": 20,
       "context_strategy": "summary",
-      "context_drift_signals": { "semantic_stability": false },
+      "context_drift_signals": { "semantic_stability": false, "response_repetition": false },
       "rate_limit": { "requests_per_minute": 0, "delay_between_calls_ms": 1000 },
       "retry": { "max_attempts": 3, "backoff_ms": 3000, "backoff_multiplier": 2.0, "jitter": true, "retry_on": [429, 500, 503], "skip_key_on": [401], "key_retry_after_seconds": 0 }
     },

--- a/examples/living-script/src/living-script.naab
+++ b/examples/living-script/src/living-script.naab
@@ -1002,6 +1002,9 @@ main {
     }
     print("FINAL_REVIEW|verdict=" + string(final_approved))
     print("FINAL_REVIEW|iterations=" + string(final_iter))
+    // FINAL_REVIEW is the authoritative verdict — without this, the REFINE
+    // verdict set earlier is what memory/summary report as "approved"
+    tracking["final_verdict"] = final_approved
 
     consult_operator({"phase": "FINAL_REVIEW", "event": "final_review_complete", "features": tracking["features_processed"], "ops_len": len(ops_code), "final_approved": final_approved, "final_iterations": final_iter, "question": "Final review done (" + string(final_iter) + " iterations, approved=" + string(final_approved) + "). How did team handle feature evolution?"})
     tracking["phases_completed"].push("FINAL_REVIEW")


### PR DESCRIPTION
## Summary
Two fixes from the latest run analysis (F1 and F3): the run summary reported the REFINE verdict as the final one because FINAL_REVIEW never wrote `tracking["final_verdict"]`, and the developer's required whole-file output format structurally triggers the S21 response_repetition signal.

## Changes
- **F1 (script bug, one line)**: `tracking["final_verdict"]` was set once after the REFINE loop and never overwritten, so `memory/observations.json` and the run summary reported REFINE's verdict regardless of what FINAL_REVIEW decided. FINAL_REVIEW now writes the authoritative verdict.
- **F3 (config)**: add `"response_repetition": false` to the developer's `context_drift_signals` block (same per-agent override pattern as the existing `semantic_stability` exemption). S21 fingerprints the first 200 chars of each response; the developer must always output the COMPLETE file, so every response shares the file-header prefix and the signal fires on the output format, not on drift — it was a dominant coherence-drain signal in the latest run.

## Test Plan
- [x] `govern.json` validates as JSON; `living-script.naab` parses clean (`naab-lang parse`)
- [x] No runtime changes — the per-agent signal override mechanism is covered by `tests/governance_v4/test_per_agent_signals.sh` on master
- [ ] Live `examples/living-script/run.sh` needs GK API keys — expect `SUMMARY_APPROVED` to match the FINAL_REVIEW verdict, and `response_repetition` absent from the developer's dominant CDD signals

## Related Issues
Follow-up to #77/#78 (living-script validation rounds).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01Dw4yPfRnCPSXLY5xADAfSn

---
_Generated by [Claude Code](https://claude.ai/code/session_01Dw4yPfRnCPSXLY5xADAfSn)_