### PR TITLE
Consolidate the stub platform guard, and record why it was needed

### DIFF
--- a/docs/governance-campaign-findings.md
+++ b/docs/governance-campaign-findings.md
@@ -346,6 +346,55 @@ script reported something other than what happened.
 
 ---
 
+## A fix that reached one caller
+
+The Windows CI job stalled four times inside `CLI tests — shell suites`: the step
+sat `in_progress` for ~47 minutes, the runner was killed service-side, and the log
+archive 404'd. Two of those runs carried a `timeout-minutes: 25` added expressly to
+preserve logs — it never fired, so the runner could not enforce its own step
+timeout either. The cause could not be read out of anything. It could only be
+excluded.
+
+The diagnosis was already in the tree, and had been before any of it:
+
+> *"Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
+> process cleanup issues. Skip entirely — Linux CI validates the behavior."*
+> — `test_absorption_degenerate.sh`
+
+That comment sat in **1 of the 29 suites** that launch `agent_stub.py`. The other
+28 kept running on Windows. Excluding all 29 took the step from a 47-minute hang
+to **2m04s**.
+
+The same shape had already happened once in this file's own table. `081f460`
+fixed stub startup picking a single random port — *"a one-shot pick turned a busy
+port into a scenario that silently produced no data"* — and that fix reached
+**2 of 29**. Three CI runs later, three different stub suites failed on Linux for
+what was very likely that same collision, and the obvious repair (add the retry
+everywhere) is the withdrawn proposal below, because it hung Windows instead.
+
+| fix | diagnosed in | reached |
+|---|---|---|
+| stub port retry (`081f460`) | 1 suite | 2 of 29 |
+| Windows/MSYS2 stub guard | 1 suite | 1 of 29 |
+
+The defect is not duplication. Copies of a helper are cheap and each file stays
+runnable alone, which is worth something. The defect is that **a finding was
+recorded where the other callers could not see it** — a comment in one file is
+invisible to the 28 people who will next hit the same wall.
+
+The platform guard is now one definition in `tests/helpers/stub_platform.sh`, so
+the next finding about it lands on every caller at once. The *launcher itself* is
+still 29 near-copies, and the port retry still reaches only some of them — the
+same exposure, unfixed, and the reason it was not consolidated with the guard is
+that the correct Windows behaviour of that code is exactly what is still unknown.
+Consolidating it would freeze one guess into 29 callers.
+
+Note what this cost. Four stalls, three misattributed Linux failures, one
+incorrect one-commit bisect, and a "fix" that had to be reverted — all
+downstream of a correct diagnosis nobody could find.
+
+---
+
 ## Taint tracking: two defects that hid each other
 
 Found by tracing the taint tracker cold, after the propose/commit path was
@@ -453,12 +502,39 @@ Kept because the reasoning against them is the useful part.
    fired 4 turns and stopped, `thinking_collapse` fired 11 and continued, with
    one turn of overlap. The run terminated on advisory escalation with 23 checks
    never evaluated. Reverted in `9f63c4e`.
+5. **Check `allowed_actions` in `agent.commit()`.** Claimed as a gap in the same
+   family as #8 and #13: `commit` re-checks the lease and CRITICAL but not the
+   action matrix, and removing an action mid-run is *ratchet-legal* (recorded as
+   `tightened` in `governance_config.cpp`), so a proposal looked committable
+   after its agent's `AGENT_SEND` was gone. **The gap does not exist.**
+   `agentCommit` already compares `getReloadCount()` against the count stamped
+   into the proposal at propose time, and `reload_count_++` fires only on an
+   *accepted* reload — so any config change that could remove the action has
+   already invalidated the proposal. `allowed_actions` is config-derived and has
+   no other mutation path, and `s_pending_proposals` has exactly one insert,
+   inside `agentPropose`, behind that function's own `AGENT_SEND` check, so a
+   caller cannot supply a proposal either. Covered by `test_propose_commit.sh`
+   H-01/H-02. The reason it looked open: the gates were enumerated with a grep
+   for `allowed_actions|AGENT_SEND|checkCriticalSuspension|leaseExpiredLocked|checkAdmission`,
+   and `reload_count` was not in the pattern. See the method note below.
+6. **Give the stub launcher a port retry and a longer readiness ceiling.** Three
+   CI runs failed in three *different* stub-backed suites — the signature of the
+   launcher, not a regression — so the launcher was hardened across the 9 suites
+   then known to share the idiom. Linux went green; Windows stalled. A
+   one-commit bisect looked conclusive (the commit before passed, the delta was
+   the launcher alone) and **was coincidence**: the next commit restored the
+   Windows path to byte-equivalent prior behaviour and it stalled anyway. Two
+   things were wrong at once. The retry's cleanup used `kill` followed by an
+   unbounded `wait`, which cannot return if TERM is ignored — a hazard this
+   repo's own `run-all-tests.sh` comments already warn about for MSYS2. And
+   "the 9 suites" came from grepping one launcher idiom rather than for
+   `agent_stub.py`; the real population is 29. The retry now runs on POSIX only.
 
 ---
 
 ## Method notes
 
