### PR TITLE
Attribute attestation signatures, and prove the evidence layer fires

### DIFF
--- a/examples/living-script_extended/run.sh
+++ b/examples/living-script_extended/run.sh
@@ -1446,14 +1446,27 @@ assert 'refinement_iterations' in d
         fail "L24-01" "Evidence audit phase not reached"
     fi
 
+    # Deliberately NOT an equality against the script's send counter.
+    # agent.commit() attests as well as agent.send(), and safe_send() bumps
+    # total_sends even when the send was blocked before reaching
+    # emitAttestation — so equality would swing on agent behaviour, the same
+    # trap L24-05 avoids. What IS invariant: attestations exist, every one is a
+    # known action, and attested sends cannot outnumber attempted sends.
     EV_ATT=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|exec_attestations=\K[0-9]+' | head -1)
-    EV_SENDS=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|exec_attestations=[0-9]+\|sends=\K[0-9]+' | head -1)
-    if [ "${EV_ATT:-0}" -gt 0 ] && [ "${EV_ATT:-0}" -eq "${EV_SENDS:-(-1)}" ]; then
-        pass "L24-02" "One signed execution attestation per send (${EV_ATT}/${EV_SENDS})"
-    elif [ "${EV_ATT:-0}" -eq 0 ]; then
+    EV_SEND_ATT=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|.*\|send_attestations=\K[0-9]+' | head -1)
+    EV_COMMIT_ATT=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|.*\|commit_attestations=\K[0-9]+' | head -1)
+    EV_SENDS=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|.*\|script_sends=\K[0-9]+' | head -1)
+    EV_ACTION_SUM=$(( ${EV_SEND_ATT:-0} + ${EV_COMMIT_ATT:-0} ))
+    if [ "${EV_ATT:-0}" -eq 0 ]; then
         gk_fail "L24-02" "No execution attestations recorded" "audit.level or provenance.record_attestations is not in effect"
+    elif [ "${EV_ATT:-0}" -ne "$EV_ACTION_SUM" ]; then
+        fail "L24-02" "Attestations with an unaccounted action" \
+            "total=${EV_ATT:-?} but send=${EV_SEND_ATT:-0} + commit=${EV_COMMIT_ATT:-0} = ${EV_ACTION_SUM}"
+    elif [ "${EV_SEND_ATT:-0}" -gt "${EV_SENDS:-0}" ]; then
+        fail "L24-02" "More attested sends than sends attempted" \
+            "send_attestations=${EV_SEND_ATT:-?} script_sends=${EV_SENDS:-?}; phantom attestation"
     else
-        gk_fail "L24-02" "Attestation/send mismatch" "attestations=${EV_ATT:-?} sends=${EV_SENDS:-?}"
+        pass "L24-02" "Execution attestations recorded and accounted (${EV_SEND_ATT:-0} send + ${EV_COMMIT_ATT:-0} commit, ${EV_SENDS:-?} sends attempted)"
     fi
 
     # Fingerprint CONTENT, not presence: the field was empty for every

--- a/examples/living-script_extended/run.sh
+++ b/examples/living-script_extended/run.sh
@@ -33,6 +33,7 @@
 #   Level 21: Engine-side ratchet (signed-but-loosened config refused on reload)
 #   Level 22: Output admissibility (quarantine dispositions + streak accounting)
 #   Level 23: Transcript integrity (entry_hash coverage vs chained TRANSCRIPT_REF)
+#   Level 24: Evidence layer (signed attestations, decision snapshots, chain verify)
 #
 # Levels 19b/21/22/23 exist because the corresponding engine behaviour was
 # configured but unobserved: the Jul 22 run registered two tools and made zero
@@ -503,7 +504,7 @@ assert 'refinement_iterations' in d
     # ============================================================
     echo -e "${CYAN}Level 4: Phase Transitions & Evolution${NC}"
 
