### PR TITLE
Fix RLIMIT_NPROC containment: preserve hard limit for restorability

### DIFF
--- a/run-all-tests.sh
+++ b/run-all-tests.sh
@@ -328,6 +328,7 @@ for dir in "${TEST_DIRS[@]}"; do
         # Exclude agent-governance (requires run.sh setup with test data)
         # Exclude codebase_qa (interactive Q&A tool, requires stdin + live API key)
         # Exclude governed_codegen (LLM codegen orchestrator, requires live API key)
+        # Exclude runtime-boundary-demo (requires run.sh for govern.json setup)
         while IFS= read -r -d '' test_file; do
             run_test "$test_file" "$timeout"
         done < <(find "$dir" -name "*.naab" -type f \
@@ -335,6 +336,7 @@ for dir in "${TEST_DIRS[@]}"; do
             -not -path "*/codebase_qa/*" \
             -not -path "*/governed_codegen/*" \
             -not -path "*/governed_codegen_py/*" \
+            -not -path "*/runtime-boundary-demo/*" \
             -print0 | sort -z)
     else
         while IFS= read -r -d '' test_file; do

--- a/src/runtime/python_c_executor.cpp
+++ b/src/runtime/python_c_executor.cpp
@@ -193,10 +193,13 @@ interpreter::NaabVal PythonCExecutor::executeWithReturn(const std::string& code)
         PyRun_SimpleString(scrub_code.str().c_str());
     }
 
-    // OS-level containment: set RLIMIT_NPROC=0 to prevent Python from forking
-    // (subprocess.run, os.system, os.fork all fail with EAGAIN)
-    // This is process-wide but safe: NAAb doesn't fork during in-process Python execution.
-    // RAII guard restores NPROC on all exit paths (normal, exception, early return).
+    // OS-level containment: set RLIMIT_NPROC soft limit to 0 to prevent Python
+    // from forking (subprocess.run, os.system, os.fork all fail with EAGAIN).
+    // Only the soft limit is lowered — the hard limit is preserved so the RAII
+    // guard can restore the original value.  Lowering the hard limit to 0 is
+    // irreversible for non-root processes (setrlimit returns EPERM), which would
+    // permanently break any code that needs to create threads (e.g. libcurl's
+    // threaded DNS resolver).
 #ifndef _WIN32
     struct NprocGuard {
         struct rlimit saved = {0, 0};
@@ -207,7 +210,7 @@ interpreter::NaabVal PythonCExecutor::executeWithReturn(const std::string& code)
         auto containment = SubprocessContainment::fromCurrentSandbox("python3");
         if (containment.block_fork) {
             getrlimit(RLIMIT_NPROC, &nproc_guard.saved);
-            struct rlimit zero = {0, 0};
+            struct rlimit zero = {0, nproc_guard.saved.rlim_max};
             setrlimit(RLIMIT_NPROC, &zero);
             nproc_guard.active = true;
         }

--- a/src/stdlib/http_impl.cpp
+++ b/src/stdlib/http_impl.cpp
@@ -258,6 +258,12 @@ interpreter::NaabVal performRequest(
 
     // Set timeout (in milliseconds)
     curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(timeout_ms));
+    curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, std::min(static_cast<long>(timeout_ms), 10000L));
+
+    // Required for thread safety and Python interop — curl must not use
+    // signal-based DNS timeouts (SIGALRM) because Python's Py_Initialize()
+    // replaces signal handlers, causing curl_easy_perform() to hang on DNS.
+    curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
 
     // Follow redirects
     curl_easy_setopt(curl, CURLOPT_FOLLOWLOCATION, 1L);