-Four things this campaign kept relearning:
+Five things this campaign kept relearning:
 
 **Trace the code before running the experiment.** Every fix that came from
 reading call graphs held up. Both hypotheses formed by reading a live run and
@@ -475,6 +551,25 @@ it immediately, because the baseline is what the window actually controls.
 may be redundant" when the two runs already differ; `PW-02` fails if the window
 answers to no key at all, so a pinned value cannot pass by looking stable. A
 test that can only pass or fail cannot tell you it measured nothing.
+
+**A grep defines what you are able to see.** Three times in one session a
+conclusion was wrong because the pattern that produced the evidence was narrower
+than the thing being reasoned about, and nothing in the output said so — absence
+from a grep result reads exactly like absence from the code.
+
+| pattern | what it hid | consequence |
+|---|---|---|
+| `allowed_actions\|AGENT_SEND\|checkCriticalSuspension\|leaseExpiredLocked\|checkAdmission` | `agentCommit`'s reload-generation check | a security gap reported that did not exist |
+| `seq 1 50); do grep -q READY` (one launcher idiom) | 20 of 29 suites launching the stub | an exclusion experiment whose negative result would have been uninterpretable |
+| `taint_tracking.sink_violation` | the second violation message format | a working taint engine reported as broken |
+
+The third is the one already recorded above as a *detector carrying the defect it
+was hunting*; it is the same error at one remove, and the keyword-filter
+postscript below is a fourth. The habit that catches it is cheap: after a grep
+that will support a conclusion, ask what the pattern **cannot** match, and widen
+it once on purpose. Search for the artifact (`agent_stub.py`) rather than for a
+usage of it, and enumerate a function's guards by reading it rather than by
+filtering it.
 
 **An assertion that looks specific can be satisfiable without the property
 holding.** This appeared three times in the transition-admissibility phase and

--- a/tests/governance_v4/test_absorption_degenerate.sh
+++ b/tests/governance_v4/test_absorption_degenerate.sh
@@ -42,12 +42,8 @@ skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo -e "  ${YELLOW}SKIP${NC} [$1] $2";
 IS_WINDOWS=false
 if [[ "$(uname -s)" == MINGW* ]] || [[ "$(uname -s)" == MSYS* ]] || [[ -n "${WINDIR:-}" ]]; then IS_WINDOWS=true; fi
 
-# Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-# process cleanup issues. Skip entirely — Linux CI validates the behavior.
-if $IS_WINDOWS; then
-    echo "  SKIP: test_absorption_degenerate.sh — stub-backed tests not supported on Windows/MSYS2"
-    exit 0
-fi
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_absorption_degenerate.sh"
 
 source "$SCRIPT_DIR/../helpers/trust_setup.sh"
 setup_isolated_trust

--- a/tests/governance_v4/test_adversarial_detection.sh
+++ b/tests/governance_v4/test_adversarial_detection.sh
@@ -53,33 +53,8 @@ pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo -e "  ${GREEN}PASS${NC} [$1] $2"; 
 fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo -e "  ${RED}FAIL${NC} [$1] $2"; [ -n "${3:-}" ] && echo -e "       ${RED}-> $3${NC}"; FAILURES="${FAILURES}\n  [$1] $2"; }
 skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo -e "  ${YELLOW}SKIP${NC} [$1] $2"; }
 