-    for phase in TOOL_REGISTRATION PREFLIGHT TOOL_EXEC DESIGN IMPLEMENT REFINE PROPOSE_SELECT FEATURES PARALLEL_REVIEW BATCH_PIPELINE FINAL_REVIEW SCORING INTROSPECTION RATCHET ENGINE_RATCHET HEALTH_PULSE LEASE_EPOCH TELEMETRY_AUDIT TRANSCRIPT_AUDIT CODEGEN_BOUNDARY; do
+    for phase in TOOL_REGISTRATION PREFLIGHT TOOL_EXEC DESIGN IMPLEMENT REFINE PROPOSE_SELECT FEATURES PARALLEL_REVIEW BATCH_PIPELINE FINAL_REVIEW SCORING INTROSPECTION RATCHET ENGINE_RATCHET HEALTH_PULSE LEASE_EPOCH TELEMETRY_AUDIT TRANSCRIPT_AUDIT EVIDENCE_AUDIT CODEGEN_BOUNDARY; do
         if echo "$OUTPUT" | grep -q "PHASE|${phase}|"; then
             pass "L4-$phase" "Phase $phase reached"
         else
@@ -1427,6 +1428,91 @@ assert 'refinement_iterations' in d
     fi
 
     # ============================================================
+    # L24: EVIDENCE LAYER (attestations + decision snapshots)
+    #
+    # The run signs every send and snapshots every CDD decision. Nothing read
+    # either back, and the chain it builds was never verified — the same gap
+    # L19b/21/22/23 exist for. Execution attestations are asserted as a hard
+    # count (deterministic, one per send); refusal attestations are asserted for
+    # AGREEMENT only, because demanding one would require the agent to misbehave.
+    # ============================================================
+    echo -e "${CYAN}Level 24: Evidence Layer${NC}"
+
+    if ! govkill_block "L24-*" 'PHASE|EVIDENCE_AUDIT|'; then
+
+    if echo "$OUTPUT" | grep -q "PHASE|EVIDENCE_AUDIT|start"; then
+        pass "L24-01" "Evidence audit phase reached"
+    else
+        fail "L24-01" "Evidence audit phase not reached"
+    fi
+
+    EV_ATT=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|exec_attestations=\K[0-9]+' | head -1)
+    EV_SENDS=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|exec_attestations=[0-9]+\|sends=\K[0-9]+' | head -1)
+    if [ "${EV_ATT:-0}" -gt 0 ] && [ "${EV_ATT:-0}" -eq "${EV_SENDS:-(-1)}" ]; then
+        pass "L24-02" "One signed execution attestation per send (${EV_ATT}/${EV_SENDS})"
+    elif [ "${EV_ATT:-0}" -eq 0 ]; then
+        gk_fail "L24-02" "No execution attestations recorded" "audit.level or provenance.record_attestations is not in effect"
+    else
+        gk_fail "L24-02" "Attestation/send mismatch" "attestations=${EV_ATT:-?} sends=${EV_SENDS:-?}"
+    fi
+
+    # Fingerprint CONTENT, not presence: the field was empty for every
+    # attestation the engine ever wrote, because the signing key was handed to a
+    # fingerprint function that only accepts public keys. A signature with no
+    # attributable key is not proof of who acted.
+    EV_SIGNED=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|signed=\K[0-9]+' | head -1)
+    EV_FP=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|signed=[0-9]+\|fingerprinted=\K[0-9]+' | head -1)
+    EV_EMPTY_FP=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|.*\|empty_fingerprint=\K[0-9]+' | head -1)
+    if [ "${EV_SIGNED:-0}" -eq "${EV_ATT:-(-1)}" ] && [ "${EV_FP:-0}" -eq "${EV_ATT:-(-1)}" ] \
+       && [ "${EV_EMPTY_FP:-1}" -eq 0 ]; then
+        pass "L24-03" "Every attestation is signed and attributable (${EV_SIGNED} signed, 0 empty fingerprints)"
+    else
+        gk_fail "L24-03" "Attestations unsigned or unattributable" \
+            "signed=${EV_SIGNED:-?} fingerprinted=${EV_FP:-?} empty_fp=${EV_EMPTY_FP:-?} of ${EV_ATT:-?}"
+    fi
+
+    EV_SNAP=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|snapshots=\K[0-9]+' | head -1)
+    EV_SEM=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|snapshots=[0-9]+\|semantic_turns=\K[0-9]+' | head -1)
+    EV_OA=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|.*\|oa_evals=\K[0-9]+' | head -1)
+    EV_EXPECT_SNAP=$(( ${EV_SEM:-0} + ${EV_OA:-0} ))
+    if [ "${EV_SNAP:-0}" -gt 0 ] && [ "${EV_SNAP:-0}" -eq "$EV_EXPECT_SNAP" ]; then
+        pass "L24-04" "Decision snapshots on every scored turn (${EV_SNAP} = ${EV_SEM:-0} semantic + ${EV_OA:-0} OA)"
+    elif [ "${EV_SNAP:-0}" -eq 0 ]; then
+        gk_fail "L24-04" "No decision snapshots recorded" "telemetry.decision_snapshots is not in effect"
+    else
+        gk_fail "L24-04" "Snapshot coverage incomplete" "snapshots=${EV_SNAP:-?} expected=${EV_EXPECT_SNAP} (semantic+OA)"
+    fi
+
+    # Agreement, never a floor. Zero refusals and zero attestations is a pass:
+    # a clean run has nothing to attest.
+    EV_REF=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|refusals=\K[0-9]+' | head -1)
+    EV_REF_ATT=$(echo "$OUTPUT" | grep -oP 'EVIDENCE\|refusals=[0-9]+\|refusal_attestations=\K[0-9]+' | head -1)
+    if [ "${EV_REF:-0}" -eq 0 ]; then
+        pass "L24-05" "No governance refusals this run (nothing to attest)"
+    elif [ "${EV_REF_ATT:-0}" -ge "${EV_REF:-0}" ]; then
+        pass "L24-05" "Every refusal carries an attestation (${EV_REF_ATT}/${EV_REF})"
+    else
+        fail "L24-05" "Refusals without attestations" \
+            "refusals=${EV_REF:-?} attestations=${EV_REF_ATT:-?}; a block with no signed record is unprovable"
+    fi
+
+    # The chain is built on every run and has never been verified.
+    for _chain in telemetry audit; do
+        _cf="$WORKDIR/${_chain}.jsonl"
+        if [ ! -f "$_cf" ]; then
+            gk_fail "L24-06-${_chain}" "${_chain}.jsonl absent" "nothing to verify"
+        elif (cd "$WORKDIR" && "$NAAB" --verify-telemetry-chain "${_chain}.jsonl" 2>&1) \
+                | grep -q "Chain verified:"; then
+            pass "L24-06-${_chain}" "${_chain} hash chain verifies end to end"
+        else
+            fail "L24-06-${_chain}" "${_chain} hash chain BROKEN or TAMPERED" \
+                "$( (cd "$WORKDIR" && "$NAAB" --verify-telemetry-chain "${_chain}.jsonl" 2>&1) | grep -E 'BREAK|TAMPER|CORRUPT' | head -2)"
+        fi
+    done
+
+    fi
+
+    # ============================================================
     # L19b: TOOL EXECUTION (forced) + dual-gate negative control
     # ============================================================
     echo -e "${CYAN}Level 19b: Tool Execution (forced)${NC}"
