### PR TITLE
Split the Windows test step so a killed runner is diagnosable

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -114,9 +114,25 @@ jobs:
           NAAB
           ./build/naab-lang.exe --no-governance pytest.naab
 
-      - name: CLI tests
+      # Split so a killed runner is diagnosable. This job has stalled twice —
+      # the step sits in_progress for ~50 minutes, the runner is terminated,
+      # and GitHub uploads no logs (the archive 404s), so the only surviving
+      # evidence is per-step metadata: which step was running, and when it
+      # started. One monolithic step reduces that to "it died in the tests".
+      #
+      # Both stalls were on commits that could not have caused them — one was
+      # a docs-and-comments diff against a commit that had just passed in 13
+      # minutes — and both cleared on an unchanged re-run, which is why the
+      # working diagnosis is the runner rather than a hang. That diagnosis is
+      # currently unfalsifiable, and these steps are what make it testable: if
+      # future stalls cluster in one phase, the runner is not the cause.
+      - name: CLI tests — NAAb programs
         shell: msys2 {0}
-        run: bash run-all-tests.sh
+        run: NAAB_TEST_PHASE=naab bash run-all-tests.sh
+
+      - name: CLI tests — shell suites
+        shell: msys2 {0}
+        run: NAAB_TEST_PHASE=shell bash run-all-tests.sh
 
   build-linux:
     runs-on: ubuntu-latest

--- a/run-all-tests.sh
+++ b/run-all-tests.sh
@@ -249,6 +249,31 @@ run_shell_test() {
     return "$rc"
 }
 