-# EXPERIMENT (reversible in one commit). build-windows has stalled inside
-# "CLI tests — shell suites" four times: the step sits in_progress ~47 minutes,
-# the runner is killed service-side, and the log archive 404s. timeout-minutes
-# has now failed to fire TWICE, so the runner cannot enforce its own step
-# timeout — we cannot read our way to the cause, only change the outcome.
-#
-# A live observation caught it hanging at the test_challenge_discrimination.sh
-# header, immediately after another stub-backed suite passed. These 9 suites are
-# the only ones that run a Python HTTP server and talk to it from a native
-# Windows binary under MSYS2, so they are the region to exclude first.
-#
-# Read the next Windows run as the result:
-#   green      -> these suites are implicated; narrow from 9
-#   stalls     -> they are exonerated; the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test both run every one of these
-# in full, and what they test (agent governance semantics) is platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_adversarial_detection.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_adversarial_detection.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_adversarial_detection.sh"
 source "$SCRIPT_DIR/../helpers/trust_setup.sh"
 setup_isolated_trust
 STUB_PID=""

--- a/tests/governance_v4/test_cdd_turn0.sh
+++ b/tests/governance_v4/test_cdd_turn0.sh
@@ -17,33 +17,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_cdd_turn0.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_cdd_turn0.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_cdd_turn0.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_challenge_discrimination.sh
+++ b/tests/governance_v4/test_challenge_discrimination.sh
@@ -55,33 +55,8 @@ pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo -e "  ${GREEN}PASS${NC} [$1] $2"; 
 fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo -e "  ${RED}FAIL${NC} [$1] $2"; [ -n "${3:-}" ] && echo -e "       ${RED}-> $3${NC}"; FAILURES="${FAILURES}\n  [$1] $2"; }
 skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo -e "  ${YELLOW}SKIP${NC} [$1] $2"; }
 
-# EXPERIMENT (reversible in one commit). build-windows has stalled inside
-# "CLI tests — shell suites" four times: the step sits in_progress ~47 minutes,
-# the runner is killed service-side, and the log archive 404s. timeout-minutes
-# has now failed to fire TWICE, so the runner cannot enforce its own step
-# timeout — we cannot read our way to the cause, only change the outcome.
-#
-# A live observation caught it hanging at the test_challenge_discrimination.sh
-# header, immediately after another stub-backed suite passed. These 9 suites are
-# the only ones that run a Python HTTP server and talk to it from a native
-# Windows binary under MSYS2, so they are the region to exclude first.
-#
-# Read the next Windows run as the result:
-#   green      -> these suites are implicated; narrow from 9
-#   stalls     -> they are exonerated; the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test both run every one of these
-# in full, and what they test (agent governance semantics) is platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_challenge_discrimination.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_challenge_discrimination.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_challenge_discrimination.sh"
 source "$SCRIPT_DIR/../helpers/trust_setup.sh"
 setup_isolated_trust
 STUB_PID=""

--- a/tests/governance_v4/test_challenge_fail_path.sh
+++ b/tests/governance_v4/test_challenge_fail_path.sh
@@ -49,33 +49,8 @@ pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo -e "  ${GREEN}PASS${NC} [$1] $2"; 
 fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo -e "  ${RED}FAIL${NC} [$1] $2"; [ -n "${3:-}" ] && echo -e "       ${RED}-> $3${NC}"; FAILURES="${FAILURES}\n  [$1] $2"; }
 skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo -e "  ${YELLOW}SKIP${NC} [$1] $2"; }
 
-# EXPERIMENT (reversible in one commit). build-windows has stalled inside
-# "CLI tests — shell suites" four times: the step sits in_progress ~47 minutes,
-# the runner is killed service-side, and the log archive 404s. timeout-minutes
-# has now failed to fire TWICE, so the runner cannot enforce its own step
-# timeout — we cannot read our way to the cause, only change the outcome.
-#
-# A live observation caught it hanging at the test_challenge_discrimination.sh
-# header, immediately after another stub-backed suite passed. These 9 suites are
-# the only ones that run a Python HTTP server and talk to it from a native
-# Windows binary under MSYS2, so they are the region to exclude first.
-#
-# Read the next Windows run as the result:
-#   green      -> these suites are implicated; narrow from 9
-#   stalls     -> they are exonerated; the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test both run every one of these
-# in full, and what they test (agent governance semantics) is platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_challenge_fail_path.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_challenge_fail_path.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_challenge_fail_path.sh"
 source "$SCRIPT_DIR/../helpers/trust_setup.sh"
 setup_isolated_trust
 STUB_PID=""