@@ -1911,5 +1997,8 @@ echo "{\"pass\": $PASS_COUNT, \"fail\": $FAIL_COUNT, \"skip\": $SKIP_COUNT, \"to
 [ -f "${STDERR_FILE:-/dev/null}" ] && cp "$STDERR_FILE" "$RESULTS_DIR/stderr_${TIMESTAMP}.txt" 2>/dev/null || true
 [ -f "${WORKDIR:-/dev/null}/telemetry.jsonl" ] && cp "$WORKDIR/telemetry.jsonl" "$RESULTS_DIR/telemetry_${TIMESTAMP}.jsonl" 2>/dev/null || true
 [ -f "${WORKDIR:-/dev/null}/transcript.jsonl" ] && cp "$WORKDIR/transcript.jsonl" "$RESULTS_DIR/transcript_${TIMESTAMP}.jsonl" 2>/dev/null || true
+# Signed execution attestations live here. Unarchived, they died with WORKDIR —
+# the same "configured but unobserved" gap that L19b/21/22/23 were added for.
+[ -f "${WORKDIR:-/dev/null}/audit.jsonl" ] && cp "$WORKDIR/audit.jsonl" "$RESULTS_DIR/audit_${TIMESTAMP}.jsonl" 2>/dev/null || true
 
 exit "$FAIL_COUNT"

