### PR TITLE
Report unexercised semantic signals as SKIP, not PASS

### DIFF
--- a/tests/governance_v4/test_semantic_signals.sh
+++ b/tests/governance_v4/test_semantic_signals.sh
@@ -649,8 +649,14 @@ NAABEOF
         echo -e "  ${YELLOW}NOTE${NC} [B02] SSC=$SSC_VAL after 2 on-topic turns — LLM responses may have low keyword overlap"
         pass "B02" "On-topic test completed (SSC=$SSC_VAL — LLM keyword overlap varies)"
     elif echo "$OUTPUT" | grep -qiE "API key|INVALID_ARGUMENT|attempts exhausted|status 40[013]"; then
+        # SKIP, not pass. The sends never landed, so signal 10 was never exercised
+        # — "the signal did not fire" and "the signal never ran" are the same
+        # observation here, and only one of them is a result. Group B is gated on
+        # GK1 being SET, not on it being valid, so a stale or revoked key reaches
+        # this branch: passing here reports the semantic-stability check green on
+        # a run that never made it past authentication.
         B02_API_ERROR=true
-        pass "B02" "On-topic test ran (API error, non-deterministic)"
+        skip "B02" "On-topic test never ran (API error — signal not exercised)"
     else
         fail "B02" "On-topic test failed" "exit=$EXIT_CODE output=$(echo "$OUTPUT" | head -5)"
     fi
@@ -659,7 +665,7 @@ NAABEOF
     if echo "$OUTPUT" | grep -q "SEMANTIC_DICT_PRESENT"; then
         pass "B03" "Response dict contains 'semantic' section"
     elif [ "$B02_API_ERROR" = true ]; then
-        pass "B03" "Semantic section check skipped (API error in B02)"
+        skip "B03" "Semantic section not observable (API error in B02)"
     else
         fail "B03" "Response dict missing 'semantic' section"
     fi
@@ -916,8 +922,11 @@ NAABEOF
 
     OUTPUT=$(cd "$WORKDIR" && timeout 180 "$NAAB" "test_c01.naab" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
     SSC=$(echo "$OUTPUT" | grep -oP 'SSC=\K[0-9]+' | head -1)
+    # SKIP, not pass — see B02. The catch prints ERROR= for ANY exception, and
+    # this branch is tested BEFORE SSC is read, so a failed send is scored as a
+    # satisfied assertion about a signal that never ran.
     if echo "$OUTPUT" | grep -q "ERROR="; then
-        pass "C01" "On-topic pair test ran (API error, non-deterministic)"
+        skip "C01" "On-topic pair never ran (error — signal not exercised)"
     elif [ "${SSC:-}" = "0" ]; then
         pass "C01" "SSC=0 after on-topic pair (high keyword overlap confirmed)"
     elif [ -n "${SSC:-}" ]; then
@@ -997,7 +1006,7 @@ NAABEOF
     SSC=$(echo "$OUTPUT" | grep -oP 'SSC=\K[0-9]+' | head -1)
     COH=$(echo "$OUTPUT" | grep -oP 'COHERENCE=\K[0-9.]+' | head -1)
     if echo "$OUTPUT" | grep -q "ERROR="; then
-        pass "C02" "Off-topic shift test ran (API error, non-deterministic)"
+        skip "C02" "Off-topic shift never ran (error — signal not exercised)"
     elif [ "${SSC:-0}" -ge 1 ]; then
         pass "C02" "SSC=$SSC after topic shift (Jaccard detected divergence, coherence=$COH)"
     elif [ -n "${SSC:-}" ]; then
@@ -1080,7 +1089,7 @@ NAABEOF
 
     OUTPUT=$(cd "$WORKDIR" && timeout 180 "$NAAB" "test_c03.naab" 2>/dev/null) && EXIT_CODE=0 || EXIT_CODE=$?
     if echo "$OUTPUT" | grep -q "ERROR="; then
-        pass "C03" "Mandate alignment test ran (API error, non-deterministic)"
+        skip "C03" "Mandate alignment never ran (error — signal not exercised)"
     elif echo "$OUTPUT" | grep -q "RANGE_OK"; then
         MA=$(echo "$OUTPUT" | grep -oP 'MA=\K[0-9.]+' | head -1)
         pass "C03" "Mandate alignment in [0.0, 1.0] (MA=$MA)"


### PR DESCRIPTION
## Summary

`test_semantic_signals.sh` scored five assertions as **PASS** when the agent send failed. Group B is gated on `GK1` being **set**, not on it being **valid**, so a stale or revoked key reaches these branches — and the suite reported the `semantic_stability` signal green on a run that never got past authentication.

B03 was the clearest case: its message read *"Semantic section check skipped"* while calling `pass()`.

## Reproduction

`GK1` set to an invalid key, against `master`:

```
PASS [B02] On-topic test ran (API error, non-deterministic)
PASS [B03] Semantic section check skipped (API error in B02)
PASS [C01] On-topic pair test ran (API error, non-deterministic)
PASS [C02] Off-topic shift test ran (API error, non-deterministic)
PASS [C03] Mandate alignment test ran (API error, non-deterministic)

PASS: 20  FAIL: 0  SKIP: 0  TOTAL: 20
```

Nothing about signal 10 or signal 11 was measured. The suite was green.

## C01–C03 are the older instance

B02/B03 arrived in #118; C01–C03 predate it and are the pattern that was copied. C01 is the worst of them — it tests for a printed `ERROR=` **before** it reads `SSC` at all, so *any* caught exception scores as a satisfied assertion about a signal that never ran:

```bash
if echo "$OUTPUT" | grep -q "ERROR="; then
    pass "C01" "On-topic pair test ran (API error, non-deterministic)"
elif [ "${SSC:-}" = "0" ]; then
    ...
```

Fixing only the new pair would have left the source in place, so all five move together.

## The distinction

"The signal did not fire" and "the signal never ran" are the same observation here, and only one of them is a result. This is the same shape as `H01`, `L24-02`, `L25-03`, and the two defects in my own work earlier in this campaign: **an assertion satisfiable without the property holding**, because absence of the bad outcome and absence of the mechanism look identical.

`skip()` already exists in this file and increments `TOTAL`, so nothing is hidden — the count stays at 20 and the skips are visible in the summary line.

## Test Plan

- [x] Ran `bash run-all-tests.sh` with no new failures — **441 tests, 0 unexpected failures**
- [x] `bash tests/security/test_error_msg_leaks.sh` — 874 checks, 0 failures
- [x] Added/updated tests for new functionality — n/a, this corrects existing assertions
- [ ] Tested manually in the REPL — n/a

**Degraded-case check** (invalid `GK1`, the condition that produced the vacuous passes):

| | before | after |
|---|---|---|
| B02, B03, C01, C02, C03 | PASS | **SKIP** |
| totals | 20 PASS / 0 SKIP | 15 PASS / 5 SKIP |

Paths confirmed unchanged:
- **No key at all** — 9 PASS / 11 SKIP, identical to `master` (Group B was already fully skipped when `GK1` is unset)
- **Valid key** — untouched; only the error branches moved, every success branch is byte-identical

## Related Issues

Follow-up to #118. The Termux work that surfaced this was correct in substance — `test_consequence_proof.sh` and `test_d1_reconciliation.sh` both used `skip` on their API-error paths, which is the right three-way form. `test_semantic_signals.sh` used `pass`, matching a C-group pattern that was already wrong.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC)_