### PR TITLE
Close the feature-2 contract gap, operator blindspot, and challenge-fail coverage

### DIFF
--- a/examples/living-script/run.sh
+++ b/examples/living-script/run.sh
@@ -46,7 +46,8 @@ skip() { local id="$1" desc="$2"; SKIP_COUNT=$((SKIP_COUNT + 1)); TOTAL=$((TOTAL
 # ------------------------------------------------------------
 # Governance-kill classification.
 #
-# When an agent exceeds max_quarantine_streak, the engine throws an
+# When an agent exceeds max_quarantine_streak (or fails a step-up
+# challenge), the engine throws an
 # uncatchable GovernanceHardError: main.cpp prints
 # "Error: Agent exceeded maximum quarantine streak" to stdout and exits 3.
 # That is governance succeeding, not the harness failing — so checks on
@@ -59,6 +60,8 @@ GOV_KILL=""
 detect_gov_kill() {  # $1=exit code, $2=captured stdout — echoes kill kind, or nothing
     if [ "$1" -eq 3 ] && echo "$2" | grep -q "Agent exceeded maximum quarantine streak"; then
         echo "quarantine_streak"
+    elif [ "$1" -eq 3 ] && echo "$2" | grep -q "Step-up challenge failed"; then
+        echo "challenge_failure"
     fi
 }
 
@@ -132,17 +135,18 @@ else
     if [ -n "$GOV_KILL" ]; then
         echo -e "${YELLOW}================================================================${NC}"
         echo -e "${YELLOW}  GOVERNANCE KILL: $GOV_KILL -- run terminated by design.${NC}"
-        echo -e "${YELLOW}  An agent exceeded max_quarantine_streak. Levels the script${NC}"
-        echo -e "${YELLOW}  never reached are reported as SKIP, not FAIL.${NC}"
+        echo -e "${YELLOW}  Levels the script never reached are reported as SKIP, not FAIL.${NC}"
         echo -e "${YELLOW}================================================================${NC}"
         echo ""
-        # The kill must be attributable: the engine emits QUARANTINE_STREAK_EXCEEDED
-        # telemetry BEFORE throwing. Exit 3 + streak message with no telemetry
-        # event would be a genuine bug, not an expected outcome.
-        if grep -q "QUARANTINE_STREAK_EXCEEDED" "$WORKDIR/telemetry.jsonl" 2>/dev/null; then
-            pass "GK-01" "Governance kill attributable (QUARANTINE_STREAK_EXCEEDED in telemetry)"
+        # The kill must be attributable: the engine emits the matching telemetry
+        # event BEFORE throwing (QUARANTINE_STREAK_EXCEEDED / AGENT_CHALLENGE_FAIL).
+        # Exit 3 + kill message with no telemetry event would be a genuine bug.
+        GK_EVENT="QUARANTINE_STREAK_EXCEEDED"
+        [ "$GOV_KILL" = "challenge_failure" ] && GK_EVENT="AGENT_CHALLENGE_FAIL"
+        if grep -q "$GK_EVENT" "$WORKDIR/telemetry.jsonl" 2>/dev/null; then
+            pass "GK-01" "Governance kill attributable ($GK_EVENT in telemetry)"
         else
-            fail "GK-01" "Unattributable governance kill" "exit 3 + streak message but no QUARANTINE_STREAK_EXCEEDED telemetry event"
+            fail "GK-01" "Unattributable governance kill" "exit 3 + kill message but no $GK_EVENT telemetry event"
         fi
     fi
 

--- a/examples/living-script/src/living-script.naab
+++ b/examples/living-script/src/living-script.naab
@@ -737,6 +737,22 @@ main {
         print("REACTIVE|found=" + fname)
         print("FEATURE|" + string(feat_num) + "|start|" + trimmed)
 
+        // Per-feature error-semantics CONTRACT — one sentence shared verbatim by
+        // the ops prompt, the test prompt, and the fix prompts, so code and tests
+        // are written against the same behavior instead of re-deriving it
+        // independently (the Jul 18 feature-2 coin flip: the developer was told
+        // "recall returns None, do NOT raise" while the tests expected ValueError).
+        let feat_contract = ""
+        if fname == "requirement-001.txt" {
+            feat_contract = "power() raises ValueError for complex results; modulo() raises ValueError on zero."
+        }
+        if fname == "requirement-002.txt" {
+            feat_contract = "memory_recall() with nothing stored returns None — that is NOT an error: do not raise, and do not write a test expecting a raise; memory_store() with a non-numeric value raises ValueError; memory_store() records to history."
+        }
+        if fname == "requirement-003.txt" {
+            feat_contract = "evaluate() records ONE history entry (not intermediate steps) and uses ast.parse not eval(); invalid or malformed expressions (including division by zero) raise ValueError."
+        }
+
         // Architect analyzes impact
         if handles.get("architect") != null && len(trimmed) > 5 {
             let arch_msg = "New feature requirement for the calculator:\n" + trimmed + "\n\nCurrent Calculator class has: add, subtract, multiply, divide, get_history, clear_history."
@@ -759,6 +775,7 @@ main {
                     dev_msg = dev_msg + "ADD this feature to operations.py:\n" + guidance
                     dev_msg = dev_msg + "\n\nRequirement: " + trimmed
                     dev_msg = dev_msg + "\n\n" + invariants
+                    if len(feat_contract) > 0 { dev_msg = dev_msg + "\nCONTRACT for this feature (code MUST match): " + feat_contract }
                     dev_msg = dev_msg + "\nEXISTING METHODS (do NOT modify): " + existing_methods
                     dev_msg = dev_msg + "\nOnly ADD new methods for this feature. Do not rewrite or change existing methods."
                     dev_msg = dev_msg + "\n\nCurrent operations.py:\n```python\n" + ops_code + "\n```\nOutput the COMPLETE file with the new methods added. ```python fences. Code only."
@@ -779,7 +796,9 @@ main {
                     // Developer updates test file
                     check_coherence(handles["developer"], "developer")
                     let test_msg = "Add tests for this new feature ONLY:\n" + trimmed
+                    if len(feat_contract) > 0 { test_msg = test_msg + "\n\nCONTRACT (tests MUST match this exactly): " + feat_contract }
                     test_msg = test_msg + "\n\nInvalid input MUST be tested with pytest.raises(ValueError) — the calculator NEVER raises bare ZeroDivisionError/TypeError or custom exception classes."
+                    test_msg = test_msg + "\n\nCurrent operations.py (write tests against THESE method signatures — do not guess names):\n```python\n" + ops_code + "\n```"
                     test_msg = test_msg + "\nDo NOT modify existing tests. Only ADD new test functions."
                     test_msg = test_msg + "\n\nCurrent test_calc.py:\n```python\n" + test_code + "\n```\nOutput the COMPLETE file with new tests added. pytest with fixture. ```python fences. Code only."
                     resp = safe_send(handles["developer"], test_msg)
@@ -845,14 +864,10 @@ main {
             existing_methods = existing_methods + ", " + new_methods
         }
         // Feature-specific reminders (lightweight — full invariants in system_prompt)
-        if fname == "requirement-001.txt" {
-            invariants = invariants + " Also: power() raises ValueError for complex results, modulo() raises ValueError on zero."
-        }
-        if fname == "requirement-002.txt" {
-            invariants = invariants + " Also: memory_recall() returns None when no value is stored (do NOT raise ValueError), memory_store() records to history."
-        }
-        if fname == "requirement-003.txt" {
-            invariants = invariants + " Also: evaluate() records ONE history entry (not intermediate steps), uses ast.parse not eval()."
+        // (Accumulates the shared CONTRACT so later features and the refinement
+        // fix prompts keep honoring earlier features' error semantics.)
+        if len(feat_contract) > 0 {
+            invariants = invariants + " Also: " + feat_contract
         }
 
         // Validate evolved code (includes pytest)
@@ -866,12 +881,16 @@ main {
             fvk = fvk + 1
         }
 
-        // If pytest failed, send the failing test names PLUS the exception detail
-        // lines ("E ..." from --tb=short) for 1 fix attempt. Names alone are not
-        // enough: without seeing "ZeroDivisionError" vs the expected exception
-        // type, the model cannot know WHAT to fix.
-        if fval.get("pytest_passed") == false && handles.get("developer") != null {
-            let pytest_out = fval.get("pytest_output") ?? ""
+        // Pytest fix loop — up to 2 attempts, re-validating after each. Attempt 1
+        // fixes operations.py against the failure detail. Attempt 2 additionally
+        // shows test_calc.py and the feature CONTRACT: if a failing test
+        // contradicts the contract, the developer may fix the TEST instead —
+        // never to weaken assertions that match the contract.
+        let cur_val = fval
+        let fix_attempt = 0
+        while cur_val.get("pytest_passed") == false && fix_attempt < 2 && handles.get("developer") != null {
+            fix_attempt = fix_attempt + 1
+            let pytest_out = cur_val.get("pytest_output") ?? ""
             let plines = string.split(pytest_out, "\n")
             let fail_names = ""
             let pfi = 0
@@ -894,31 +913,43 @@ main {
             if len(operator_msg_prefix) > 0 { pytest_fix_msg = operator_msg_prefix + "\n\n" }
             pytest_fix_msg = pytest_fix_msg + "Pytest FAILED after adding: " + trimmed + "\nFailing tests:\n" + fail_names
             pytest_fix_msg = pytest_fix_msg + "\n" + invariants
-            pytest_fix_msg = pytest_fix_msg + "\nFix ONLY the failing parts. Do NOT rewrite the whole file."
-            pytest_fix_msg = pytest_fix_msg + "\nCurrent operations.py:\n```python\n" + ops_code + "\n```\nOutput the COMPLETE fixed operations.py. ```python fences. Code only."
+            if len(feat_contract) > 0 { pytest_fix_msg = pytest_fix_msg + "\nCONTRACT for this feature: " + feat_contract }
+            if fix_attempt == 1 {
+                pytest_fix_msg = pytest_fix_msg + "\nFix ONLY the failing parts. Do NOT rewrite the whole file."
+                pytest_fix_msg = pytest_fix_msg + "\nCurrent operations.py:\n```python\n" + ops_code + "\n```\nOutput the COMPLETE fixed operations.py. ```python fences. Code only."
+            } else {
+                pytest_fix_msg = pytest_fix_msg + "\nSECOND ATTEMPT. If a failing test CONTRADICTS the CONTRACT above, output the corrected COMPLETE test_calc.py instead; otherwise output the corrected COMPLETE operations.py. NEVER weaken or delete assertions that match the contract."
+                pytest_fix_msg = pytest_fix_msg + "\nCurrent operations.py:\n```python\n" + ops_code + "\n```"
+                pytest_fix_msg = pytest_fix_msg + "\nCurrent test_calc.py:\n```python\n" + test_code + "\n```\nOutput exactly ONE complete file. ```python fences. Code only."
+            }
             check_coherence(handles["developer"], "developer")
             let pfresp = safe_send(handles["developer"], pytest_fix_msg)
             tracking["total_sends"] = tracking["total_sends"] + 1
             if pfresp.get("error") == null {
                 track("developer", pfresp)
-                let fixed_ops = agent.extract_code(pfresp.get("content") ?? "", "python")
-                if len(fixed_ops) > 20 {
-                    ops_code = fixed_ops
-                    print("PYTEST_FIX|developer_fixed|ops=" + string(len(ops_code)))
+                post_send_check(handles["developer"], pfresp, "developer")
+                let fixed = agent.extract_code(pfresp.get("content") ?? "", "python")
+                if len(fixed) > 20 {
+                    if fix_attempt > 1 && string.contains(fixed, "def test_") {
+                        test_code = fixed
+                        print("PYTEST_FIX|developer_fixed|tests=" + string(len(test_code)))
+                    } else {
+                        ops_code = fixed
+                        print("PYTEST_FIX|developer_fixed|ops=" + string(len(ops_code)))
+                    }
                 }
             } else {
                 tracking["send_errors"] = tracking["send_errors"] + 1
             }
             print("TURN|developer|pytest_fix" + string(feat_num) + "|c=" + string(tracking["coherences"].get("developer") ?? -1))
+            cur_val = validate_code(ops_code, main_code, test_code, ops_pattern)
+            print("VALIDATE|feat" + string(feat_num) + "|attempt" + string(fix_attempt) + "_pytest_passed=" + string(cur_val.get("pytest_passed") == true))
         }
 
-        // Final validation status for this feature. If pytest failed initially, a
-        // single fix was attempted above — re-validate so completion isn't marked
-        // on still-broken code.
-        let feat_passed = fval.get("pytest_passed") == true
+        // FINAL validation status for this feature (the fix loop re-validated
+        // after each attempt), so completion isn't marked on still-broken code.
+        let feat_passed = cur_val.get("pytest_passed") == true
         if fval.get("pytest_passed") == false {
-            let reval = validate_code(ops_code, main_code, test_code, ops_pattern)
-            feat_passed = reval.get("pytest_passed") == true
             print("VALIDATE|feat" + string(feat_num) + "|revalidated_pytest_passed=" + string(feat_passed))
         }
         // Feed the ground-truth outcome into the developer's coherence (S22 signal).
@@ -936,7 +967,9 @@ main {
 
         // Consult operator after each feature
         let dc = tracking["coherences"].get("developer") ?? -1
-        let feat_ctx = {"phase": "FEATURES", "event": "feature_implemented", "feature_num": feat_num, "requirement": trimmed, "ops_len": len(ops_code), "test_len": len(test_code), "developer_coherence": dc, "specialist_consults": tracking.get("specialist_consults") ?? 0, "question": "Feature " + string(feat_num) + " done. Developer coherence: " + string(dc) + ". Code grew from " + string(prev_ops_len) + " to " + string(len(ops_code)) + " chars. Adjust if drift detected."}
+        let feat_status_txt = " INCOMPLETE — pytest still failing."
+        if feat_passed { feat_status_txt = " complete." }
+        let feat_ctx = {"phase": "FEATURES", "event": "feature_implemented", "validation_passed": feat_passed, "feature_num": feat_num, "requirement": trimmed, "ops_len": len(ops_code), "test_len": len(test_code), "developer_coherence": dc, "specialist_consults": tracking.get("specialist_consults") ?? 0, "question": "Feature " + string(feat_num) + feat_status_txt + " Developer coherence: " + string(dc) + ". Code grew from " + string(prev_ops_len) + " to " + string(len(ops_code)) + " chars. Adjust if drift detected."}
         let feat_decision = consult_operator(feat_ctx)
         handle_specialist_request(feat_decision, "FEATURES")
 

--- a/examples/living-script_extended/results/regression-surface-analysis.md
+++ b/examples/living-script_extended/results/regression-surface-analysis.md
@@ -322,3 +322,50 @@ harnesses.
   and `src/govern.json` (exception-convention invariant, `E `-line detail,
   `record_validation` detail arg)
 - Jul 18 run figures: follow-up forensic session, originating device.
+
+---
+
+## Round 3: post-#88 live confirmation and the feature-2 contract fix
+
+The first live run on the #88 changes went APPROVED (105/105 harness, 3/4
+features, coherence floor 0.86, tokens back to 746K). Forensics on that run
+(follow-up session, originating device) confirmed each intervention with exact
+values: one S22 recovery of +0.075 fired only on the fail→pass transition
+(VR2→VR3), a `validation`-type challenge fired grounded in 9 failure-detail
+keywords and passed at 0.667, feature 3's division-by-zero and feature 4's
+exception types were correct on first attempt. The "ghost run" in that
+telemetry file is the harness's own L3-03 cross-run invocation (second
+`run_id` segment in the same file, by design) — analyses must filter by
+`run_id`.
+
+**Feature 2's coin flip had a locatable cause.** The per-feature reminder
+`"memory_recall() returns None when no value is stored (do NOT raise
+ValueError)"` was appended to `invariants` AFTER that feature's ops and test
+prompts had already been sent — so it reached only the fix prompts and later
+features, while the test prompt's blanket "invalid input MUST be tested with
+pytest.raises(ValueError)" line pushed the tests the opposite way, and the
+test prompt never saw the ops code at all. Two independently-derived,
+contradictory contracts.
+
+Interventions in this round (scripts/harness/tests only — no engine changes):
+
+1. **Shared per-feature CONTRACT**: error semantics for each feature are now
+   one string computed at feature start and included verbatim in the ops
+   prompt, the test prompt, and the fix prompts; the test prompt additionally
+   embeds the current `operations.py` so tests are written against real
+   signatures.
+2. **Two-attempt fix loop**: PYTEST_FIX now retries up to twice with
+   re-validation between attempts; attempt 2 shows both files plus the
+   contract and may fix a test only where it contradicts the contract.
+3. **Operator ground truth**: the post-feature operator consult now carries
+   `validation_passed` and states complete/INCOMPLETE explicitly (the
+   post-#88 run's operator had misread an incomplete feature as complete).
+4. **`challenge_failure` kill kind**: a failed step-up challenge throws
+   GovernanceHardError (exit 3) — the same designed-kill class as the
+   quarantine streak. Both harnesses now classify it (`detect_gov_kill`),
+   with GK-01 attributability against `AGENT_CHALLENGE_FAIL` telemetry.
+5. **Deterministic challenge-failure coverage**:
+   `tests/governance_v4/test_challenge_fail_path.sh` forces both challenge
+   outcomes with the loopback stub (off-topic answer → FAIL → exit 3 +
+   telemetry; on-topic answer → PASS → run completes), closing the gap where
+   the fail path had never been exercised outside live-model luck.

--- a/examples/living-script_extended/run.sh
+++ b/examples/living-script_extended/run.sh
@@ -60,7 +60,8 @@ skip() { local id="$1" desc="$2"; SKIP_COUNT=$((SKIP_COUNT + 1)); TOTAL=$((TOTAL
 # ------------------------------------------------------------
 # Governance-kill classification.
 #
-# When an agent exceeds max_quarantine_streak, the engine throws an
+# When an agent exceeds max_quarantine_streak (or fails a step-up
+# challenge), the engine throws an
 # uncatchable GovernanceHardError: main.cpp prints
 # "Error: Agent exceeded maximum quarantine streak" to stdout and exits 3.
 # That is governance succeeding, not the harness failing — so checks on
@@ -73,6 +74,8 @@ GOV_KILL=""
 detect_gov_kill() {  # $1=exit code, $2=captured stdout — echoes kill kind, or nothing
     if [ "$1" -eq 3 ] && echo "$2" | grep -q "Agent exceeded maximum quarantine streak"; then
         echo "quarantine_streak"
+    elif [ "$1" -eq 3 ] && echo "$2" | grep -q "Step-up challenge failed"; then
+        echo "challenge_failure"
     fi
 }
 
@@ -159,17 +162,18 @@ else
     if [ -n "$GOV_KILL" ]; then
         echo -e "${YELLOW}================================================================${NC}"
         echo -e "${YELLOW}  GOVERNANCE KILL: $GOV_KILL -- run terminated by design.${NC}"
-        echo -e "${YELLOW}  An agent exceeded max_quarantine_streak. Levels the script${NC}"
-        echo -e "${YELLOW}  never reached are reported as SKIP, not FAIL.${NC}"
+        echo -e "${YELLOW}  Levels the script never reached are reported as SKIP, not FAIL.${NC}"
         echo -e "${YELLOW}================================================================${NC}"
         echo ""
-        # The kill must be attributable: the engine emits QUARANTINE_STREAK_EXCEEDED
-        # telemetry BEFORE throwing. Exit 3 + streak message with no telemetry
-        # event would be a genuine bug, not an expected outcome.
-        if grep -q "QUARANTINE_STREAK_EXCEEDED" "$WORKDIR/telemetry.jsonl" 2>/dev/null; then
-            pass "GK-01" "Governance kill attributable (QUARANTINE_STREAK_EXCEEDED in telemetry)"
+        # The kill must be attributable: the engine emits the matching telemetry
+        # event BEFORE throwing (QUARANTINE_STREAK_EXCEEDED / AGENT_CHALLENGE_FAIL).
+        # Exit 3 + kill message with no telemetry event would be a genuine bug.
+        GK_EVENT="QUARANTINE_STREAK_EXCEEDED"
+        [ "$GOV_KILL" = "challenge_failure" ] && GK_EVENT="AGENT_CHALLENGE_FAIL"
+        if grep -q "$GK_EVENT" "$WORKDIR/telemetry.jsonl" 2>/dev/null; then
+            pass "GK-01" "Governance kill attributable ($GK_EVENT in telemetry)"
         else
-            fail "GK-01" "Unattributable governance kill" "exit 3 + streak message but no QUARANTINE_STREAK_EXCEEDED telemetry event"
+            fail "GK-01" "Unattributable governance kill" "exit 3 + kill message but no $GK_EVENT telemetry event"
         fi
     fi
 

--- a/examples/living-script_extended/src/living-script.naab
+++ b/examples/living-script_extended/src/living-script.naab
@@ -872,6 +872,25 @@ main {
         print("REACTIVE|found=" + fname)
         print("FEATURE|" + string(feat_num) + "|start|" + trimmed)
 
+        // Per-feature error-semantics CONTRACT — one sentence shared verbatim by
+        // the ops prompt, the test prompt, and the fix prompts, so code and tests
+        // are written against the same behavior instead of re-deriving it
+        // independently (the Jul 18 feature-2 coin flip: the developer was told
+        // "recall returns None, do NOT raise" while the tests expected ValueError).
+        let feat_contract = ""
+        if fname == "requirement-001.txt" {
+            feat_contract = "power() raises ValueError for complex results; modulo() raises ValueError on zero."
+        }
+        if fname == "requirement-002.txt" {
+            feat_contract = "memory_recall() with nothing stored returns None — that is NOT an error: do not raise, and do not write a test expecting a raise; memory_store() with a non-numeric value raises ValueError; memory_store() records to history."
+        }
+        if fname == "requirement-003.txt" {
+            feat_contract = "evaluate() records ONE history entry (not intermediate steps) and uses ast.parse not eval(); invalid or malformed expressions (including division by zero) raise ValueError."
+        }
+        if fname == "requirement-004.txt" {
+            feat_contract = "run_plugin() raises ValueError for unregistered plugins; register_plugin() raises ValueError for duplicate names or non-callable plugins."
+        }
+
         // Architect analyzes impact
         if handles.get("architect") != null && len(trimmed) > 5 {
             let arch_msg = "New feature requirement for the calculator:\n" + trimmed + "\n\nCurrent Calculator class has: add, subtract, multiply, divide, get_history, clear_history."
@@ -894,6 +913,7 @@ main {
                     dev_msg = dev_msg + "ADD this feature to operations.py:\n" + guidance
                     dev_msg = dev_msg + "\n\nRequirement: " + trimmed
                     dev_msg = dev_msg + "\n\n" + invariants
+                    if len(feat_contract) > 0 { dev_msg = dev_msg + "\nCONTRACT for this feature (code MUST match): " + feat_contract }
                     dev_msg = dev_msg + "\nEXISTING METHODS (do NOT modify): " + existing_methods
                     dev_msg = dev_msg + "\nOnly ADD new methods for this feature. Do not rewrite or change existing methods."
                     dev_msg = dev_msg + "\n\nCurrent operations.py:\n```python\n" + ops_code + "\n```\nOutput the COMPLETE file with the new methods added. ```python fences. Code only."
@@ -915,7 +935,9 @@ main {
                     // Developer updates test file
                     check_coherence(handles["developer"], "developer")
                     let test_msg = "Add tests for this new feature ONLY:\n" + trimmed
+                    if len(feat_contract) > 0 { test_msg = test_msg + "\n\nCONTRACT (tests MUST match this exactly): " + feat_contract }
                     test_msg = test_msg + "\n\nInvalid input MUST be tested with pytest.raises(ValueError) — the calculator NEVER raises bare ZeroDivisionError/TypeError or custom exception classes."
+                    test_msg = test_msg + "\n\nCurrent operations.py (write tests against THESE method signatures — do not guess names):\n```python\n" + ops_code + "\n```"
                     test_msg = test_msg + "\nDo NOT modify existing tests. Only ADD new test functions."
                     test_msg = test_msg + "\n\nCurrent test_calc.py:\n```python\n" + test_code + "\n```\nOutput the COMPLETE file with new tests added. pytest with fixture. ```python fences. Code only."
                     resp = safe_send(handles["developer"], test_msg)
@@ -983,17 +1005,10 @@ main {
             existing_methods = existing_methods + ", " + new_methods
         }
         // Feature-specific reminders (lightweight — full invariants in system_prompt)
-        if fname == "requirement-001.txt" {
-            invariants = invariants + " Also: power() raises ValueError for complex results, modulo() raises ValueError on zero."
-        }
-        if fname == "requirement-002.txt" {
-            invariants = invariants + " Also: memory_recall() returns None when no value is stored (do NOT raise ValueError), memory_store() records to history."
-        }
-        if fname == "requirement-003.txt" {
-            invariants = invariants + " Also: evaluate() records ONE history entry (not intermediate steps), uses ast.parse not eval()."
-        }
-        if fname == "requirement-004.txt" {
-            invariants = invariants + " Also: run_plugin() raises ValueError for unregistered plugins, register_plugin() raises ValueError for duplicate names."
+        // (Accumulates the shared CONTRACT so later features and the refinement
+        // fix prompts keep honoring earlier features' error semantics.)
+        if len(feat_contract) > 0 {
+            invariants = invariants + " Also: " + feat_contract
         }
 
         // Validate evolved code (includes pytest)
@@ -1007,13 +1022,16 @@ main {
             fvk = fvk + 1
         }
 
-        // If pytest failed, send the failing test names PLUS the exception detail
-        // lines ("E ..." from --tb=short) for 1 fix attempt. Names alone are not
-        // enough: without seeing "ZeroDivisionError" vs the expected exception
-        // type, the model cannot know WHAT to fix (Jul 18 run: two failed fix
-        // attempts on the same division-by-zero bug it never saw).
-        if fval.get("pytest_passed") == false && handles.get("developer") != null {
-            let pytest_out = fval.get("pytest_output") ?? ""
+        // Pytest fix loop — up to 2 attempts, re-validating after each. Attempt 1
+        // fixes operations.py against the failure detail. Attempt 2 additionally
+        // shows test_calc.py and the feature CONTRACT: if a failing test
+        // contradicts the contract, the developer may fix the TEST instead —
+        // never to weaken assertions that match the contract.
+        let cur_val = fval
+        let fix_attempt = 0
+        while cur_val.get("pytest_passed") == false && fix_attempt < 2 && handles.get("developer") != null {
+            fix_attempt = fix_attempt + 1
+            let pytest_out = cur_val.get("pytest_output") ?? ""
             let plines = string.split(pytest_out, "\n")
             let fail_names = ""
             let pfi = 0
@@ -1036,32 +1054,43 @@ main {
             if len(operator_msg_prefix) > 0 { pytest_fix_msg = operator_msg_prefix + "\n\n" }
             pytest_fix_msg = pytest_fix_msg + "Pytest FAILED after adding: " + trimmed + "\nFailing tests:\n" + fail_names
             pytest_fix_msg = pytest_fix_msg + "\n" + invariants
-            pytest_fix_msg = pytest_fix_msg + "\nFix ONLY the failing parts. Do NOT rewrite the whole file."
-            pytest_fix_msg = pytest_fix_msg + "\nCurrent operations.py:\n```python\n" + ops_code + "\n```\nOutput the COMPLETE fixed operations.py. ```python fences. Code only."
+            if len(feat_contract) > 0 { pytest_fix_msg = pytest_fix_msg + "\nCONTRACT for this feature: " + feat_contract }
+            if fix_attempt == 1 {
+                pytest_fix_msg = pytest_fix_msg + "\nFix ONLY the failing parts. Do NOT rewrite the whole file."
+                pytest_fix_msg = pytest_fix_msg + "\nCurrent operations.py:\n```python\n" + ops_code + "\n```\nOutput the COMPLETE fixed operations.py. ```python fences. Code only."
+            } else {
+                pytest_fix_msg = pytest_fix_msg + "\nSECOND ATTEMPT. If a failing test CONTRADICTS the CONTRACT above, output the corrected COMPLETE test_calc.py instead; otherwise output the corrected COMPLETE operations.py. NEVER weaken or delete assertions that match the contract."
+                pytest_fix_msg = pytest_fix_msg + "\nCurrent operations.py:\n```python\n" + ops_code + "\n```"
+                pytest_fix_msg = pytest_fix_msg + "\nCurrent test_calc.py:\n```python\n" + test_code + "\n```\nOutput exactly ONE complete file. ```python fences. Code only."
+            }
             check_coherence(handles["developer"], "developer")
             let pfresp = safe_send(handles["developer"], pytest_fix_msg)
             tracking["total_sends"] = tracking["total_sends"] + 1
             if pfresp.get("error") == null {
                 track("developer", pfresp)
                 post_send_check(handles["developer"], pfresp, "developer")
-                let fixed_ops = agent.extract_code(pfresp.get("content") ?? "", "python")
-                if len(fixed_ops) > 20 {
-                    ops_code = fixed_ops
-                    print("PYTEST_FIX|developer_fixed|ops=" + string(len(ops_code)))
+                let fixed = agent.extract_code(pfresp.get("content") ?? "", "python")
+                if len(fixed) > 20 {
+                    if fix_attempt > 1 && string.contains(fixed, "def test_") {
+                        test_code = fixed
+                        print("PYTEST_FIX|developer_fixed|tests=" + string(len(test_code)))
+                    } else {
+                        ops_code = fixed
+                        print("PYTEST_FIX|developer_fixed|ops=" + string(len(ops_code)))
+                    }
                 }
             } else {
                 tracking["send_errors"] = tracking["send_errors"] + 1
             }
             print("TURN|developer|pytest_fix" + string(feat_num) + "|c=" + string(tracking["coherences"].get("developer") ?? -1))
+            cur_val = validate_code(ops_code, main_code, test_code, ops_pattern)
+            print("VALIDATE|feat" + string(feat_num) + "|attempt" + string(fix_attempt) + "_pytest_passed=" + string(cur_val.get("pytest_passed") == true))
         }
 
-        // Determine the FINAL validation status for this feature. If pytest failed
-        // initially, a single fix was attempted above — re-validate to see whether
-        // it actually passes now, so completion isn't marked on still-broken code.
-        let feat_passed = fval.get("pytest_passed") == true
+        // FINAL validation status for this feature (the fix loop re-validated
+        // after each attempt), so completion isn't marked on still-broken code.
+        let feat_passed = cur_val.get("pytest_passed") == true
         if fval.get("pytest_passed") == false {
-            let reval = validate_code(ops_code, main_code, test_code, ops_pattern)
-            feat_passed = reval.get("pytest_passed") == true
             print("VALIDATE|feat" + string(feat_num) + "|revalidated_pytest_passed=" + string(feat_passed))
         }
         // Feed the ground-truth outcome into the developer's coherence (S22 signal):
@@ -1081,7 +1110,9 @@ main {
 
         // Consult operator after each feature
         let dc = tracking["coherences"].get("developer") ?? -1
-        let feat_ctx = {"phase": "FEATURES", "event": "feature_implemented", "feature_num": feat_num, "requirement": trimmed, "ops_len": len(ops_code), "test_len": len(test_code), "developer_coherence": dc, "specialist_consults": tracking.get("specialist_consults") ?? 0, "question": "Feature " + string(feat_num) + " done. Developer coherence: " + string(dc) + ". Code grew from " + string(prev_ops_len) + " to " + string(len(ops_code)) + " chars. Adjust if drift detected."}
+        let feat_status_txt = " INCOMPLETE — pytest still failing."
+        if feat_passed { feat_status_txt = " complete." }
+        let feat_ctx = {"phase": "FEATURES", "event": "feature_implemented", "validation_passed": feat_passed, "feature_num": feat_num, "requirement": trimmed, "ops_len": len(ops_code), "test_len": len(test_code), "developer_coherence": dc, "specialist_consults": tracking.get("specialist_consults") ?? 0, "question": "Feature " + string(feat_num) + feat_status_txt + " Developer coherence: " + string(dc) + ". Code grew from " + string(prev_ops_len) + " to " + string(len(ops_code)) + " chars. Adjust if drift detected."}
         let feat_decision = consult_operator(feat_ctx)
         handle_specialist_request(feat_decision, "FEATURES")
 

--- a/run-all-tests.sh
+++ b/run-all-tests.sh
@@ -1517,6 +1517,19 @@ else
     echo "  test_validation_signal.sh: not found, skipping"
 fi
 
+# Step-up challenge failure path (stub-backed, deterministic)
+CHALLENGE_FAIL_SCRIPT="tests/governance_v4/test_challenge_fail_path.sh"
+if [ -f "$CHALLENGE_FAIL_SCRIPT" ]; then
+    if bash "$CHALLENGE_FAIL_SCRIPT" 2>&1; then
+        echo "  test_challenge_fail_path.sh: ALL PASSED"
+    else
+        FAILED=$((FAILED + 1))
+        FAILED_TESTS+=("test_challenge_fail_path.sh")
+    fi
+else
+    echo "  test_challenge_fail_path.sh: not found, skipping"
+fi
+
 # Per-tool-call admissibility gate (stub-backed)
 TOOL_GATE_SCRIPT="tests/governance_v4/test_tool_admissibility_gate.sh"
 if [ -f "$TOOL_GATE_SCRIPT" ]; then

--- a/tests/governance_v4/test_challenge_fail_path.sh
+++ b/tests/governance_v4/test_challenge_fail_path.sh
@@ -1,0 +1,232 @@
+#!/usr/bin/env bash
+# ============================================================
+# test_challenge_fail_path.sh — step-up challenge FAILURE path
+#
+# Across five live living-script runs the challenge system produced exactly
+# one failure — the fail path had no deterministic coverage (gorilla tests
+# only count failures a live model happens to produce). This test forces
+# both outcomes with the loopback stub:
+#
+# Group A: an off-topic challenge answer FAILS the challenge — the engine
+#          throws GovernanceHardError ("Step-up challenge failed"), the
+#          process exits 3, and AGENT_CHALLENGE_FAIL telemetry carries the
+#          challenge_type and keyword_ratio. This is the same governance-
+#          kill class the living-script harnesses classify as
+#          "challenge_failure".
+# Group B: control — an on-topic answer PASSES the same challenge and the
+#          gated send completes normally (exit 0).
+#
+# Escalation staging mirrors test_challenge_first_turn.sh: S22 fires once
+# (validation failure), signal_density alone drives the level to ELEVATED,
+# where step-up gates the next send. The recorded failure detail makes the
+# challenge the priority-0 "validation" type.
+# ============================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAAB="$SCRIPT_DIR/../../build/naab-lang"
+
+if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
+    _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
+else
+    _SYSTMP="${TMPDIR:-/tmp}"
+fi
+TEST_TMP="${_SYSTMP}/challenge-fail-$$"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+PASS_COUNT=0; FAIL_COUNT=0; SKIP_COUNT=0; FAILURES=""
+
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo -e "  ${GREEN}PASS${NC} [$1] $2"; }
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo -e "  ${RED}FAIL${NC} [$1] $2"; [ -n "${3:-}" ] && echo -e "       ${RED}-> $3${NC}"; FAILURES="${FAILURES}\n  [$1] $2"; }
+skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo -e "  ${YELLOW}SKIP${NC} [$1] $2"; }
+
+source "$SCRIPT_DIR/../helpers/trust_setup.sh"
+setup_isolated_trust
+STUB_PID=""
+cleanup() {
+    [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null
+    teardown_isolated_trust
+    rm -rf "$TEST_TMP"
+}
+trap cleanup EXIT
+mkdir -p "$TEST_TMP"
+
+"$NAAB" --keygen "$TEST_TMP/test-key.pem" >/dev/null 2>&1
+"$NAAB" --trust-key "$TEST_TMP/test-key.pem.pub" 2>/dev/null
+export NAAB_SIGNING_KEY="$TEST_TMP/test-key.pem"
+export FAKE_KEY_CHALFAIL="fake-key-challenge-fail"
+
+sign_govern() { (cd "$1" && NAAB_SIGNING_KEY="$NAAB_SIGNING_KEY" "$NAAB" --sign-governance >/dev/null 2>&1) || true; }
+
+start_stub() {  # $1=fixture $2=workdir
+    STUB_PORT=$(( (RANDOM % 20000) + 20000 ))
+    python3 "$SCRIPT_DIR/../helpers/agent_stub.py" "$STUB_PORT" "$1" "$2" > "$2/stub.log" 2>&1 &
+    STUB_PID=$!
+    for _ in $(seq 1 50); do grep -q READY "$2/stub.log" 2>/dev/null && return 0; sleep 0.1; done
+    return 1
+}
+stop_stub() { [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null; wait "$STUB_PID" 2>/dev/null; STUB_PID=""; }
+
+mk_govern() {  # $1=port
+    cat <<EOF
+{
+  "version": "5.0", "mode": "enforce",
+  "security": { "sandbox_level": "elevated" },
+  "telemetry": { "enabled": true, "output_file": "tele.jsonl" },
+  "behavioral_sequences": { "enabled": true },
+  "context_drift": {
+    "enabled": true, "level": "advisory", "check_interval_turns": 1,
+    "signals": {
+      "circular_actions": false, "repeated_failures": false, "scope_creep": false,
+      "intent_contradictions": false, "coherence_velocity": false,
+      "response_quality": false, "thinking_collapse": false,
+      "semantic_stability": false, "mandate_alignment": false,
+      "context_growth": false, "instruction_recall": false, "plan_drift": false,
+      "entity_consistency": false, "instruction_conflict": false,
+      "persona_fingerprint": false, "tool_chain_integrity": false,
+      "claim_result_reconciliation": false, "prompt_compliance": false,
+      "response_repetition": false, "validation_outcome": true
+    },
+    "reality_checkpoint": {
+      "enabled": false, "pressure_threshold": 0.5, "signal_density_divisor": 1,
+      "weights": {
+        "coherence_proximity": 0, "risk_score_proximity": 0,
+        "signal_density": 1.0, "conversation_depth": 0,
+        "bsd_partial_progress": 0, "pipeline_inherited": 0,
+        "coherence_acceleration": 0, "codegen_pressure": 0,
+        "bsd_eviction_pressure": 0, "semantic_deviation": 0
+      }
+    }
+  },
+  "circuit_breaker": {
+    "enabled": true, "elevated_threshold": 0.5, "elevated_sustained": 1,
+    "deescalate_sustained": 5,
+    "step_up_enabled": true, "step_up_contextual": true,
+    "step_up_at_level": "elevated"
+  },
+  "agents": { "developer": { "provider": "gemini", "model": "stub-model",
+      "api_base": "http://127.0.0.1:$1",
+      "api_key_env": "FAKE_KEY_CHALFAIL", "max_tokens": 100, "max_turns": 20 } }
+}
+EOF
+}
+
+# Test script shared by both groups: send1 delivers, a failing validation with
+# detail escalates via S22, send2 draws the (validation-type) challenge whose
+# answer is the stub's next fixture response, send3 only runs if send2 survived.
+TEST_NAAB='use agent
+main {
+    let h = agent.create("developer")
+    let r1 = agent.send(h, "implement divide")
+    let _f = agent.record_validation(h, false, "FAILED test_divide_by_zero: divide raised ZeroDivisionError, expected ValueError for zero divisor")
+    let r2 = agent.send(h, "fix the divide operation")
+    print("SEND2_OK")
+    let r3 = agent.send(h, "add divide docstring")
+    print("SEND3_OK")
+}'
+
+echo ""
+echo -e "${CYAN}+==============================================================+${NC}"
+echo -e "${CYAN}|   Step-up challenge FAILURE path (deterministic, stub)       |${NC}"
+echo -e "${CYAN}+==============================================================+${NC}"
+echo ""
+
+# ============================================================
+# Group A: off-topic challenge answer → FAIL → GovernanceHardError, exit 3
+# ============================================================
+echo -e "${CYAN}--- Group A: failed challenge kills the run (exit 3) ---${NC}"
+WDIR="$TEST_TMP/a"; mkdir -p "$WDIR"
+# Response order: r1=send1, r2=send2 (escalation lands in its post-CDD),
+# r3=the CHALLENGE answer gating send3 — maximally off-topic so keyword
+# overlap with the validation-failure detail is ~zero, r4=unreached.
+printf '%s' '{"responses": [
+  {"content": "def divide(a, b): return a / b  # implemented divide operation", "output_tokens": 30},
+  {"content": "def divide(a, b): return a / b  # attempting fix", "output_tokens": 30},
+  {"content": "banana umbrella weather picnic sunshine holiday melody", "output_tokens": 30},
+  {"content": "def divide(a, b): return a / b  # docstring added", "output_tokens": 30}
+]}' > "$WDIR/fixture.json"
+start_stub "$WDIR/fixture.json" "$WDIR" || { skip "A-00" "stub failed"; STUB_PORT=0; }
+if [ "$STUB_PORT" != "0" ]; then
+mk_govern "$STUB_PORT" > "$WDIR/govern.json"; sign_govern "$WDIR"
+printf '%s' "$TEST_NAAB" > "$WDIR/test.naab"
+OUT=$(cd "$WDIR" && timeout 60s "$NAAB" test.naab 2>&1); EXIT_A=$?
+stop_stub
+if [ "$EXIT_A" -eq 3 ]; then
+    pass "A-01" "Failed challenge exits 3 (GovernanceHardError)"
+else
+    fail "A-01" "Wrong exit code" "exit=$EXIT_A, expected 3"
+fi
+if echo "$OUT" | grep -q "Step-up challenge failed"; then
+    pass "A-02" "Kill message surfaced on stdout (harness-detectable signature)"
+else
+    fail "A-02" "No 'Step-up challenge failed' in output" "$(echo "$OUT" | tail -3)"
+fi
+CHAL_A=$(grep '"event_type":"AGENT_CHALLENGE_FAIL"' "$WDIR/tele.jsonl" 2>/dev/null | head -1)
+if [ -n "$CHAL_A" ]; then
+    pass "A-03" "AGENT_CHALLENGE_FAIL telemetry emitted before the throw"
+else
+    fail "A-03" "No AGENT_CHALLENGE_FAIL event" "$(grep -c CDD_TURN "$WDIR/tele.jsonl" 2>/dev/null) CDD turns"
+fi
+if echo "$CHAL_A" | grep -q '"challenge_type":"validation"'; then
+    pass "A-04" "Failed challenge was the validation (competence) type"
+else
+    fail "A-04" "Unexpected challenge type" "$CHAL_A"
+fi
+RATIO_A=$(echo "$CHAL_A" | grep -oP '"keyword_ratio":"\K[0-9.]+' | head -1)
+if [ -n "$RATIO_A" ] && awk "BEGIN{exit !($RATIO_A < 0.30)}"; then
+    pass "A-05" "keyword_ratio below contextual threshold ($RATIO_A < 0.30)"
+else
+    fail "A-05" "keyword_ratio not below threshold" "ratio=$RATIO_A"
+fi
+# Escalation lands during send2's post-response CDD, so send2 completes and
+# the CHALLENGE gates send3 — which must never finish after the failed gate.
+if echo "$OUT" | grep -q "SEND2_OK" && ! echo "$OUT" | grep -q "SEND3_OK"; then
+    pass "A-06" "Gated send (send3) never completed; pre-gate send2 did"
+else
+    fail "A-06" "Unexpected send completion pattern" "$(echo "$OUT" | grep -c SEND2_OK)x SEND2, $(echo "$OUT" | grep -c SEND3_OK)x SEND3"
+fi
+if ! grep -q '"event_type":"AGENT_CHALLENGE_PASS"' "$WDIR/tele.jsonl" 2>/dev/null; then
+    pass "A-07" "No spurious CHALLENGE_PASS (no recovery credited on fail)"
+else
+    fail "A-07" "CHALLENGE_PASS present in a fail-only scenario"
+fi
+fi
+
+# ============================================================
+# Group B: control — on-topic answer passes the same challenge
+# ============================================================
+echo -e "${CYAN}--- Group B: on-topic answer passes the same gate ---${NC}"
+WDIR="$TEST_TMP/b"; mkdir -p "$WDIR"
+# r3 is the CHALLENGE answer: on-topic, restating the recorded defect.
+printf '%s' '{"responses": [
+  {"content": "def divide(a, b): return a / b  # implemented divide operation", "output_tokens": 30},
+  {"content": "def divide(a, b): return a / b  # attempting fix", "output_tokens": 30},
+  {"content": "The divide test failed because divide raised ZeroDivisionError instead of ValueError for a zero divisor. I will catch ZeroDivisionError and raise ValueError, then proceed.", "output_tokens": 40},
+  {"content": "def divide(a, b): return a / b  # docstring added", "output_tokens": 30}
+]}' > "$WDIR/fixture.json"
+start_stub "$WDIR/fixture.json" "$WDIR" || { skip "B-00" "stub failed"; STUB_PORT=0; }
+if [ "$STUB_PORT" != "0" ]; then
+mk_govern "$STUB_PORT" > "$WDIR/govern.json"; sign_govern "$WDIR"
+printf '%s' "$TEST_NAAB" > "$WDIR/test.naab"
+OUT=$(cd "$WDIR" && timeout 60s "$NAAB" test.naab 2>&1); EXIT_B=$?
+stop_stub
+if [ "$EXIT_B" -eq 0 ] && echo "$OUT" | grep -q "SEND3_OK"; then
+    pass "B-01" "On-topic answer passes; script completes (exit 0)"
+else
+    fail "B-01" "Control run did not complete" "exit=$EXIT_B $(echo "$OUT" | tail -2)"
+fi
+CHAL_B=$(grep '"event_type":"AGENT_CHALLENGE_PASS"' "$WDIR/tele.jsonl" 2>/dev/null | head -1)
+if echo "$CHAL_B" | grep -q '"challenge_type":"validation"'; then
+    pass "B-02" "Same validation-type challenge, passed with on-topic answer"
+else
+    fail "B-02" "No validation-type CHALLENGE_PASS" "$CHAL_B"
+fi
+fi
+
+# ============================================================
+echo ""
+echo -e "${CYAN}+==============================================================+${NC}"
+TOTAL=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+echo -e "  Total: $TOTAL | ${GREEN}Pass: $PASS_COUNT${NC} | ${RED}Fail: $FAIL_COUNT${NC} | ${YELLOW}Skip: $SKIP_COUNT${NC}"
+if [ "$FAIL_COUNT" -gt 0 ]; then echo -e "${RED}Failures:${NC}$FAILURES"; exit 1; fi
+exit 0


### PR DESCRIPTION
## Summary
Follow-up to #88, driven by the post-#88 live-run forensics (first APPROVED run since Jul 15; S22 recovery and the validation challenge both confirmed working live). Three residual items, all now precisely located: feature 2's coin-flip failure had a **static, locatable cause** (contradictory error-semantics text reaching code and tests through different prompts), the operator misread an incomplete feature as complete, and the step-up challenge failure path had zero deterministic test coverage. No engine changes — scripts, harnesses, one new test, docs.

## Changes
**Living-script (base + extended)** (`living-script.naab`):
- **Per-feature CONTRACT**: error semantics are one string computed at feature start and included verbatim in the ops prompt, the test prompt, and the fix prompts. Previously the feature-specific reminders were appended to `invariants` *after* that feature's ops/test prompts had been sent — the developer was told "memory_recall returns None, do NOT raise" while the independently-written tests expected `ValueError`.
- The test prompt now embeds the current `operations.py`, so tests are written against real method signatures instead of guessed names (the Jul 17 `store_memory` vs `memory_store` class of failure).
- **Two-attempt PYTEST_FIX loop** with re-validation after each attempt; attempt 2 shows both files plus the contract and may fix a test *only* where it contradicts the contract — never to weaken assertions.
- Operator consult after each feature now carries `validation_passed` and states complete/INCOMPLETE explicitly.

**Harnesses** (`run.sh` ×2):
- Second governance-kill kind **`challenge_failure`**: a failed step-up challenge throws `GovernanceHardError` (exit 3, "Step-up challenge failed") — the same designed-kill class as the quarantine streak. `detect_gov_kill` classifies it; GK-01 attributes it against `AGENT_CHALLENGE_FAIL` telemetry.

**Tests**:
- New `tests/governance_v4/test_challenge_fail_path.sh` (9 assertions, stub-driven, registered in `run-all-tests.sh`): deterministically forces both challenge outcomes — an off-topic answer fails the validation-type challenge (exit 3, telemetry with `keyword_ratio`, gated send never completes, no spurious recovery); an on-topic answer passes the same gate and the run completes.

**Docs**: round-3 section appended to `regression-surface-analysis.md` (post-#88 live confirmation, feature-2 root cause, interventions).

## Test Plan
- [x] New `test_challenge_fail_path.sh` — 9/9 (also established that the challenge gates the *next* send after escalation lands in post-response CDD)
- [x] Both `.naab` scripts parse-verified; both `run.sh` `bash -n` clean; no-key path unchanged (exit 0)
- [x] Harness `challenge_failure` classification stub-verified: banner + GK-01 attributability + full check rigor preserved for phases that ran
- [x] `bash run-all-tests.sh` full sweep — 441 tests, **0 unexpected failures**; both stub tests ALL PASSED inside the sweep
- [ ] Live-key run on the originating device (no `GK1` in this environment) — the real feature-2 pass-rate validation

## Related Issues
Follow-up to #87 / #88.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_018L3RcVMf1tLNsGeJtofWmS