--- a/examples/living-script_extended/src/govern.json
+++ b/examples/living-script_extended/src/govern.json
@@ -26,6 +26,7 @@
     "enabled": true,
     "output_file": "telemetry.jsonl",
     "deduplicate_checks": true,
+    "decision_snapshots": true,
     "tamper_evidence": {
       "enabled": true,
       "algorithm": "sha256",
@@ -34,6 +35,22 @@
     "transcript": {
       "enabled": true,
       "output_file": "transcript.jsonl"
+    }
+  },
+
+  "audit": {
+    "level": "basic",
+    "output_file": "audit.jsonl",
+    "tamper_evidence": {
+      "enabled": true,
+      "algorithm": "sha256",
+      "chain_genesis": "living-script-audit"
+    },
+    "provenance": {
+      "enabled": true,
+      "record_attestations": true,
+      "sign_records": true,
+      "signing_key_env": "NAAB_SIGNING_KEY"
     }
   },
 

--- a/examples/living-script_extended/src/living-script.naab
+++ b/examples/living-script_extended/src/living-script.naab
@@ -271,6 +271,23 @@ fn count_telemetry(pattern) {
     return count_lines_matching("telemetry.jsonl", pattern)
 }
 
+// Fixed-string counter. Needed for the audit file, whose attestation bodies are
+// escaped JSON inside a "message" string: the pattern must match a literal
+// \"signature\": sequence. process.run() passes argv with no shell in between,
+// so grep sees ONE backslash and its BRE reads \" as a plain " — which never
+// matches the escaped text. -F sidesteps the escaping layer entirely.
+fn count_fixed_matching(path, pattern) {
+    try {
+        let g = process.run("grep", ["-c", "-F", pattern, path])
+        if g.exit_code != 0 { return "0" }
+        let s = string.trim(g.stdout)
+        if len(s) == 0 { return "0" }
+        return s
+    } catch (e) {
+        return "0"
+    }
+}
+
 fn write_govern_raw(config) {
     let signing_key_path = env.get("NAAB_SIGN_PATH", "")
     let naab_binary = env.get("NAAB_BINARY", "naab-lang")
@@ -1901,6 +1918,47 @@ main {
     print("TRANSCRIPT_AUDIT|every_entry_hashed=" + string(len(ta_lines) > 0 && ta_lines == ta_hashed))
     print("TRANSCRIPT_AUDIT|ref_matches_entries=" + string(len(ta_refs) > 0 && ta_refs == ta_lines))
     tracking["phases_completed"].push("TRANSCRIPT_AUDIT")
+
+    // ================================================================
+    // PHASE: EVIDENCE_AUDIT — attestations + decision snapshots (Level 24)
+    // ================================================================
+    // The run signs every send and snapshots every CDD decision, and until now
+    // nothing read either back. Two distinct populations, deliberately asserted
+    // differently:
+    //
+    //   Execution attestations are DETERMINISTIC — emitAttestation() fires once
+    //   per agent.send() whenever provenance is on, so the count is a hard
+    //   expectation against total_sends.
+    //
+    //   Refusal attestations only exist when governance actually blocked
+    //   something. Asserting a floor on them would demand the agent misbehave,
+    //   so this compares refusals to refusal-attestations and checks they AGREE.
+    //   Zero of both is a pass; refusals with no attestation is the failure.
+    //
+    // Attestation bodies live escaped inside the audit record's "message"
+    // string, hence the \" patterns. Counting stays in grep/wc for the same
+    // reason TRANSCRIPT_AUDIT does it: decision_snapshots pushes telemetry past
+    // a megabyte and it must never enter script memory.
+    print("PHASE|EVIDENCE_AUDIT|start")
+
+    let ev_attest = count_lines_matching("audit.jsonl", "execution_attestation")
+    let ev_signed = count_fixed_matching("audit.jsonl", "\\\"signature\\\":")
+    let ev_empty_fp = count_fixed_matching("audit.jsonl", "\\\"key_fingerprint\\\":\\\"\\\"")
+    let ev_fp = count_fixed_matching("audit.jsonl", "\\\"key_fingerprint\\\":")
+    print("EVIDENCE|exec_attestations=" + ev_attest + "|sends=" + string(tracking["total_sends"]))
+    print("EVIDENCE|signed=" + ev_signed + "|fingerprinted=" + ev_fp + "|empty_fingerprint=" + ev_empty_fp)
+
+    // cdd_snapshot is embedded structurally, so a bare key match is enough.
+    let ev_snap = count_telemetry("\"cdd_snapshot\":")
+    let ev_semantic = count_telemetry("SEMANTIC_TURN")
+    let ev_oa = count_telemetry("OUTPUT_ADMISSIBILITY_EVAL")
+    print("EVIDENCE|snapshots=" + ev_snap + "|semantic_turns=" + ev_semantic + "|oa_evals=" + ev_oa)
+
+    let ev_refusals = count_telemetry("RuleViolation")
+    let ev_refusal_att = count_telemetry("RefusalAttestation")
+    print("EVIDENCE|refusals=" + ev_refusals + "|refusal_attestations=" + ev_refusal_att)
+
+    tracking["phases_completed"].push("EVIDENCE_AUDIT")
 
     // ================================================================
     // PHASE: CODEGEN_BOUNDARY — codegen strict failure path (Level 18)

--- a/examples/living-script_extended/src/living-script.naab
+++ b/examples/living-script_extended/src/living-script.naab
@@ -1942,10 +1942,17 @@ main {
     print("PHASE|EVIDENCE_AUDIT|start")
 
     let ev_attest = count_lines_matching("audit.jsonl", "execution_attestation")
+    let ev_send_att = count_fixed_matching("audit.jsonl", "\\\"action\\\":\\\"send\\\"")
+    let ev_commit_att = count_fixed_matching("audit.jsonl", "\\\"action\\\":\\\"commit\\\"")
     let ev_signed = count_fixed_matching("audit.jsonl", "\\\"signature\\\":")
     let ev_empty_fp = count_fixed_matching("audit.jsonl", "\\\"key_fingerprint\\\":\\\"\\\"")
     let ev_fp = count_fixed_matching("audit.jsonl", "\\\"key_fingerprint\\\":")
-    print("EVIDENCE|exec_attestations=" + ev_attest + "|sends=" + string(tracking["total_sends"]))
+    // script_sends is reported for forensics, NOT asserted as an equality.
+    // agent.commit() attests too, and safe_send() increments the counter even
+    // when the send was blocked and never reached emitAttestation — so exact
+    // equality would depend on agent behaviour. That is the same reason the
+    // refusal check below asserts agreement rather than a floor.
+    print("EVIDENCE|exec_attestations=" + ev_attest + "|send_attestations=" + ev_send_att + "|commit_attestations=" + ev_commit_att + "|script_sends=" + string(tracking["total_sends"]))
     print("EVIDENCE|signed=" + ev_signed + "|fingerprinted=" + ev_fp + "|empty_fingerprint=" + ev_empty_fp)
 
     // cdd_snapshot is embedded structurally, so a bare key match is enough.

--- a/src/runtime/governance_reports.cpp
+++ b/src/runtime/governance_reports.cpp
@@ -471,7 +471,12 @@ void GovernanceEngine::emitAttestation(const std::string& action_type,
                 std::string pem((std::istreambuf_iterator<char>(kf)),
                                  std::istreambuf_iterator<char>());
                 att["signature"] = security::CryptoUtils::ed25519Sign(att.dump(), pem);
-                att["key_fingerprint"] = security::CryptoUtils::ed25519Fingerprint(pem);
+                // Fingerprint the PUBLIC half. ed25519Fingerprint() reads with
+                // PEM_read_bio_PUBKEY and deliberately refuses private keys, so
+                // handing it the signing key silently produced "" — a valid
+                // signature with no key to attribute it to.
+                att["key_fingerprint"] = security::CryptoUtils::ed25519Fingerprint(
+                    security::CryptoUtils::ed25519PublicFromPrivate(pem));
             }
         } catch (...) {}
     }
@@ -570,7 +575,9 @@ void GovernanceEngine::emitRefusalAttestation(
                 std::string pem((std::istreambuf_iterator<char>(kf)),
                                  std::istreambuf_iterator<char>());
                 ev["signature"] = security::CryptoUtils::ed25519Sign(ev.dump(), pem);
-                ev["key_fingerprint"] = security::CryptoUtils::ed25519Fingerprint(pem);
+                // Public half — see emitAttestation() for why.
+                ev["key_fingerprint"] = security::CryptoUtils::ed25519Fingerprint(
+                    security::CryptoUtils::ed25519PublicFromPrivate(pem));
             }
         } catch (...) {}
     }