+# --- Phase selection ----------------------------------------------------------
+#
+# NAAB_TEST_PHASE=all (default) | naab | shell
+#
+# Exists for CI diagnosability, not for skipping work. When a runner is killed
+# mid-job, GitHub uploads no logs — a 404 — but the per-step metadata (which
+# step was in progress, when it started) SURVIVES. That metadata is the only
+# reason we know the Windows stalls happen inside `CLI tests` at all.
+#
+# One monolithic step therefore gives one bit of information: "it died in the
+# tests". Splitting the run across steps costs nothing and turns "probably
+# infrastructure" into a claim that can be checked — if stalls cluster in one
+# phase, that is a lead; if they scatter, that is evidence for the runner.
+#
+# Phases only gate WHICH tests run, never how they are judged: each phase exits
+# non-zero on its own failures, so no failure can hide in an unrun phase.
+NAAB_TEST_PHASE="${NAAB_TEST_PHASE:-all}"
+case "$NAAB_TEST_PHASE" in
+    all|naab|shell) ;;
+    *)
+        echo "Error: NAAB_TEST_PHASE must be all, naab, or shell (got: $NAAB_TEST_PHASE)" >&2
+        exit 1 ;;
+esac
+phase_runs() { [ "$NAAB_TEST_PHASE" = "all" ] || [ "$NAAB_TEST_PHASE" = "$1" ]; }
+
 # Function to check if a path should be skipped
 should_skip() {
     local file_path="$1"
@@ -352,6 +377,7 @@ run_test() {
 }
 
 # Run tests from each directory
+if phase_runs naab; then
 for dir in "${TEST_DIRS[@]}"; do
     if [ ! -d "$dir" ]; then
         continue
@@ -454,7 +480,9 @@ for f in tests/type_system/valid/*.naab; do
     fi
     rm -f "$output_file"
 done
+fi  # phase_runs naab
 
+if phase_runs shell; then
 # --- Property-Based Tests ---
 echo ""
 echo "═══════════════════════════════════════════════════════════"
@@ -499,7 +527,17 @@ else
     echo "  LSP test script or naab-lsp binary not found, skipping"
 fi
 
+fi  # phase_runs shell — closed here; the VM block below is a naab-phase block
+
 # --- Bytecode VM Tests ---
+# These are .naab programs re-run under --vm sharing TOTAL/PASSED with the main
+# .naab loop, so they belong to the naab phase even though they sit between two
+# shell suites. The surrounding shell region is closed and reopened around them
+# rather than nesting the gate: a `phase_runs naab` test INSIDE the shell region
+# can never be true, which silently dropped all 19 of these from both phases.
+# Gated in place rather than moved — reordering would change what runs before
+# what, and this is the only TOTAL increment outside the main loop.
+if phase_runs naab; then
 echo ""
 echo "═══════════════════════════════════════════════════════════"
 echo "  Bytecode VM Tests (--vm)"
@@ -537,7 +575,9 @@ if [ -d "$VM_TEST_DIR" ]; then
 else
     echo "  No VM test directory (tests/vm/), skipping"
 fi
+fi  # phase_runs naab (Bytecode VM Tests)
 
+if phase_runs shell; then
 # --- Report Format Tests ---
 echo ""
 echo "═══════════════════════════════════════════════════════════"
@@ -2054,11 +2094,15 @@ if [ -f "$CANARY_SCRIPT" ]; then
 else
     echo "  test_prescan_canaries.sh: not found, skipping"
 fi
+fi  # phase_runs shell
 
 # Print summary
 echo ""
 echo "═══════════════════════════════════════════════════════════"
 echo "  TEST SUMMARY"
+if [ "$NAAB_TEST_PHASE" != "all" ]; then
+    echo "  (phase: $NAAB_TEST_PHASE — counts cover this phase only)"
+fi
 echo "═══════════════════════════════════════════════════════════"
 echo ""
 echo "Total Tests:        $TOTAL"
@@ -2072,8 +2116,13 @@ if [ $SKIPPED -gt 0 ]; then
 fi
 ACCOUNTED=$((PASSED + ERROR_BEHAVIOR + MISSING_EXECUTOR + NEEDS_TREE_WALK))
 echo ""
-echo "  Accounted for:    $ACCOUNTED / $TOTAL ($(awk "BEGIN {printf \"%.1f\", ($ACCOUNTED/$TOTAL)*100}")%)"
-echo ""
+# TOTAL counts .naab programs only, so it is 0 in the shell-only phase — the
+# percentage would divide by zero. Shell suites are judged by $FAILED below,
+# which is shared across phases.
+if [ "$TOTAL" -gt 0 ]; then
+    echo "  Accounted for:    $ACCOUNTED / $TOTAL ($(awk "BEGIN {printf \"%.1f\", ($ACCOUNTED/$TOTAL)*100}")%)"
+    echo ""
+fi
 
 if [ $FAILED -gt 0 ]; then
     echo "Unexpected Failures:"
@@ -2082,8 +2131,12 @@ if [ $FAILED -gt 0 ]; then
     done
     echo ""
     exit 1
-else
+elif [ "$TOTAL" -gt 0 ]; then
     echo "ALL $TOTAL TESTS ACCOUNTED FOR ($PASSED passed + $ERROR_BEHAVIOR error behavior + $MISSING_EXECUTOR missing executor + $NEEDS_TREE_WALK needs tree-walk)"
+    echo ""
+    exit 0
+else
+    echo "ALL SHELL TEST SUITES PASSED"
     echo ""
     exit 0
 fi


### PR DESCRIPTION
## Summary

`build-windows` has stalled twice: the step sits `in_progress` for ~50 minutes, the runner is terminated, and GitHub uploads **no logs at all** — the archive 404s.

Both stalls were on commits that could not have caused them (one was a docs-and-comments diff against a commit that had just passed in 13 minutes), and both cleared on an unchanged re-run. So the working diagnosis is the runner, not a hang.

That diagnosis is currently **unfalsifiable**, and "probably infrastructure" is exactly the reasoning that lets a real Windows regression through — I already made that error in the opposite direction once, calling a runner stall a regression. This makes the claim testable.

### Why splitting steps works

What survives a killed runner is **per-step metadata** — which step was running, and when it started. That metadata is the only reason we know the stalls happen inside `CLI tests` at all; the logs are simply gone.

One monolithic step therefore yields one bit of information: *it died in the tests*. Two steps double the resolution for free. If future stalls cluster in one phase, the runner is not the cause and there's a real hang to find; if they scatter, that's genuine evidence for infrastructure rather than an argument from absence.

## Changes

- **`run-all-tests.sh`** — `NAAB_TEST_PHASE=all|naab|shell` (default `all`, so every other caller is unaffected). Phases gate only **which** tests run, never how they are judged: each phase exits non-zero on its own failures, so nothing can hide in an unrun phase. An unrecognised value is rejected rather than silently treated as a filter.
- **`.github/workflows/windows.yml`** — `CLI tests` becomes `CLI tests — NAAb programs` and `CLI tests — shell suites`.

## Two defects found while verifying

Both were invisible from pass/fail, and are the reason this took three verification rounds:

1. **Wrong phase.** The bytecode VM block re-runs `.naab` programs under `--vm` and shares `TOTAL`/`PASSED` with the main loop, but sits physically *between* two shell suites. The first split filed 19 NAAb-program tests under a step labelled "shell suites" — correct coverage, lying step name, which defeats the entire point when the step name *is* the diagnostic.

2. **No phase.** Fixing that by nesting a `phase_runs naab` gate inside the `phase_runs shell` region was worse: the two conditions can never both hold, so all 19 ran in **neither** phase. Both phases still exited 0 and printed clean summaries while running 19 fewer tests than claimed. Only checking the count against the known 441 caught it.

The gates are now **flat rather than nested** — four alternating regions — so that failure mode is structurally unavailable rather than merely avoided.

## Test Plan

- [x] Ran `bash run-all-tests.sh` with no new failures — default `all` path unchanged
- [x] Added/updated tests for new functionality — n/a for the runner itself; verified by coverage comparison below
- [ ] Tested manually in the REPL — n/a, CI harness

| phase | tests | unexpected fails | shell suites |
|---|---|---|---|
| `naab` | **441** (376 + 52 + 1 + 12) | 0 | — |
| `shell` | 0 | 0 | 92, **0 missing** vs the full run |

`naab` matches the full-run total exactly. `comm` against the full run shows every shell suite also runs in the shell phase (92 vs 91 — the phase has one *more*, since `test_prescan_canaries.sh` skips on a dirty tree). An invalid `NAAB_TEST_PHASE` is rejected with a non-zero exit.

## Related Issues

Follow-up to #110, which bounded hung suites. This addresses the different failure the bound cannot catch — the runner dying beneath the script.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC)_