--- a/tests/governance_v4/test_challenge_first_turn.sh
+++ b/tests/governance_v4/test_challenge_first_turn.sh
@@ -19,33 +19,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_challenge_first_turn.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_challenge_first_turn.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_challenge_first_turn.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_code_aware_keywords.sh
+++ b/tests/governance_v4/test_code_aware_keywords.sh
@@ -23,33 +23,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_code_aware_keywords.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_code_aware_keywords.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_code_aware_keywords.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_config_adjustment.sh
+++ b/tests/governance_v4/test_config_adjustment.sh
@@ -18,33 +18,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_config_adjustment.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_config_adjustment.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_config_adjustment.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_deescalation_hysteresis.sh
+++ b/tests/governance_v4/test_deescalation_hysteresis.sh
@@ -23,33 +23,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_deescalation_hysteresis.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_deescalation_hysteresis.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_deescalation_hysteresis.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_deescalation_multiagent.sh
+++ b/tests/governance_v4/test_deescalation_multiagent.sh
@@ -37,33 +37,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_deescalation_multiagent.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_deescalation_multiagent.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_deescalation_multiagent.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_developer_blindspot.sh
+++ b/tests/governance_v4/test_developer_blindspot.sh
@@ -60,33 +60,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_developer_blindspot.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_developer_blindspot.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_developer_blindspot.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_drift_sensitivity.sh
+++ b/tests/governance_v4/test_drift_sensitivity.sh
@@ -50,33 +50,8 @@ pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo -e "  ${GREEN}PASS${NC} [$1] $2"; 
 fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo -e "  ${RED}FAIL${NC} [$1] $2"; [ -n "${3:-}" ] && echo -e "       ${RED}-> $3${NC}"; FAILURES="${FAILURES}\n  [$1] $2"; }
 skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo -e "  ${YELLOW}SKIP${NC} [$1] $2"; }
 
-# EXPERIMENT (reversible in one commit). build-windows has stalled inside
-# "CLI tests — shell suites" four times: the step sits in_progress ~47 minutes,
-# the runner is killed service-side, and the log archive 404s. timeout-minutes
-# has now failed to fire TWICE, so the runner cannot enforce its own step
-# timeout — we cannot read our way to the cause, only change the outcome.
-#
-# A live observation caught it hanging at the test_challenge_discrimination.sh
-# header, immediately after another stub-backed suite passed. These 9 suites are
-# the only ones that run a Python HTTP server and talk to it from a native
-# Windows binary under MSYS2, so they are the region to exclude first.
-#
-# Read the next Windows run as the result:
-#   green      -> these suites are implicated; narrow from 9
-#   stalls     -> they are exonerated; the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test both run every one of these
-# in full, and what they test (agent governance semantics) is platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_drift_sensitivity.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_drift_sensitivity.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_drift_sensitivity.sh"
 source "$SCRIPT_DIR/../helpers/trust_setup.sh"
 setup_isolated_trust
 STUB_PID=""

--- a/tests/governance_v4/test_entity_window.sh
+++ b/tests/governance_v4/test_entity_window.sh
@@ -18,33 +18,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_entity_window.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_entity_window.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_entity_window.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_evidence_chain.sh
+++ b/tests/governance_v4/test_evidence_chain.sh
@@ -16,33 +16,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_evidence_chain.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_evidence_chain.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_evidence_chain.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_failure_mode_coverage.sh
+++ b/tests/governance_v4/test_failure_mode_coverage.sh
@@ -48,33 +48,8 @@ pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo -e "  ${GREEN}PASS${NC} [$1] $2"; 
 fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo -e "  ${RED}FAIL${NC} [$1] $2"; [ -n "${3:-}" ] && echo -e "       ${RED}-> $3${NC}"; FAILURES="${FAILURES}\n  [$1] $2"; }
 skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo -e "  ${YELLOW}SKIP${NC} [$1] $2"; }
 