@@ -659,7 +666,9 @@ void GovernanceEngine::emitOutputAdmissibilityAttestation(
                 std::string pem((std::istreambuf_iterator<char>(kf)),
                                  std::istreambuf_iterator<char>());
                 ev["signature"] = security::CryptoUtils::ed25519Sign(ev.dump(), pem);
-                ev["key_fingerprint"] = security::CryptoUtils::ed25519Fingerprint(pem);
+                // Public half — see emitAttestation() for why.
+                ev["key_fingerprint"] = security::CryptoUtils::ed25519Fingerprint(
+                    security::CryptoUtils::ed25519PublicFromPrivate(pem));
             }
         } catch (...) {}
     }

--- a/tests/governance_v4/test_nonformation_proof.sh
+++ b/tests/governance_v4/test_nonformation_proof.sh
@@ -204,10 +204,16 @@ else
     fail "C-04" "binding_status missing" "${ATT:0:200}"
 fi
 
-if echo "$ATT" | grep -q '"signature":"' && echo "$ATT" | grep -q '"key_fingerprint":"'; then
-    pass "C-05" "attestation is Ed25519-signed with a key fingerprint"
+# Assert the fingerprint's CONTENT, not its presence. The original check was
+# '"key_fingerprint":"' which also matches an empty value — and the field was in
+# fact always empty, because the signing (private) key was handed to
+# ed25519Fingerprint(), which only accepts public keys. A signature you cannot
+# attribute to a key is not proof of who refused.
+if echo "$ATT" | grep -qE '"signature":"[A-Za-z0-9+/=]{40,}"' &&
+   echo "$ATT" | grep -qE '"key_fingerprint":"[0-9a-f]{16,}"'; then
+    pass "C-05" "attestation is Ed25519-signed and the key fingerprint is non-empty"
 else