--- a/src/stdlib/http_impl.cpp
+++ b/src/stdlib/http_impl.cpp
@@ -259,10 +259,6 @@ interpreter::NaabVal performRequest(
     // Set timeout (in milliseconds)
     curl_easy_setopt(curl, CURLOPT_TIMEOUT_MS, static_cast<long>(timeout_ms));
     curl_easy_setopt(curl, CURLOPT_CONNECTTIMEOUT_MS, std::min(static_cast<long>(timeout_ms), 10000L));
-
-    // Required for thread safety and Python interop — curl must not use
-    // signal-based DNS timeouts (SIGALRM) because Python's Py_Initialize()
-    // replaces signal handlers, causing curl_easy_perform() to hang on DNS.
     curl_easy_setopt(curl, CURLOPT_NOSIGNAL, 1L);
 
     // Follow redirects

--- a/tests/security/test_taint_polyglot_vm001.sh
+++ b/tests/security/test_taint_polyglot_vm001.sh
@@ -44,7 +44,7 @@ secret
 }
 EOF
 
-out=$("$NAAB" "$WORKDIR/test_t1.naab" --vm 2>&1) || true
+out=$(timeout 15 "$NAAB" "$WORKDIR/test_t1.naab" --vm 2>&1) || true
 if echo "$out" | grep -qi "taint\|blocked\|governance\|sink\|denied"; then
     ok "http.post blocked — taint propagated through polyglot block"
 else
@@ -70,7 +70,7 @@ clean + "_processed"
 }
 EOF
 
-out=$("$NAAB" "$WORKDIR/test_t2.naab" --vm 2>&1) || ec=$?
+out=$(timeout 15 "$NAAB" "$WORKDIR/test_t2.naab" --vm 2>&1) || ec=$?
 ec=${ec:-0}
 # V-GOV-006: polyglot output is ALWAYS tainted → http.post must be blocked.
 # If Python is unavailable the polyglot block itself fails (different error).
@@ -90,7 +90,7 @@ echo ""
 # T3: Same script as T1 but with --no-governance → must run without error
 # ---------------------------------------------------------------------------
 echo "[T3] With --no-governance, taint laundering script runs without governance block"
-out=$("$NAAB" "$WORKDIR/test_t1.naab" --vm --no-governance 2>&1) || ec=$?
+out=$(timeout 15 "$NAAB" "$WORKDIR/test_t1.naab" --vm --no-governance 2>&1) || ec=$?
 ec=${ec:-0}
 if echo "$out" | grep -qi "taint\|governance block\|hard block"; then
     fail "governance fired despite --no-governance: ${out:0:120}"


### PR DESCRIPTION
## Summary

- **Root cause fix**: `python_c_executor.cpp` set `RLIMIT_NPROC` to `{0, 0}` (both soft AND hard limit). Non-root processes cannot raise the hard limit after lowering it, so the RAII guard's `setrlimit` restore silently fails (EPERM). NPROC stays at 0 permanently, breaking curl's threaded DNS resolver and any subsequent thread creation.
- **Fix**: `{0, nproc_guard.saved.rlim_max}` — only lower the soft limit (still blocks Python fork/subprocess with EAGAIN), preserve the hard limit so the destructor can actually restore it.
- **Symptom mitigation** (prior commit): `CURLOPT_CONNECTTIMEOUT_MS` (10s cap), `CURLOPT_NOSIGNAL`, and `timeout 15` safety nets on the polyglot taint test.
- **Test exclusion**: `runtime-boundary-demo/` excluded from `run-all-tests.sh` (requires `run.sh` setup, was causing 3 false failures).

## Verification

- Proven with C test program: `setrlimit(RLIMIT_NPROC, {0,0})` → restore returns EPERM, NPROC stuck at `{0,0}`
- `test_taint_polyglot_vm001.sh`: was hanging indefinitely, now 3/3 pass instantly
- Full test suite: 441 tests, 0 regressions (1 pre-existing failure in `test_reality_checkpoint.sh`)

## Test plan

- [x] C program confirms EPERM on hard limit restore
- [x] `test_taint_polyglot_vm001.sh` — 3/3 pass (was infinite hang)
- [x] `run-all-tests.sh` — 441 tests, 0 new failures
- [x] Subprocess containment in `subprocess_helpers.cpp` unaffected (runs in forked child, no restore needed)

🤖 Generated with [Claude Code](https://claude.com/claude-code)