-# EXPERIMENT (reversible in one commit). build-windows has stalled inside
-# "CLI tests — shell suites" four times: the step sits in_progress ~47 minutes,
-# the runner is killed service-side, and the log archive 404s. timeout-minutes
-# has now failed to fire TWICE, so the runner cannot enforce its own step
-# timeout — we cannot read our way to the cause, only change the outcome.
-#
-# A live observation caught it hanging at the test_challenge_discrimination.sh
-# header, immediately after another stub-backed suite passed. These 9 suites are
-# the only ones that run a Python HTTP server and talk to it from a native
-# Windows binary under MSYS2, so they are the region to exclude first.
-#
-# Read the next Windows run as the result:
-#   green      -> these suites are implicated; narrow from 9
-#   stalls     -> they are exonerated; the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test both run every one of these
-# in full, and what they test (agent governance semantics) is platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_failure_mode_coverage.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_failure_mode_coverage.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_failure_mode_coverage.sh"
 source "$SCRIPT_DIR/../helpers/trust_setup.sh"
 setup_isolated_trust
 STUB_PID=""

--- a/tests/governance_v4/test_instruction_recall_windowing.sh
+++ b/tests/governance_v4/test_instruction_recall_windowing.sh
@@ -17,33 +17,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_instruction_recall_windowing.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_instruction_recall_windowing.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_instruction_recall_windowing.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_output_admissibility.sh
+++ b/tests/governance_v4/test_output_admissibility.sh
@@ -7,33 +7,8 @@ set -euo pipefail
 SCRIPT_DIR="$(cd "$(dirname "$0")" && pwd)"
 NAAB="${NAAB:-$SCRIPT_DIR/../../build/naab-lang}"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_output_admissibility.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_output_admissibility.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_output_admissibility.sh"
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
 else

--- a/tests/governance_v4/test_per_agent_signals.sh
+++ b/tests/governance_v4/test_per_agent_signals.sh
@@ -21,33 +21,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_per_agent_signals.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_per_agent_signals.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_per_agent_signals.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_persona_window.sh
+++ b/tests/governance_v4/test_persona_window.sh
@@ -38,33 +38,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_persona_window.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_persona_window.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_persona_window.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_propose_commit.sh
+++ b/tests/governance_v4/test_propose_commit.sh
@@ -13,33 +13,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_propose_commit.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_propose_commit.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_propose_commit.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_pulse_uniformity.sh
+++ b/tests/governance_v4/test_pulse_uniformity.sh
@@ -39,33 +39,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_pulse_uniformity.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_pulse_uniformity.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_pulse_uniformity.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_quarantine_corroboration.sh
+++ b/tests/governance_v4/test_quarantine_corroboration.sh
@@ -40,33 +40,8 @@ pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo -e "  ${GREEN}PASS${NC} [$1] $2"; 
 fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo -e "  ${RED}FAIL${NC} [$1] $2"; [ -n "${3:-}" ] && echo -e "       ${RED}-> $3${NC}"; FAILURES="${FAILURES}\n  [$1] $2"; }
 skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo -e "  ${YELLOW}SKIP${NC} [$1] $2"; }
 
-# EXPERIMENT (reversible in one commit). build-windows has stalled inside
-# "CLI tests — shell suites" four times: the step sits in_progress ~47 minutes,
-# the runner is killed service-side, and the log archive 404s. timeout-minutes
-# has now failed to fire TWICE, so the runner cannot enforce its own step
-# timeout — we cannot read our way to the cause, only change the outcome.
-#
-# A live observation caught it hanging at the test_challenge_discrimination.sh
-# header, immediately after another stub-backed suite passed. These 9 suites are
-# the only ones that run a Python HTTP server and talk to it from a native
-# Windows binary under MSYS2, so they are the region to exclude first.
-#
-# Read the next Windows run as the result:
-#   green      -> these suites are implicated; narrow from 9
-#   stalls     -> they are exonerated; the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test both run every one of these
-# in full, and what they test (agent governance semantics) is platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_quarantine_corroboration.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_quarantine_corroboration.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_quarantine_corroboration.sh"
 source "$SCRIPT_DIR/../helpers/trust_setup.sh"
 setup_isolated_trust
 STUB_PID=""

