### PR TITLE
Make govern.json sandbox settings reach every execution path

### DIFF
--- a/.github/workflows/windows.yml
+++ b/.github/workflows/windows.yml
@@ -126,12 +126,31 @@ jobs:
       # working diagnosis is the runner rather than a hang. That diagnosis is
       # currently unfalsifiable, and these steps are what make it testable: if
       # future stalls cluster in one phase, the runner is not the cause.
+      #
+      # timeout-minutes is the other half of that. Without it a stall runs to
+      # GitHub's 360-minute job default and the runner is killed service-side,
+      # which is precisely the case where no logs are uploaded — so the stall we
+      # most want to read is the one that leaves nothing to read. A step-level
+      # timeout is enforced by the runner itself: the step is marked failed and
+      # the logs it produced are still uploaded. That turns each stall from an
+      # anecdote into a transcript naming where it stopped.
+      #
+      # Bounds are set off measured times, with room for a slow runner:
+      #   NAAb programs   57s observed  -> 15
+      #   shell suites  3m37s observed  -> 25
+      # The shell bound also has to clear one legitimate SHELL_TEST_TIMEOUT
+      # (600s + 30s kill grace) firing inside an otherwise healthy run, or a
+      # single hung suite would take the whole step down as a timeout and hide
+      # which suite it was — the wrapper's failure line is the more specific
+      # evidence, so it must be allowed to print.
       - name: CLI tests — NAAb programs
         shell: msys2 {0}
+        timeout-minutes: 15
         run: NAAB_TEST_PHASE=naab bash run-all-tests.sh
 
       - name: CLI tests — shell suites
         shell: msys2 {0}
+        timeout-minutes: 25
         run: NAAB_TEST_PHASE=shell bash run-all-tests.sh
 
   build-linux:

--- a/run-all-tests.sh
+++ b/run-all-tests.sh
@@ -1787,6 +1787,21 @@ else
 fi
 
 # Evidence chain hardening (cross-run continuity, decision snapshots, transcript refs)
+# govern.json sandbox settings reach the VM path and the tree-walker path through
+# separate code; this asserts they agree. The VM keeps its inline block on
+# purpose, so nothing but this test prevents the two drifting.
+SANDBOX_PARITY_SCRIPT="tests/governance_v4/test_sandbox_engine_parity.sh"
+if [ -f "$SANDBOX_PARITY_SCRIPT" ]; then
+    if run_shell_test "$SANDBOX_PARITY_SCRIPT" 2>&1; then
+        echo "  test_sandbox_engine_parity.sh: ALL PASSED"
+    else
+        FAILED=$((FAILED + 1))
+        FAILED_TESTS+=("test_sandbox_engine_parity.sh")
+    fi
+else
+    echo "  test_sandbox_engine_parity.sh: not found, skipping"
+fi
+
 # Taint tracking is implemented twice (AST walk vs VM taint_stack_); this is the
 # only thing that checks the two agree. tests/differential/ cannot — it runs
 # --no-governance, so taint is switched off there.

--- a/src/cli/main.cpp
+++ b/src/cli/main.cpp
@@ -154,6 +154,76 @@ static void syncGovernanceToSandbox(
     }
 }
 