-    fail "C-05" "attestation unsigned" "${ATT:0:200}"
+    fail "C-05" "attestation unsigned or fingerprint empty" "${ATT:0:300}"
 fi
 
 # ============================================================


### PR DESCRIPTION
## Summary

`living-script_extended` demonstrated 23 governance levels and produced **zero signed attestations** — `telemetry.tamper_evidence` was on with no `audit` section at all. It also built a tamper-evident chain nothing ever verified, and archived telemetry and transcript but no audit file. Two more instances of the "configured but unobserved" gap its own `run.sh` header records as the reason levels 19b/21/22/23 exist.

## The defect this surfaced

Validating the config against the stub *before* writing the level found a real bug:

`ed25519Fingerprint()` reads with `PEM_read_bio_PUBKEY` and refuses private keys by design, but all three `emit*Attestation` sites handed it the **signing** key. Fingerprinting silently returned `""` into the surrounding `catch (...) {}`. **Every signed attestation NAAb has ever written carries a signature that cannot be attributed to a key.**

Fixed by fingerprinting the derived public half via the existing `ed25519PublicFromPrivate()`, matching how `governance_engine.cpp:4123` already does it. The fingerprint now equals what the trust store reports for the same key:

```
attestation key_fingerprint: c223415f60114f4d8f861d8be037e59f
naab-lang --list-keys:       c223415f60114f4d8f861d8be037e59f
```

**The C-05 assertion merged in #104 could not have caught this** — it greps `'"key_fingerprint":"'`, which also matches `""`. Tightened to require hex content. The new level asserts fingerprint *content* for the same reason.

## Why the level is shaped this way

The two attestation kinds go to different files behind different gates:

| Kind | Destination | Gate |
|---|---|---|
| Refusal | telemetry | `provenance.enabled` + `record_attestations` |
| Execution | audit | above **+ `audit.level != "none"`** (defaults to `none`) |

Refusal attestations only exist when governance actually blocked something, so asserting a floor on them would demand the agent misbehave. Refusals are checked for **agreement** with their attestations instead — zero of both is a pass. That's also why `audit.level` and archiving the audit file are required, not optional.