--- a/tests/governance_v4/test_signal_discrimination.sh
+++ b/tests/governance_v4/test_signal_discrimination.sh
@@ -56,33 +56,8 @@ pass() { PASS_COUNT=$((PASS_COUNT + 1)); echo -e "  ${GREEN}PASS${NC} [$1] $2"; 
 fail() { FAIL_COUNT=$((FAIL_COUNT + 1)); echo -e "  ${RED}FAIL${NC} [$1] $2"; [ -n "${3:-}" ] && echo -e "       ${RED}-> $3${NC}"; FAILURES="${FAILURES}\n  [$1] $2"; }
 skip() { SKIP_COUNT=$((SKIP_COUNT + 1)); echo -e "  ${YELLOW}SKIP${NC} [$1] $2"; }
 
-# EXPERIMENT (reversible in one commit). build-windows has stalled inside
-# "CLI tests — shell suites" four times: the step sits in_progress ~47 minutes,
-# the runner is killed service-side, and the log archive 404s. timeout-minutes
-# has now failed to fire TWICE, so the runner cannot enforce its own step
-# timeout — we cannot read our way to the cause, only change the outcome.
-#
-# A live observation caught it hanging at the test_challenge_discrimination.sh
-# header, immediately after another stub-backed suite passed. These 9 suites are
-# the only ones that run a Python HTTP server and talk to it from a native
-# Windows binary under MSYS2, so they are the region to exclude first.
-#
-# Read the next Windows run as the result:
-#   green      -> these suites are implicated; narrow from 9
-#   stalls     -> they are exonerated; the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test both run every one of these
-# in full, and what they test (agent governance semantics) is platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_signal_discrimination.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_signal_discrimination.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_signal_discrimination.sh"
 source "$SCRIPT_DIR/../helpers/trust_setup.sh"
 setup_isolated_trust
 STUB_PID=""

--- a/tests/governance_v4/test_split_commit.sh
+++ b/tests/governance_v4/test_split_commit.sh
@@ -16,33 +16,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_split_commit.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_split_commit.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_split_commit.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_thinking_reported.sh
+++ b/tests/governance_v4/test_thinking_reported.sh
@@ -45,33 +45,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_thinking_reported.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_thinking_reported.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_thinking_reported.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_tool_admissibility_gate.sh
+++ b/tests/governance_v4/test_tool_admissibility_gate.sh
@@ -11,33 +11,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_tool_admissibility_gate.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_tool_admissibility_gate.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_tool_admissibility_gate.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_truncation_exposure.sh
+++ b/tests/governance_v4/test_truncation_exposure.sh
@@ -12,33 +12,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_truncation_exposure.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_truncation_exposure.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_truncation_exposure.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/governance_v4/test_validation_signal.sh
+++ b/tests/governance_v4/test_validation_signal.sh
@@ -40,33 +40,8 @@ if [[ "$(uname -s)" == MINGW* ]] || [[ "$(uname -s)" == MSYS* ]] || [[ -n "${WIN
     IS_WINDOWS=true
 fi
 
-# EXPERIMENT (reversible in one commit). build-windows has stalled inside
-# "CLI tests — shell suites" four times: the step sits in_progress ~47 minutes,
-# the runner is killed service-side, and the log archive 404s. timeout-minutes
-# has now failed to fire TWICE, so the runner cannot enforce its own step
-# timeout — we cannot read our way to the cause, only change the outcome.
-#
-# A live observation caught it hanging at the test_challenge_discrimination.sh
-# header, immediately after another stub-backed suite passed. These 9 suites are
-# the only ones that run a Python HTTP server and talk to it from a native
-# Windows binary under MSYS2, so they are the region to exclude first.
-#
-# Read the next Windows run as the result:
-#   green      -> these suites are implicated; narrow from 9
-#   stalls     -> they are exonerated; the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test both run every one of these
-# in full, and what they test (agent governance semantics) is platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_validation_signal.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_validation_signal.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_validation_signal.sh"
 source "$SCRIPT_DIR/../helpers/trust_setup.sh"
 setup_isolated_trust
 STUB_PID=""

--- a/tests/governance_v4/test_velocity_no_double_count.sh
+++ b/tests/governance_v4/test_velocity_no_double_count.sh
@@ -20,33 +20,8 @@ set -uo pipefail
 SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
 NAAB="$SCRIPT_DIR/../../build/naab-lang"
 
-# EXPERIMENT (reversible in one commit). See test_absorption_degenerate.sh, which
-# has carried this guard alone since before this change:
-#   "Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and
-#    process cleanup issues. Skip entirely — Linux CI validates the behavior."
-# That diagnosis was made once and applied to one file out of 29 that launch the
-# stub. build-windows has since stalled four times inside "CLI tests — shell
-# suites": the step sits in_progress ~47 minutes, the runner is killed
-# service-side, and the log archive 404s. timeout-minutes failed to fire TWICE,
-# so the runner cannot enforce its own step timeout either — the cause cannot be
-# read, only excluded.
-#
-# Read the next Windows run as the result:
-#   green   -> stub-backed suites are the cause; narrow from here
-#   stalls  -> they are exonerated and the cause is elsewhere in the phase
-#
-# Coverage is not lost: build-linux and Build & Test run every one of these in
-# full, and agent-governance semantics are platform-neutral.
-case "$(uname -s)" in
-    MINGW*|MSYS*|CYGWIN*)
-        echo "  test_velocity_no_double_count.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-        exit 0 ;;
-esac
-if [ -n "${WINDIR:-}" ]; then
-    echo "  test_velocity_no_double_count.sh: SKIPPED (stub-backed; excluded on Windows pending stall bisect)"
-    exit 0
-fi
-
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support "test_velocity_no_double_count.sh"
 
 if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
     _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"

--- a/tests/helpers/stub_platform.sh
+++ b/tests/helpers/stub_platform.sh
@@ -1,0 +1,56 @@
+#!/usr/bin/env bash
+# ============================================================
+# stub_platform.sh — platform gate for suites that launch agent_stub.py
+#
+# Stub-backed HTTP tests hang on Windows/MSYS2, from signal propagation and
+# process cleanup. That was diagnosed once, for test_absorption_degenerate.sh,
+# and the guard applied to that file alone — while 28 other suites launched the
+# same stub and kept running there. build-windows then stalled four times inside
+# "CLI tests — shell suites": the step sat in_progress ~47 minutes, the runner
+# was killed service-side, and the log archive 404'd. `timeout-minutes` could not
+# fire either, so the cause could not be read out of a log — only excluded.
+#
+# Excluding all 29 took that step from a 47-minute hang to 2m04s (#120), which is
+# what confirms the original one-file diagnosis generalises.
+#
+# This is a WORKAROUND, not a fix. The launcher's signal and cleanup behaviour
+# under MSYS2 is the actual defect and is still open. Coverage is not lost in the
+# meantime: build-linux and Build & Test run every one of these suites in full,
+# and what they test — agent governance semantics — is platform-neutral.
+#
+# Why this lives in one file: the guard previously existed as 29 near-copies, and
+# the reason it took four stalls to apply was that the finding sat in a comment in
+# one of them. A single definition is the thing that makes the next such finding
+# reach every caller.
+#
+# Usage — before any stub is launched:
+#     source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+#     skip_if_no_stub_support
+#
+# The file is sourced, so `exit 0` here ends the CALLING script. The suite name is
+# printed so the skip is visible in the run log rather than silently absent.
+# ============================================================
+
+skip_if_no_stub_support() {
+    local name="${1:-}"
+    if [ -z "$name" ]; then
+        name="$(basename "${BASH_SOURCE[1]:-unknown}")"
+    fi
+
+    local is_windows=0
+    case "$(uname -s)" in
+        MINGW*|MSYS*|CYGWIN*) is_windows=1 ;;
+    esac
+    # Second signal: a native shell where uname is absent or lies.
+    if [ -n "${WINDIR:-}" ]; then
+        is_windows=1
+    fi
+
+    if [ "$is_windows" -eq 0 ]; then
+        return 0
+    fi
+
+    echo "  ${name}: SKIPPED — stub-backed tests unsupported on Windows/MSYS2"
+    echo "    (signal propagation / process cleanup; covered by build-linux)"
+    exit 0
+}


### PR DESCRIPTION
## Summary

Two commits: the consolidation, and the campaign record of what made it necessary.

## 1. Consolidate the guard (`4bad165`)

The 29 guards added in #120 carried `pending stall bisect` in their comments. The bisect is finished — excluding all 29 took `CLI tests — shell suites` from a 47-minute hang to **2m04s** — so the comments described a hypothesis that had been settled.

Replaces 29 near-copies with one helper:

```bash
source "$SCRIPT_DIR/../helpers/stub_platform.sh"
skip_if_no_stub_support "test_quarantine_corroboration.sh"
```

**762 lines removed, 58 added.** The line count is not the point. The reason this took four stalls to diagnose is that the finding was recorded in *one file's comment*, where the 28 other callers of the same launcher could not see it:

> *"Stub-backed HTTP tests hang on Windows/MSYS2 due to signal propagation and process cleanup issues. Skip entirely — Linux CI validates the behavior."*
> — `test_absorption_degenerate.sh`, present before any of this work

The helper states what is known rather than what was suspected, and says plainly that it is a **workaround, not a fix** — the launcher's signal and cleanup behaviour under MSYS2 is the actual defect and is still open.

## 2. Record it (`642cce5`)

`docs/governance-campaign-findings.md` exists so the next person does not rediscover what was already settled — which is precisely the failure this entry is about. 522 → 613 lines.

**New section, "A fix that reached one caller."** The same shape had already happened once, in that file's own table: `081f460` fixed the stub's one-shot port pick. Measured, not estimated:

| fix | diagnosed in | reached |
|---|---|---|
| stub port retry (`081f460`) | 1 suite | **2 of 29** |
| Windows/MSYS2 stub guard | 1 suite | **1 of 29** |

Cost of the second one: four stalls, three misattributed Linux failures, one incorrect one-commit bisect, and a fix that had to be reverted — all downstream of a correct diagnosis nobody could find.

**Two withdrawn proposals**, in the section kept because the reasoning against them is the useful part:

- *Check `allowed_actions` in `agent.commit()`* — reported as a gap in the same family as #105/#114; **it does not exist**. `agentCommit` already compares `getReloadCount()` against the count stamped at propose time, and `reload_count_++` fires only on an accepted reload, so any config change that could remove the action has already invalidated the proposal.
- *Give the stub launcher a port retry* — fixed Linux, hung Windows. The one-commit bisect that appeared to prove it was **coincidence**: the next commit restored the Windows path byte-equivalently and stalled anyway.

**Fifth method note — "A grep defines what you are able to see."** Three wrong conclusions in one session, tabulated with what each pattern hid: the `reload_count` guard, 20 of 29 stub suites, and the second taint violation message format. Absence from a grep result reads exactly like absence from the code.

One overstatement corrected while writing: the platform guard is now one definition, but the *launcher* is still 29 near-copies and the port retry still reaches only some of them. Deliberately not consolidated — the correct Windows behaviour of that code is what remains unknown, and consolidating would freeze one guess into 29 callers. Left recorded as an open exposure rather than rounded up.

## Test Plan

- [x] Ran `bash run-all-tests.sh` with no new failures — **441 tests, 0 unexpected failures** (total unchanged)
- [x] `bash tests/security/test_error_msg_leaks.sh` — 874 checks, 0 failures
- [x] Added/updated tests for new functionality — n/a, test infrastructure and documentation only
- [ ] Tested manually in the REPL — n/a

**Both directions verified**, since a guard that never fires and a guard that always fires look identical from a green suite:

| condition | result |
|---|---|
| simulated `MINGW64_NT` uname | all **29** observed taking the skip |
| `$WINDIR` set, normal uname | skip taken — second signal works independently |
| Linux, neither signal | guard does **not** fire; `test_quarantine_corroboration.sh` still 5/5 |

Every figure in the documentation was checked against the tree: 1 of 29, 2 of 29, 29 launchers, `H-01`/`H-02` present. No `pending stall bisect` text remains in `tests/`.

`build-windows` has now passed three consecutive times since the exclusion (`e5c6f00`, `4bad165`, `642cce5`).

## Follow-ups not in this PR

- Fixing the launcher's MSYS2 signal/cleanup behaviour so the suites can run on Windows again — the honest fix, of which this is the workaround.
- The launcher itself is still 29 copies; consolidating it is blocked on knowing what its Windows behaviour should be.
- `test_absorption_degenerate.sh` retains an `IS_WINDOWS` branch at ~line 265 that is now unreachable. Left alone rather than widening this change.

## Related Issues

Follow-up to #120, which established the result this PR records.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC)_