+// Apply govern.json's sandbox settings — level, fail-closed upgrade, and
+// capability sync — to the config and the live sandbox.
+//
+// This logic lived inline inside `if (use_vm)`, so under --tree-walk every
+// govern.json sandbox setting was silently inert: shell.enabled:false left
+// SYS_EXEC in place, network.enabled:false left NET_CONNECT, and
+// security.sandbox_level was never applied at all. A config that reads as locked
+// down enforced nothing on a supported engine.
+//
+// The level rebuild has to be here and not just the capability sync: applying
+// capabilities on top of a still-CLI-derived (unrestricted) config strips
+// SYS_EXEC and NET_CONNECT but leaves the filesystem open, which looks correct
+// on a shell probe and leaves sandbox_level inert.
+//
+// The VM path still has an equivalent block inline. test_sandbox_engine_parity.sh
+// asserts the two agree — a shared helper alone would not have caught the taint
+// engines drifting either; the missing piece there was a test, not a refactor.
+static void applyGovernanceSandbox(
+    const naab::governance::GovernanceRules& rules,
+    naab::security::SandboxConfig& config,
+    std::string& sandbox_level,
+    unsigned int timeout,
+    unsigned int memory_limit,
+    bool enforce_mode)
+{
+    bool level_changed = false;
+    if (!rules.sandbox_level_config.empty() && sandbox_level == "unrestricted") {
+        sandbox_level = rules.sandbox_level_config;
+        level_changed = true;
+        if (sandbox_level == "restricted") {
+            config = naab::security::SandboxConfig::fromPermissionLevel(
+                naab::security::PermissionLevel::RESTRICTED);
+        } else if (sandbox_level == "standard") {
+            config = createEnterpriseConfig();
+        } else if (sandbox_level == "elevated") {
+            config = naab::security::SandboxConfig::fromPermissionLevel(
+                naab::security::PermissionLevel::ELEVATED);
+        }
+        config.max_cpu_seconds = timeout;
+        config.max_memory_mb = memory_limit;
+    }
+    if (enforce_mode && rules.sandbox_level_config.empty() &&
+        sandbox_level == "unrestricted") {
+        sandbox_level = "standard";
+        config = createEnterpriseConfig();
+        config.max_cpu_seconds = timeout;
+        config.max_memory_mb = memory_limit;
+        level_changed = true;
+        fmt::print(stderr,
+            "[governance] Sandbox: upgraded unrestricted → standard "
+            "(enforce mode; set security.sandbox_level in govern.json to override)\n");
+    }
+    syncGovernanceToSandbox(rules, config);
+    naab::security::SandboxManager::instance().setDefaultConfig(config);
+    auto* live = naab::security::ScopedSandbox::getCurrent();
+    if (!live) return;
+    if (level_changed) live->replaceConfig(config);
+    if (!rules.network_allowed) {
+        live->setNetworkEnabled(false);
+        live->removeCapability(naab::security::Capability::NET_CONNECT);
+    }
+    if (!rules.shell_allowed) {
+        live->setAllowExec(false);
+        live->removeCapability(naab::security::Capability::SYS_EXEC);
+    }
+    if (!rules.capabilities.env_vars.read) {
+        live->removeCapability(naab::security::Capability::SYS_ENV);
+    }
+}
+
 // Phase 7c: Initialize language registry with available executors
 void initialize_executors() {
     auto& registry = naab::runtime::LanguageRegistry::instance();
@@ -2468,6 +2538,15 @@ int main(int argc, char** argv) {
                 // Clear dangling governance pointer before vm_governance goes out of scope
                 naab::governance::GovernanceEngine::setCurrent(nullptr);
             } else {
+                // govern.json sandbox settings reached only the VM path; this is
+                // the tree-walker's equivalent of the block in `if (use_vm)`.
+                if (gov_loaded && !no_governance && shared_governance.isActive()) {
+                    applyGovernanceSandbox(
+                        shared_governance.getRules(), security_config, sandbox_level,
+                        timeout, memory_limit,
+                        shared_governance.getMode() ==
+                            naab::governance::GovernanceMode::ENFORCE);
+                }
                 // V-LSP-005: lint-only gate for tree-walker path.
                 if (lint_only) {
                     auto* gov = interpreter.getGovernance();

--- a/src/interpreter/call_dispatch.cpp
+++ b/src/interpreter/call_dispatch.cpp
@@ -12,6 +12,7 @@
 #include "naab/stdlib_new_modules.h"
 #include "naab/struct_registry.h"
 #include "naab/error_helpers.h"
+#include "naab/sandbox.h"   // async fn must reactivate the parent sandbox on its worker thread
 #ifndef _WIN32
 #include "naab/js_executor_adapter.h"
 #endif
@@ -169,7 +170,16 @@ NaabVal Interpreter::callFunction(NaabVal fn,
         // V-CONC-005: Shallow-copy global env to avoid data race on shared map.
         // Async functions get a snapshot of globals — writes don't propagate back.
         auto global_copy = global->shallowCopy();
-        auto shared_future = std::async(std::launch::async, [body, func_env, global_copy, func_name, gov_path, parent_taint, parent_counters, taint_flag]() -> NaabVal {
+        // The sandbox is thread_local, so a worker thread starts with none — and
+        // every capability check fails OPEN on a null sandbox ("No sandbox active
+        // → allow"). Without this, an async fn ran unsandboxed: absolute-path
+        // reads permitted, polyglot subprocesses uncontained. Taint, counters and
+        // the governance config were already propagated below; the sandbox was
+        // the one piece of parent state left behind. Same capture-and-reactivate
+        // shape as the agent batch/fan_out pool (agent_impl.cpp, "GAP 7").
+        auto sandbox_config = naab::security::SandboxManager::instance().getDefaultConfig();
+        auto shared_future = std::async(std::launch::async, [body, func_env, global_copy, func_name, gov_path, parent_taint, parent_counters, taint_flag, sandbox_config]() -> NaabVal {
+            naab::security::ScopedSandbox async_sandbox(sandbox_config);
             Interpreter async_interp;
             async_interp.setGlobalEnv(global_copy);
 

--- a/src/vm/vm.cpp
+++ b/src/vm/vm.cpp
@@ -3689,9 +3689,16 @@ bool VM::callValue(interpreter::NaabVal callee, int argc) {
 
             // Thread-local handle allocators ensure each async thread gets its
             // own handle range — no cross-thread handle reuse, no TOCTOU race.
+            // The sandbox is thread_local and every capability check fails OPEN on
+            // a null one, so an async fn ran with no enforcement at all — absolute
+            // paths readable, polyglot subprocesses uncontained — regardless of
+            // govern.json. Propagate it, same as the agent batch/fan_out pool does.
+            auto async_sandbox_config =
+                security::SandboxManager::instance().getDefaultConfig();
             auto shared_future = std::async(std::launch::async,
-                [closure_copy, args, async_stdlib, file, globals_copy,
+                [closure_copy, args, async_stdlib, file, globals_copy, async_sandbox_config,
                  owned_fns = std::move(async_owned_fns)]() mutable -> interpreter::NaabVal {
+                    security::ScopedSandbox async_sandbox(async_sandbox_config);
                     interpreter::NaabVal safe_result;
                     {
                         VM async_vm;

--- a/tests/governance_v4/test_sandbox_engine_parity.sh
+++ b/tests/governance_v4/test_sandbox_engine_parity.sh
@@ -42,6 +42,29 @@ pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo -e "  ${GREEN}PASS${NC} [$1] $2"; 
 fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo -e "  ${RED}FAIL${NC} [$1] $2"; [ -n "${3:-}" ] && echo -e "       ${RED}-> $3${NC}"; FAILURES="${FAILURES}\n  [$1] $2"; }
 skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo -e "  ${YELLOW}SKIP${NC} [$1] $2"; }
 
+# POSIX-only, same as test_subprocess_containment.sh. Every probe here asserts a
+# filesystem decision about an ABSOLUTE path, and that is not portable to the
+# Windows job: naab-lang is a native binary running under an MSYS2 harness, so an
+# MSYS path like /etc/hostname or /tmp/... is not a path it can open. The read
+# then fails for file-not-found rather than sandbox denial, which is
+# indistinguishable from a block — and the "elevated must ALLOW" control fails,
+# correctly reporting that the probe cannot tell the two apart. That is the same
+# trap that broke test_nonformation_proof.sh on Windows in #104.
+#
+# The engine-parity guard this file provides is not weakened much: build-linux
+# and Build & Test both run it, so a VM/tree-walker divergence still fails CI.
+case "$(uname -s)" in
+    MINGW*|MSYS*|CYGWIN*)
+        echo ""
+        echo "  test_sandbox_engine_parity.sh: SKIPPED (POSIX-only —"
+        echo "    absolute-path probes are not meaningful for a native binary under MSYS2)"
+        exit 0 ;;
+esac
+if [ -n "${WINDIR:-}" ]; then
+    echo "  test_sandbox_engine_parity.sh: SKIPPED (POSIX-only)"
+    exit 0
+fi
+
 source "$SCRIPT_DIR/../helpers/trust_setup.sh"
 setup_isolated_trust
 cleanup() { teardown_isolated_trust; rm -rf "$TEST_TMP"; }

--- a/tests/governance_v4/test_sandbox_engine_parity.sh
+++ b/tests/governance_v4/test_sandbox_engine_parity.sh
@@ -1,0 +1,138 @@
+#!/usr/bin/env bash
+# ============================================================
+# test_sandbox_engine_parity.sh — govern.json sandbox settings must reach BOTH engines
+#
+# syncGovernanceToSandbox() and the sandbox_level rebuild lived inline inside
+# `if (use_vm)` in main.cpp, so under --tree-walk every govern.json sandbox
+# setting was silently inert:
+#
+#   security.sandbox_level              never applied
+#   capabilities.shell.enabled: false   SYS_EXEC left in place
+#   capabilities.network.enabled: false NET_CONNECT left in place
+#   enforce-mode fail-closed upgrade    never happened
+#
+# A govern.json that reads as locked down enforced nothing on a supported engine.
+# Passing --sandbox-level on the CLI worked on both, which is why the gap was
+# invisible to anyone testing that way.
+#
+# The VM still has an equivalent block inline rather than calling the shared
+# helper — deliberately, because swapping the default engine's working code
+# carries more risk than the duplication does. This file is what makes that safe:
+# the #115 taint divergence was not caused by duplication, it was caused by
+# nothing testing that the two paths agreed.
+#
+# Every case asserts BOTH engines agree AND that the expected verdict is the one
+# they agree on — two engines that both fail to enforce agree perfectly.
+# ============================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+NAAB="$SCRIPT_DIR/../../build/naab-lang"
+
+if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
+    _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
+else
+    _SYSTMP="${TMPDIR:-/tmp}"
+fi
+TEST_TMP="${_SYSTMP}/sandbox-parity-$$"
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+PASS_COUNT=0; FAIL_COUNT=0; SKIP_COUNT=0; FAILURES=""
+pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo -e "  ${GREEN}PASS${NC} [$1] $2"; }
+fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo -e "  ${RED}FAIL${NC} [$1] $2"; [ -n "${3:-}" ] && echo -e "       ${RED}-> $3${NC}"; FAILURES="${FAILURES}\n  [$1] $2"; }
+skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo -e "  ${YELLOW}SKIP${NC} [$1] $2"; }
+
+source "$SCRIPT_DIR/../helpers/trust_setup.sh"
+setup_isolated_trust
+cleanup() { teardown_isolated_trust; rm -rf "$TEST_TMP"; }
+trap cleanup EXIT
+mkdir -p "$TEST_TMP"
+
+"$NAAB" --keygen "$TEST_TMP/k.pem" >/dev/null 2>&1
+"$NAAB" --trust-key "$TEST_TMP/k.pem.pub" 2>/dev/null
+export NAAB_SIGNING_KEY="$TEST_TMP/k.pem"
+
+# Probes. READ_* uses an absolute path, denied below "elevated"; shell= exercises
+# the capability sync specifically (elevated permits exec, so only the sync can
+# remove SYS_EXEC).
+cat > "$TEST_TMP/read_sync.naab" << 'EOF'
+use file
+main {
+    try { let c = file.read("/etc/hostname") print("READ_ALLOWED") }
+    catch (e) { print("READ_BLOCKED") }
+}
+EOF
+cat > "$TEST_TMP/read_async.naab" << 'EOF'
+use file
+async fn probe() {
+    try { let c = file.read("/etc/hostname") print("READ_ALLOWED") }
+    catch (e) { print("READ_BLOCKED") }
+    return 1
+}
+main { let f = probe() let v = await f }
+EOF
+cat > "$TEST_TMP/shell.naab" << 'EOF'
+use process
+main {
+    try { let r = process.run("echo", ["hi"]) print("shell=ALLOWED") }
+    catch (e) { print("shell=BLOCKED") }
+}
+EOF
+
+write_govern() { printf '%s\n' "$2" > "$TEST_TMP/govern.json"
+    (cd "$TEST_TMP" && NAAB_SIGNING_KEY="$NAAB_SIGNING_KEY" "$NAAB" --sign-governance >/dev/null 2>&1) || true; }
+
+# The read probe prints READ_BLOCKED (underscore) and the shell probe
+# shell=BLOCKED (equals). A pattern covering only one silently reports <none>
+# for the other and makes a working engine look untested.
+verdict() {  # $1=script $2=engine-flag
+    (cd "$TEST_TMP" && timeout 30s "$NAAB" ${2:-} "$1.naab" 2>&1) \
+        | grep -oE "READ_(ALLOWED|BLOCKED)|shell=(ALLOWED|BLOCKED)" | head -1
+}
+
+check() {  # $1=id $2=script $3=expected $4=description
+    local vm tw
+    vm=$(verdict "$2" ""); tw=$(verdict "$2" "--tree-walk")
+    if [ -z "$vm" ] || [ -z "$tw" ]; then
+        fail "$1" "probe produced no verdict — nothing was measured" "vm='${vm:-}' tree-walk='${tw:-}'"
+    elif [ "$vm" != "$tw" ]; then
+        fail "$1" "engines disagree: $4" "VM=$vm tree-walk=$tw"
+    elif [ "$vm" != "$3" ]; then
+        fail "$1" "both engines agree on the WRONG verdict: $4" "expected $3, both gave $vm"
+    else
+        pass "$1" "$4 (both $vm)"
+    fi
+}
+
+echo ""
+echo -e "${CYAN}+==============================================================+${NC}"
+echo -e "${CYAN}|  govern.json sandbox settings must reach BOTH engines        |${NC}"
+echo -e "${CYAN}+==============================================================+${NC}"
+echo ""
+
+write_govern x '{ "version": "5.0", "mode": "enforce", "security": { "sandbox_level": "standard" } }'
+check "SBX-01" read_sync  READ_BLOCKED "govern.json sandbox_level=standard denies an absolute read"
+check "SBX-02" read_async READ_BLOCKED "async fn inherits the sandbox (thread_local, fails open when unset)"
+
+write_govern x '{ "version": "5.0", "mode": "enforce", "security": { "sandbox_level": "elevated" } }'
+check "SBX-03" read_sync  READ_ALLOWED "control: elevated permits it, so SBX-01 is not blocking unconditionally"
+
+write_govern x '{ "version": "5.0", "mode": "enforce", "security": { "sandbox_level": "elevated" },
+  "capabilities": { "shell": { "enabled": false } } }'
+check "SBX-04" shell shell=BLOCKED "capabilities.shell.enabled=false removes SYS_EXEC even at elevated"
+
+write_govern x '{ "version": "5.0", "mode": "enforce", "security": { "sandbox_level": "elevated" } }'
+check "SBX-05" shell shell=ALLOWED "control: without the capability restriction exec is permitted"
+
+write_govern x '{ "version": "5.0", "mode": "enforce" }'
+check "SBX-06" read_sync READ_BLOCKED "enforce mode with no level set upgrades to standard (fail-closed)"
+
+echo ""
+echo -e "${CYAN}+==============================================================+${NC}"
+TOTAL=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+echo -e "  Total: $TOTAL | ${GREEN}Pass: $PASS_COUNT${NC} | ${RED}Fail: $FAIL_COUNT${NC} | ${YELLOW}Skip: $SKIP_COUNT${NC}"
+if [ "$FAIL_COUNT" -gt 0 ]; then
+    echo -e "${RED}Failures:${NC}$FAILURES"
+    exit 1
+fi
+exit 0


### PR DESCRIPTION
## Summary

Tracing the sandbox capability sync turned up two gaps. Both fail open, and both are invisible to the way the sandbox is usually tested.

### 1. govern.json reached only the VM

`syncGovernanceToSandbox()` and the `sandbox_level` rebuild sat inside `if (use_vm)` (`main.cpp:1747`). Under `--tree-walk`, every govern.json sandbox setting was inert:

| setting | tree-walk before |
|---|---|
| `security.sandbox_level` | never applied |
| `capabilities.shell.enabled: false` | `SYS_EXEC` left in place |
| `capabilities.network.enabled: false` | `NET_CONNECT` left in place |
| enforce-mode fail-closed upgrade | never happened |

```
govern.json: sandbox_level=elevated, capabilities.shell.enabled=false
  VM:        shell=BLOCKED
  tree-walk: shell=ALLOWED
```

A config that reads as locked down enforced nothing on a supported engine. `--sandbox-level` on the CLI worked on **both** engines, which is why the gap stayed hidden — anyone verifying that way sees correct behaviour.

`--tree-walk` is presented in `--help` as a plain engine choice (*&#34;Use tree-walk interpreter instead of VM&#34;*), with none of the dev-only framing `--no-governance` carries, and 12 tests need it for VM-unsupported syntax. So this is a defect, not an intended escape hatch.

### 2. `async fn` ran unsandboxed

`current_sandbox` is `thread_local`, and every capability check fails open on a null one — `if (!sandbox) return;  // No sandbox active — allow`. Neither engine&#39;s async lambda established one:

| engine | sync | async before | async after |
|---|---|---|---|
| VM | BLOCKED | **ALLOWED** | BLOCKED |
| tree-walk | BLOCKED | **ALLOWED** | BLOCKED |

The tree-walker&#39;s async lambda already propagated `parent_taint`, `parent_counters` and the governance config — the sandbox was the one piece of parent state left behind. The agent `batch`/`fan_out` pool has propagated it since *&#34;fail-closed: GAP 7&#34;*, so the pattern existed three files away and wasn&#39;t applied here.

## The half-fix that passed a full suite run

Worth recording, because it looked correct. Hoisting only the capability sync applies capabilities on top of a still-CLI-derived (unrestricted) config: `SYS_EXEC` and `NET_CONNECT` are removed, the filesystem stays open. That passes a shell-capability probe, leaves `sandbox_level` completely inert, and **cleared a full 441-test run** before the refactor exposed it. The level rebuild has to move with the sync, not after it.

## Why the VM keeps its inline block

The VM path still has an equivalent block rather than calling the shared helper. Swapping the default engine&#39;s working code carries more risk than the duplication does — and duplication is not what let the taint engines diverge in #115. **Nothing testing that the two paths agreed** is what did.

So the guard is a test, not a refactor: `test_sandbox_engine_parity.sh`, 6 cases, two of them controls proving the probes can distinguish (`elevated` must ALLOW where `standard` BLOCKS; exec must be permitted without the capability restriction).

## Follow-up commits (CI)

**`f097f6d` — skip the parity suite on Windows.** It failed `build-windows` only. Every probe asserts a filesystem decision about an absolute path (`/etc/hostname`), which a native binary under an MSYS2 harness cannot open — the read fails for file-not-found rather than sandbox denial, and the SBX-03 `elevated` control correctly reported the probe could not tell the two apart. Same trap as #104. Guarded on `uname -s` and `$WINDIR`, matching `test_subprocess_containment.sh`.

Both guard branches were observed taking the skip (fake `uname`, `WINDIR` set) rather than assumed to fire — a skip that never triggers is the same class of lie this suite exists to catch. The parity guarantee is unaffected: `build-linux` and `Build & Test` both run all six cases, so a VM/tree-walker divergence still fails CI on two jobs.

**`79122bd` — `timeout-minutes` on the two Windows CLI test steps** (15 / 25, from measured 57s and 3m37s). Explicitly **not** a fix for the intermittent Windows stall, and not claimed as one. Without it a stall runs to GitHub&#39;s 360-minute job default and the runner is killed service-side — precisely the case where the log archive 404s, so the stall we most want to read leaves nothing to read. A step-level timeout is enforced by the runner itself: the step fails and its logs still upload. That is the other half of the #112 split — the split names the phase, the timeout preserves the transcript naming where inside it.

The 25-minute bound deliberately clears one legitimate `SHELL_TEST_TIMEOUT` (600s + 30s kill grace) firing in an otherwise healthy run, so a single hung suite prints the wrapper&#39;s line naming itself instead of being swallowed by the step timeout. Status: **inert-verified** — YAML validated and values reasoned from measurements, but neither bound has been observed firing.

Open and unresolved: three Windows stalls to date, all localized to `CLI tests — shell suites`, none reproducing on a fresh runner. By the criterion written into the #112 workflow comment, clustering in one phase is evidence *against* the runner diagnosis rather than for it.

## Test Plan

- [x] Ran `bash run-all-tests.sh` with no new failures — **441 tests, 0 unexpected failures**, including the 12 `needs-tree-walk` tests now running under real capability enforcement for the first time
- [x] Added/updated tests for new functionality — `test_sandbox_engine_parity.sh` 6/6, registered in the suite
- [x] `bash tests/security/test_error_msg_leaks.sh` — 874 checks, 0 failures
- [ ] Tested manually in the REPL — n/a

**Vacuity-checked per fix:**

| reverted | fails |
|---|---|
| tree-walk sync wiring | SBX-01, 02, 04, 06 — all four govern.json behaviours; **both controls still pass** |
| async propagation | SBX-02 only |

## Related Issues

Follow-up to #115. Same shape: one capability implemented along two paths, with nothing checking they agreed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC)_