**The live run corrected L24-02.** It first asserted one attestation per script-counted send, and failed: 22 attestations vs 21 sends. Adding commits to the denominator would not have fixed it either — 21 + 2 = 23, not 22. Exact equality is not a sound invariant here for three reasons: `agent.commit()` attests as well as `agent.send()` (`agent_impl.cpp:5382`); `safe_send()` bumps the counter even when a send was blocked before reaching `emitAttestation`, making equality swing on agent behaviour; and `agent.run`/`batch`/`fan_out`/`pipeline` each bump it by 1–2 with per-API attestation semantics.

The second reason is precisely why L24-05 asserts agreement rather than a floor — reasoned out for that check, then not applied to its neighbour. L24-02 now asserts only what is behaviour-independent: attestations exist, every one carries a known action (`send + commit` must sum to the total), and attested sends cannot outnumber attempted sends.

## Changes

- **`src/runtime/governance_reports.cpp`** — fingerprint the derived public key at all 3 attestation sites. `trust_store.cpp` untouched; it already receives a public PEM.
- **`tests/governance_v4/test_nonformation_proof.sh`** — C-05 requires `[0-9a-f]{16,}`, not mere presence.
- **`src/govern.json`** — `audit` section (`level: basic`, `tamper_evidence`, `provenance` with `signing_key_env`, not a literal path — the key lives in an ephemeral `$TEST_TMP`) plus `telemetry.decision_snapshots`.
- **`src/living-script.naab`** — new `EVIDENCE_AUDIT` phase. Counting stays in grep/wc because `decision_snapshots` pushes telemetry past a megabyte and it must not enter script memory. Added a `-F` helper: `process.run` passes argv with no shell, so grep sees one backslash and its BRE reads `\"` as a plain `"`, which never matches the escaped attestation body.
- **`run.sh`** — Level 24 assertions, archive `audit.jsonl`, and verify **both** chains.

## Test Plan

- [x] `bash run-all-tests.sh` — **441 tests, 0 unexpected failures**
- [x] `test_nonformation_proof.sh` 15/15 with the tightened C-05
- [x] `tests/security/test_error_msg_leaks.sh` — 874/0 (attestation code touched)
- [x] End-to-end **without live keys**, via `tests/helpers/agent_stub.py`: 3 sends → 3 execution attestations, all signed with non-empty fingerprints, `cdd_snapshot` on every `SEMANTIC_TURN` and `OUTPUT_ADMISSIBILITY_EVAL` (6 = 3+3), both chains `Chain verified:`
- [x] The real phase code, extracted verbatim from the script, run against those real files — correct markers
- [x] Every L24 assertion checked against its own degraded case; each fails only there (`record_attestations` off, unaccounted action type, phantom attestations, `decision_snapshots` off, partial snapshot coverage)
- [x] `parse` clean; `check` diagnostics unchanged at 35; `run.sh` passes `bash -n`; `govern.json` valid JSON
- [x] **Live keyed run against the Gemini API**:
  - **L24-03 — 22 signed attestations, 0 empty fingerprints.** The defect this PR fixes, confirmed on real data against the pre-fix state where every fingerprint was empty.
  - **L24-04 — 43 snapshots = 21 semantic + 22 OA.** Both chains verified.
  - **The `audit` section survived 15 accepted operator rewrites**, with `record_attestations: true` intact and no ratchet rejection touching provenance. That was the highest-risk item.
  - Telemetry grew ~550 KB → 1.3 MB, confirming `decision_snapshots` landing.
  - **L24 proven load-bearing**: with `record_attestations: false`, re-signed and re-run, L24-02 was the only failure.
- [x] The L24-02 correction re-verified against the live-reported numbers: `22 = 20 send + 2 commit` with 21 attempted now passes, while the degraded cases still fail.

## Notes

L24-03 reads PASS when there are zero attestations (0-of-0 signed), but L24-02 catches that case, so the pair is complete.

Left deliberately out of scope: the pre-existing `NAAB_SIGN_PATH` / `NAAB_SIGNING_KEY` naming mismatch; and `taint_tracking` / `temporal_coupling` / `integrity`, each of which needs a deliberate observable sink to avoid being inert.