### PR TITLE
Vacuity audit of tier 1: seven assertions that could not fail, three hiding defects

### DIFF
--- a/docs/governance-campaign-findings.md
+++ b/docs/governance-campaign-findings.md
@@ -801,3 +801,110 @@ AGENT_CHALLENGE_PASS=0` line reads the telemetry file mid-run, before the
 challenge fires at turn 20 — this is a known timing limitation of the in-script
 telemetry audit, not a vacuous assertion (Q02 counts from the script's own
 tracking).
+
+## Vacuity audit: tier 1
+
+`tests/security` and `tests/governance_v4` — 105 suites, 782 `pass`/`ok` sites.
+Filtered to 129 absence-guarded assertions, then to the ones whose text claims a
+negative property. The question asked of each: *what state makes this pass
+without the property holding?*
+
+### Assertions that could not fail on any input
+
+Seven, found by looking for `if/else` regions where every reachable branch
+passes. (A first pass reported 17; nesting-aware re-checking cut it to 7 — the
+other 10 were inner blocks inside an outer `if` that does have a `fail`. The
+detector needed the same correction the tests did.)
+
+| assertion | what it claimed | what was true |
+|---|---|---|
+| `test_governance_validity.sh` T19/T20/T21 | "contradiction detection ran" | asserted nothing; the stated excuse ("may not print without dashboard") was refuted by the command's own `--governance-dashboard` flag |
+| `test_r11_fixes.sh` T2 | opt-in config discovery works | its own comment read "something else is wrong — still pass the security property" |
+| `test_sandbox_symlink_f.sh` F4 | unrestricted sandbox follows symlinks | premise false by design (below) |
+| `test_stdlib_shadow_e.sh` E4 | path-separated import loads local module | the fixture never parsed (below) |
+| `test_d1_reconciliation.sh` A09 | `claim_accuracy` absent before first tool | engine emits `1.0`, always (below) |
+
+Three of these were concealing real defects. That is the argument for the audit:
+an unfailable assertion does not merely fail to catch regressions, it preserves
+whatever misunderstanding it was written with.
+
+**T20 was hiding dead engine code.** CONTRA-007 ("language in both allowed and
+blocked") iterated `languages.allowed` looking for members of `languages.blocked`
+— a set the loader empties at parse time, erasing blocked languages from allowed
+so blocked wins fail-closed (`governance_config.cpp` ~312). The intersection is
+empty by construction; the check could never fire. It now reads the overlap the
+loader records before resolving it. Level moved from a hardcoded `SOFT` to the
+configured `contradiction_detection.max_level` (ADVISORY by default): the
+hardcode ignored the operator's cap, and waking a dormant check at SOFT would
+newly `exit(3)` every config with overlapping lists — a blocking change smuggled
+in as a reporting fix. The loader already neutralises the danger; what was
+missing was telling the operator. CONTRA-001 keeps its hardcoded SOFT because it
+is live today, so relaxing it would be a real weakening rather than a dead knob.
+
+**E4 had never executed its own program.** Two stacked fixture bugs — `as *
+mymod` (invalid; the form is `as name`) and `use io` inside `main` (only legal at
+file scope). Both fixed; E4 now passes on the property.
+
+**A09's premise was inverted.** It asserted `claim_accuracy` is absent before the
+first tool call. `agent_impl.cpp` emits `1.0` on both paths — empty history
+(:816) and no DriftState at all (:855). The field is never absent, so the branch
+that "accidentally" passed was the correct one. Now asserts the documented
+default and fails if it moves (verified by changing it to 0.5).
+
+**F4's premise was false by design.** `readFileNoFollow` is gated on whether a
+sandbox is *installed*, not on its level, so `--sandbox-level unrestricted` still
+refuses symlinks. That is deliberate: the guard closes a TOCTOU window between
+the path check and the open, which is not a path-policy question and does not
+relax with the policy. F4 now asserts the level-independence. F3 was the real
+positive control for F1/F2 all along.
+
+### Catch-all `else → pass`
+
+Branches that accepted any unrelated failure as success. Converted to SKIP —
+"the mechanism did not run" is not "the mechanism held".
+
+- `test_env_scrub_polyglot.sh` T3 — a **secret-leak** test passing on "may have
+  been scrubbed or Python error". A Python error hides the key for the same
+  reason a missing interpreter does: the code that reads the environment never
+  ran. This repo's Python executor is disabled without pybind11, so the branch
+  was live, not hypothetical.
+- `test_block_integrity_rt004.sh` T1 — passed while its own message said
+  "integrity path not reached in this context".
+- `test_polyglot_taint_gov006.sh` T2 — passed on any non-zero exit: parse error,
+  missing executor, crash.
+
+### `test_orphan_kill_rt003.sh` — three defects from one unused variable
+
+`MARKER="naab_orphan_test_$$"` was declared with a comment explaining precisely
+why a unique identifier was needed, then never used: `pgrep` and `pkill` both
+matched the generic `sleep 30`. Consequences, all live: a vacuous PASS when the
+child never spawned; a spurious FAIL from any unrelated `sleep 30` on the box;
+and `pkill -f "sleep 30"` on the failure path, **killing other users' and other
+suites' processes** on a shared runner. Now observes specific PIDs — which makes
+the control possible (assert the child *did* start) and makes both the check and
+the cleanup incapable of touching anything not ours.
+
+Demonstrated rather than asserted: with the subprocess removed from the fixture,
+the old test reports `PASS: no orphan sleep process after timeout`; the new one
+reports SKIP.
+
+### Non-findings worth recording
+
+Vacuous in isolation, correct because a sibling assertion fails on the same
+absence — the `L24-02`/`L24-03` shape. Left alone, documented in place:
+`test_signing_bypass.sh` T1 (T1b fails if keygen produced no `.pub`),
+`test_challenge_fail_path.sh` A-07 (A-03 fails if the telemetry file is absent).
+
+Clean, and the pattern to copy: `test_drift_sensitivity.sh` DS-01/DS-02 —
+`${L0_SINGLE:-1}` defaults to a FAILING value so an unset measurement cannot pass,
+paired with a cross-check that quarantine fires at *some* drift level.
+
+### Method note
+
+Every fix was verified by breaking the property and confirming the assertion
+fails, then restoring. That is the only technique that has caught this class:
+five of these had been read by reviewers without the defect being visible,
+because a passing test looks identical either way.
+
+Not audited: tier 3 (`tests/gorilla`, 62 candidates) — older scenario tests,
+weaker claims, and auditing them would triple the work.

--- a/include/naab/governance.h
+++ b/include/naab/governance.h
@@ -129,6 +129,14 @@ struct LanguageConfig {
 struct LanguagesConfig {
     std::unordered_set<std::string> allowed;
     std::unordered_set<std::string> blocked;
+    // Languages that appeared in BOTH lists as written. The parser resolves the
+    // conflict immediately (blocked wins, fail-closed) by erasing them from
+    // `allowed`, so by the time any check runs the intersection is empty by
+    // construction — which made CONTRA-007 dead code testing for a state its own
+    // loader guarantees cannot exist. Recorded here so the operator can still be
+    // told their config contradicts itself; the resolution and the report are not
+    // in conflict.
+    std::unordered_set<std::string> allowed_and_blocked;
     bool require_explicit = false;
     std::unordered_map<std::string, LanguageConfig> per_language;
 };

--- a/src/runtime/governance_config.cpp
+++ b/src/runtime/governance_config.cpp
@@ -308,9 +308,13 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
                 if (l.is_string()) rules_.blocked_languages.insert(l.get<std::string>());
             }
         }
-        // naab-29 EO-08: Resolve contradictory config — blocked takes precedence
+        // naab-29 EO-08: Resolve contradictory config — blocked takes precedence.
+        // Record the overlap BEFORE erasing it: the erase is what makes CONTRA-007
+        // unable to observe the contradiction it exists to report.
         for (const auto& blocked : rules_.blocked_languages) {
-            rules_.allowed_languages.erase(blocked);
+            if (rules_.allowed_languages.erase(blocked) > 0) {
+                rules_.languages.allowed_and_blocked.insert(blocked);
+            }
         }
     }
 

--- a/src/runtime/governance_engine.cpp
+++ b/src/runtime/governance_engine.cpp
@@ -5759,16 +5759,31 @@ std::vector<ContradictionResult> GovernanceEngine::detectContradictions() {
         }
     }
 
-    // CONTRA-007: language in both allowed and blocked lists
-    for (const auto& lang : rules().languages.allowed) {
-        if (rules().languages.blocked.count(lang)) {
-            ContradictionResult c;
-            c.pattern_id = "CONTRA-007";
-            c.description = fmt::format("Language '{}' appears in both allowed and blocked lists", lang);
-            c.level = governance::EnforcementLevel::SOFT;
-            c.resolution = fmt::format("Remove '{}' from either the allowed or blocked language list", lang);
-            results.push_back(c);
-        }
+    // CONTRA-007: language in both allowed and blocked lists.
+    //
+    // This iterated languages.allowed looking for members of languages.blocked,
+    // which the loader has already made impossible: it erases every blocked
+    // language from allowed at parse time (blocked wins, fail-closed), so the
+    // intersection is empty by construction and the check could never fire. Read
+    // the overlap the loader recorded before resolving it instead.
+    //
+    // Level is `level` (contradiction_detection.max_level, ADVISORY by default)
+    // rather than the hardcoded SOFT it carried while dead. Two reasons: the
+    // hardcode ignored the cap the operator configured, and firing a dormant
+    // check at SOFT would newly exit(3) on every config with overlapping lists —
+    // a blocking change introduced by fixing a reporting gap. The danger is
+    // already neutralised fail-closed by the loader; what was missing is telling
+    // the operator. CONTRA-001 keeps its hardcoded SOFT deliberately: it is live
+    // today, so relaxing it would be a real weakening rather than a dead knob.
+    for (const auto& lang : rules().languages.allowed_and_blocked) {
+        ContradictionResult c;
+        c.pattern_id = "CONTRA-007";
+        c.description = fmt::format(
+            "Language '{}' appears in both allowed and blocked lists "
+            "(resolved in favour of blocked)", lang);
+        c.level = level;
+        c.resolution = fmt::format("Remove '{}' from either the allowed or blocked language list", lang);
+        results.push_back(c);
     }
 
     // CONTRA-008: contract defined for a function that is also banned

--- a/tests/governance_v4/test_d1_reconciliation.sh
+++ b/tests/governance_v4/test_d1_reconciliation.sh
@@ -446,14 +446,23 @@ else
     fail "A08" "claim_mismatch_count unexpected default" "$CMM_VAL"
 fi
 
-# A09: claim_accuracy absent before first tool execution (no history yet)
-# What this tests: claim_accuracy_history is empty → field not surfaced
+# A09: claim_accuracy reads 1.0 before the first tool execution.
+#
+# This asserted the field was ABSENT before any tool ran, with the comment
+# "claim_accuracy_history is empty → field not surfaced". The engine does the
+# opposite, deliberately and on both paths: agent_impl.cpp:816 emits 1.0 when
+# the history is empty, and :855 emits 1.0 when there is no DriftState at all.
+# The field is never absent. Both branches passed, so A09 could not fail — which
+# is exactly why nobody noticed its premise was inverted. An unfailable
+# assertion does not merely fail to catch regressions; it preserves whatever
+# misunderstanding it was written with.
 CA_VAL=$(echo "$OUTPUT" | grep -oP 'CLAIM_ACCURACY_DEFAULT: \K\S+' 2>/dev/null || echo "missing")
-if [ "$CA_VAL" = "absent" ] || [ "$CA_VAL" = "missing" ]; then
-    pass "A09" "claim_accuracy absent before first tool execution"
+if [ "$CA_VAL" = "1" ] || [ "$CA_VAL" = "1.0" ]; then
+    pass "A09" "claim_accuracy defaults to 1.0 before first tool execution ($CA_VAL)"
+elif [ "$CA_VAL" = "missing" ]; then
+    skip "A09" "CLAIM_ACCURACY_DEFAULT not in output — default not observable here"
 else
-    # If present, it could be a valid initial value — that's also acceptable
-    pass "A09" "claim_accuracy has initial value ($CA_VAL)"
+    fail "A09" "claim_accuracy default changed" "expected 1.0, got $CA_VAL"
 fi
 
 # A10: tool_integrity_count defaults to 0

--- a/tests/security/test_block_integrity_rt004.sh
+++ b/tests/security/test_block_integrity_rt004.sh
@@ -74,9 +74,11 @@ out=$("$NAAB" --no-governance --blocks-path "$BLOCKS_DIR" run "$SCRIPT_T1" 2>&1 
 if echo "$out" | grep -qi "tampered\|integrity.*check.*fail\|hash.*mismatch\|code_hash"; then
     ok "tampered block rejected with integrity error"
 else
-    # If block loading is not triggered in this test context, accept gracefully
+    # This branch used to pass while its own message said the integrity path was
+    # not reached. A tamper-detection test that reports success when the loader
+    # never looked at the block is asserting nothing about tamper detection.
     if echo "$out" | grep -qi "not found\|unknown.*BLOCK\|use.*error\|cannot.*load"; then
-        ok "block not found / use-statement error (integrity path not reached in this context)"
+        skip "block did not load — integrity path not reached, tamper detection not exercised"
     else
         fail "expected integrity error, got: $out"
     fi

--- a/tests/security/test_env_scrub_polyglot.sh
+++ b/tests/security/test_env_scrub_polyglot.sh
@@ -5,9 +5,10 @@
 
 set -euo pipefail
 NAAB="${1:-$(dirname "$0")/../../build/naab-lang}"
-PASS=0; FAIL=0
+PASS=0; FAIL=0; SKIP=0
 ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  SKIP: $1"; SKIP=$((SKIP + 1)); }
 
 WORKDIR="${HOME}/.naab/test_env_scrub_$$"
 mkdir -p "$WORKDIR"
@@ -175,11 +176,19 @@ if echo "$out" | grep -q "SCRUBBED"; then
 elif echo "$out" | grep -q "test_key.pem"; then
     fail "NAAB_SIGNING_KEY leaked to polyglot subprocess!"
 else
-    ok "NAAb secrets not in output (may have been scrubbed or Python error)"
+    # This used to pass, on the reasoning that the secret was "not in output
+    # (may have been scrubbed or Python error)". A Python error produces no
+    # output containing the secret for exactly the same reason a missing
+    # interpreter does: the code that would have read the environment never
+    # ran. That is not evidence of scrubbing, and it is the documented degraded
+    # state of this repo — without pybind11 the Python executor is disabled.
+    # The absent SCRUBBED sentinel is the tell: on a working run the script
+    # prints either the key or the literal default.
+    skip "NAAb secret scrub not exercised — python produced neither the key nor the SCRUBBED sentinel"
 fi
 unset NAAB_SIGNING_KEY
 echo ""
 
 TOTAL=$((PASS + FAIL))
-echo "Results: ${PASS}/${TOTAL} passed"
+echo "Results: ${PASS}/${TOTAL} passed${SKIP:+, ${SKIP} skipped}"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/security/test_governance_validity.sh
+++ b/tests/security/test_governance_validity.sh
@@ -374,9 +374,16 @@ make_script "$TDIR19/test.naab"
 OUT=$("$NAAB" --governance-dashboard "$TDIR19/test.naab" 2>&1 || true)
 if echo "$OUT" | grep -qi "CONTRA-002\|contradiction\|network.*disabled.*allowed_hosts"; then
     ok "T19: CONTRA-002 detected"
+elif [ -z "$OUT" ]; then
+    skip "T19: no dashboard output — nothing to search, detection not exercised"
 else
-    # The contradiction may be recorded but not printed without dashboard
-    ok "T19: CONTRA-002 — contradiction detection ran (advisory findings may be silent)"
+    # The old else branch passed here saying "detection ran (advisory findings may
+    # be silent)", which asserted nothing: both branches passed, so T19 could not
+    # fail on any input. The stated excuse did not apply either — the run above
+    # passes --governance-dashboard, so an advisory finding is exactly what gets
+    # printed. If the dashboard produced output and CONTRA-002 is not in it, the
+    # contradiction was not detected.
+    fail "T19: CONTRA-002 not detected in dashboard output"
 fi
 
 # T20: CONTRA-007 — language in both allowed and blocked
@@ -388,8 +395,10 @@ make_script "$TDIR20/test.naab"
 OUT=$("$NAAB" --governance-dashboard "$TDIR20/test.naab" 2>&1 || true)
 if echo "$OUT" | grep -qi "CONTRA-007\|contradiction\|both.*allowed.*blocked\|advisory"; then
     ok "T20: CONTRA-007 detected"
+elif [ -z "$OUT" ]; then
+    skip "T20: no dashboard output — detection not exercised"
 else
-    ok "T20: CONTRA-007 — contradiction detection ran (finding may be in results only)"
+    fail "T20: CONTRA-007 not detected in dashboard output"
 fi
 
 # T21: CONTRA-009 — audit level=full but output_file empty
@@ -401,8 +410,10 @@ make_script "$TDIR21/test.naab"
 OUT=$("$NAAB" --governance-dashboard "$TDIR21/test.naab" 2>&1 || true)
 if echo "$OUT" | grep -qi "CONTRA-009\|contradiction\|audit.*full.*output_file\|advisory"; then
     ok "T21: CONTRA-009 detected"
+elif [ -z "$OUT" ]; then
+    skip "T21: no dashboard output — detection not exercised"
 else
-    ok "T21: CONTRA-009 — contradiction detection ran (finding may be in results only)"
+    fail "T21: CONTRA-009 not detected in dashboard output"
 fi
 
 # T22: No contradictions in clean config

--- a/tests/security/test_orphan_kill_rt003.sh
+++ b/tests/security/test_orphan_kill_rt003.sh
@@ -3,10 +3,10 @@
 set -euo pipefail
 
 NAAB="${1:-$(dirname "$0")/../../build/naab-lang}"
-PASS=0; FAIL=0
-
+PASS=0; FAIL=0; SKIP=0
 ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  SKIP: $1"; SKIP=$((SKIP + 1)); }
 
 TMPDIR_TEST="${HOME}/.naab"
 mkdir -p "$TMPDIR_TEST"
@@ -19,35 +19,59 @@ echo ""
 # ---------------------------------------------------------------------------
 echo "[T1] Subprocess killed (not orphaned) when naab times out"
 
-# Use a unique marker string so we can identify OUR sleep child even if other
-# sleeps are running on the system.
-MARKER="naab_orphan_test_$$"
+# A unique duration, so the process we look for is OURS. The original code
+# declared a MARKER variable with a comment explaining exactly why one was
+# needed, then never used it: both pgrep and pkill matched the generic
+# "sleep 30". Three consequences, all live:
+#   - vacuous PASS — if the child never spawned, nothing matches and the orphan
+#     check reports success without a subprocess ever having existed;
+#   - spurious FAIL — any unrelated `sleep 30` on the machine fails the test;
+#   - collateral damage — the failure path ran `pkill -f "sleep 30"`, killing
+#     other users' and other suites' processes on a shared runner.
+# The fix is to observe the specific PID rather than a command pattern: it makes
+# the control possible (we can assert the child DID start) and it makes both the
+# check and the cleanup incapable of touching anything that is not ours.
+UNIQ_SLEEP="30.$(( $$ % 997 ))"
 SCRIPT_T1="${TMPDIR_TEST}/rt003_t1_$$.naab"
 cat > "$SCRIPT_T1" <<NAAB
 use process
 main {
     // This long sleep would become an orphan if we don't kill it on timeout
-    let r = process.run("sleep", ["30"])
+    let r = process.run("sleep", ["$UNIQ_SLEEP"])
     print("done")
 }
 NAAB
 
-# Run naab with a 2s timeout; the script will block on process.run("sleep 30")
-"$NAAB" "$SCRIPT_T1" --no-governance --timeout 2 >/dev/null 2>&1 || true
-# Give a moment for kill/reap to settle
-sleep 0.5
+# Run naab in the background so the child can be observed while it is alive.
+"$NAAB" "$SCRIPT_T1" --no-governance --timeout 2 >/dev/null 2>&1 &
+NAAB_PID=$!
 
-# Check no "sleep 30" process is left running (orphan check)
-# We use pgrep to look for "sleep" with arg "30".
-# Note: pgrep exits 1 when no matches found (= success for us). Wrap in a subshell
-# with || true so set -euo pipefail doesn't abort the script on no-match exit code.
-orphan_count=$( (pgrep -f "sleep 30" 2>/dev/null || true) | wc -l | tr -d ' ')
-if [[ "$orphan_count" -eq 0 ]]; then
-    ok "no orphan sleep process after timeout"
+# Control: the subprocess must actually start, or the orphan check below is
+# asserting that something which never existed was cleaned up.
+CHILD_PIDS=""
+for _ in $(seq 1 40); do
+    CHILD_PIDS=$( (pgrep -f "sleep $UNIQ_SLEEP" 2>/dev/null || true) | tr '\n' ' ')
+    [ -n "${CHILD_PIDS// /}" ] && break
+    sleep 0.1
+done
+
+wait "$NAAB_PID" 2>/dev/null || true
+sleep 0.5   # let kill/reap settle
+
+if [ -z "${CHILD_PIDS// /}" ]; then
+    skip "subprocess never started — nothing could be orphaned, kill-on-timeout not exercised"
 else
-    fail "found $orphan_count orphan 'sleep 30' process(es) after naab timeout"
-    # Kill them to not pollute the system
-    pkill -f "sleep 30" 2>/dev/null || true
+    orphan_count=0
+    for p in $CHILD_PIDS; do
+        kill -0 "$p" 2>/dev/null && orphan_count=$((orphan_count + 1))
+    done
+    if [[ "$orphan_count" -eq 0 ]]; then
+        ok "no orphan sleep process after timeout (child $CHILD_PIDS started and was reaped)"
+    else
+        fail "found $orphan_count orphan sleep process(es) after naab timeout: $CHILD_PIDS"
+        # Only ever kill PIDs we observed ourselves.
+        for p in $CHILD_PIDS; do kill -9 "$p" 2>/dev/null || true; done
+    fi
 fi
 rm -f "$SCRIPT_T1"
 
@@ -82,5 +106,5 @@ rm -f "$SCRIPT_T2"
 
 echo ""
 TOTAL=$(( PASS + FAIL ))
-echo "Results: ${PASS}/${TOTAL} passed"
+echo "Results: ${PASS}/${TOTAL} passed${SKIP:+, ${SKIP} skipped}"
 if [[ "$FAIL" -gt 0 ]]; then exit 1; fi

--- a/tests/security/test_polyglot_taint_gov006.sh
+++ b/tests/security/test_polyglot_taint_gov006.sh
@@ -67,7 +67,11 @@ if echo "$output" | grep -qiE "(taint.*violat|taint.*block|sink.*taint|hard.*blo
 elif [[ $ec -eq 0 ]]; then
     pass "T2: io.write succeeded — taint does not block non-sink operations"
 else
-    pass "T2: exited non-zero for non-governance reason (shell/io failure): ${output:0:80}"
+    # A catch-all pass on any non-zero exit: a parse error, a missing shell
+    # executor or a crash all landed here and were reported as the taint engine
+    # correctly not blocking. The absence of a taint message is only evidence
+    # once the program got far enough to reach io.write.
+    skip "T2: run failed for an unrelated reason — non-sink taint behaviour not exercised (exit $ec): ${output:0:80}"
 fi
 
 # T3: --no-governance → shell_exec not blocked even with polyglot output

--- a/tests/security/test_r11_fixes.sh
+++ b/tests/security/test_r11_fixes.sh
@@ -74,8 +74,13 @@ JSONEOF
     if ! echo "$GOV_OUTPUT2" | grep -q "no govern.json found"; then
         pass "V-GOV-009: --config-from-file opt-in loads from file's directory as expected"
     else
-        # If no govern.json was found at all even with opt-in, something else is wrong — still pass the security property
-        pass "V-GOV-009: --config-from-file flag accepted without error"
+        # The old else branch said, in its own comment, "something else is wrong —
+        # still pass the security property", and passed. Both branches passing
+        # made T2 unfailable. T2 is the opt-in control for T1: it shows the
+        # discovery path CAN reach the file's directory when asked, so T1's
+        # refusal is a policy decision rather than a broken lookup. Skip when the
+        # control does not run; do not report it as satisfied.
+        skip "V-GOV-009: opt-in found no govern.json — T1 has no positive control in this environment"
     fi
 fi
 

--- a/tests/security/test_sandbox_symlink_f.sh
+++ b/tests/security/test_sandbox_symlink_f.sh
@@ -5,9 +5,10 @@
 
 set -euo pipefail
 NAAB="${1:-$(dirname "$0")/../../build/naab-lang}"
-PASS=0; FAIL=0
+PASS=0; FAIL=0; SKIP=0
 ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  SKIP: $1"; SKIP=$((SKIP + 1)); }
 
 WORKDIR=$(mktemp -d "${TMPDIR:-/tmp}/naab_test_symlink_f_XXXXXX")
 mkdir -p "$WORKDIR"
@@ -110,9 +111,22 @@ fi
 echo ""
 
 # ---------------------------------------------------------------------------
-# F4: Symlink read works when sandbox is unrestricted (no O_NOFOLLOW applied)
+# F4: Symlink refusal does NOT depend on the sandbox LEVEL
+#
+# This was written as "symlink read works when sandbox is unrestricted (no
+# O_NOFOLLOW applied)", and all three of its branches passed, so it could not
+# fail. The premise is wrong: file_impl.cpp gates readFileNoFollow on
+# `security::ScopedSandbox::getCurrent()` — whether a sandbox is INSTALLED, not
+# what level it carries. --sandbox-level unrestricted still installs one, so
+# O_NOFOLLOW still applies. That is deliberate; the guard closes a TOCTOU window
+# between the path check and the open, which is not a path-policy question and
+# so does not relax with the policy.
+#
+# F3 ("normal file read succeeded under sandbox") is the real positive control
+# for F1/F2 — it shows file.read works on a non-symlink under the same sandbox,
+# so F1/F2 are refusals rather than a broken read path.
 # ---------------------------------------------------------------------------
-echo "[F4] Symlink read works with --sandbox-level unrestricted"
+echo "[F4] Symlink refusal is independent of sandbox level"
 cat > "$WORKDIR/test_f4.naab" << NAABEOF
 use file
 use io
@@ -123,17 +137,16 @@ main {
 NAABEOF
 
 out=$("$NAAB" "$WORKDIR/test_f4.naab" --sandbox-level unrestricted --no-governance 2>&1) || true
-if echo "$out" | grep -q "secret_content"; then
-    ok "symlink followed under unrestricted sandbox (expected)"
-elif echo "$out" | grep -qi "error\|fail"; then
-    # Could fail for other reasons (path, permissions) — acceptable
-    ok "unrestricted: non-symlink error (acceptable)"
+if echo "$out" | grep -q "path is a symlink"; then
+    ok "unrestricted sandbox still refuses the symlink (O_NOFOLLOW is level-independent)"
+elif echo "$out" | grep -q "secret_content"; then
+    fail "unrestricted sandbox followed a symlink — the TOCTOU guard now varies with level"
 else
-    ok "unrestricted: no block applied"
+    skip "unrestricted read produced neither the refusal nor the content: ${out:0:80}"
 fi
 
 echo ""
 
 TOTAL=$((PASS + FAIL))
-echo "Results: ${PASS}/${TOTAL} passed"
+echo "Results: ${PASS}/${TOTAL} passed${SKIP:+, ${SKIP} skipped}"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/security/test_stdlib_shadow_e.sh
+++ b/tests/security/test_stdlib_shadow_e.sh
@@ -5,9 +5,10 @@
 
 set -euo pipefail
 NAAB="${1:-$(dirname "$0")/../../build/naab-lang}"
-PASS=0; FAIL=0
+PASS=0; FAIL=0; SKIP=0
 ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  SKIP: $1"; SKIP=$((SKIP + 1)); }
 
 WORKDIR="${HOME}/.naab/test_shadow_e_$$"
 mkdir -p "$WORKDIR"
@@ -107,9 +108,9 @@ export function hello() { return "local_hello" }
 NAABEOF
 
 cat > "$WORKDIR/test_e4.naab" << 'NAABEOF'
-import "./subdir/mymod.naab" as * mymod
+import "./subdir/mymod.naab" as mymod
+use io
 main {
-  use io
   io.println(mymod.hello())
 }
 NAABEOF
@@ -118,12 +119,14 @@ out=$("$NAAB" "$WORKDIR/test_e4.naab" --no-governance 2>&1) || true
 if echo "$out" | grep -q "local_hello"; then
     ok "path-separated import loaded local module correctly"
 else
-    # May fail due to import syntax differences — not a regression
-    ok "path-separated import attempted (syntax may differ — not a shadow regression)"
+    # Both branches passed before, so E4 could not fail. "Syntax may differ" is a
+    # real possibility, but it means the import never resolved — which is the
+    # opposite of what the assertion title claims, not a variant of it.
+    skip "path-separated import did not resolve — shadow behaviour not exercised: ${out:0:80}"
 fi
 
 echo ""
 
 TOTAL=$((PASS + FAIL))
-echo "Results: ${PASS}/${TOTAL} passed"
+echo "Results: ${PASS}/${TOTAL} passed${SKIP:+, ${SKIP} skipped}"
 [[ "$FAIL" -eq 0 ]]


### PR DESCRIPTION
## Summary

Audited `tests/security` and `tests/governance_v4` — 105 suites, 782 `pass`/`ok` sites — for assertions satisfiable **without the property holding**. The question asked of each: *what state makes this pass when the thing it claims is untrue?*

Seven could not fail on any input: every reachable branch passed. **Three were concealing real defects**, which is the argument for doing this at all — an unfailable assertion does not merely fail to catch regressions, it preserves whatever misunderstanding it was written with.

## The three that were hiding something

**`T20` was hiding dead engine code.** `CONTRA-007` ("language in both allowed and blocked") iterated `languages.allowed` looking for members of `languages.blocked` — a set the loader empties at parse time, erasing blocked languages from allowed so blocked wins fail-closed (`governance_config.cpp` ~312). The intersection is empty by construction; **the check could never fire**. It now reads the overlap the loader records before resolving it.

Level moved from a hardcoded `SOFT` to the configured `contradiction_detection.max_level` (ADVISORY by default). Two reasons: the hardcode ignored the operator's own cap, and waking a dormant check at SOFT would newly `exit(3)` on every config with overlapping lists — a blocking change smuggled in as a reporting fix. The loader already neutralises the danger fail-closed; what was missing was telling the operator. `CONTRA-001` keeps its hardcoded SOFT deliberately: it is live today, so relaxing it would be a real weakening rather than a dead knob.

**`E4` had never executed its own program.** Two stacked fixture bugs — `as * mymod` (invalid; the form is `as name`) and `use io` inside `main` (only legal at file scope). Both fixed; E4 now passes on the property it was written for.

**`A09`'s premise was inverted.** It asserted `claim_accuracy` is absent before the first tool call. `agent_impl.cpp` emits `1.0` on both paths — empty history (`:816`) and no DriftState at all (`:855`). The field is never absent, so the branch that "accidentally" passed was the correct one. Now asserts the documented default and fails if it moves.

## Also corrected

**`F4`'s premise was false by design.** `readFileNoFollow` gates on whether a sandbox is *installed*, not on its level, so `--sandbox-level unrestricted` still refuses symlinks. That is deliberate — the guard closes a TOCTOU window between the path check and the open, which is not a path-policy question and does not relax with the policy. F4 now asserts the level-independence; F3 was the real positive control for F1/F2 all along.

**`test_orphan_kill_rt003.sh` — three defects from one unused variable.** `MARKER` was declared with a comment explaining precisely why a unique identifier was needed, then never used: `pgrep` and `pkill` both matched a generic `sleep 30`. All three consequences were live — a vacuous PASS when the child never spawned, a spurious FAIL from any unrelated `sleep 30` on the box, and `pkill -f "sleep 30"` on the failure path **killing other users' and other suites' processes** on a shared runner. Now observes specific PIDs, which makes the control possible and makes both the check and the cleanup incapable of touching anything that isn't ours.

**Catch-all `else → pass` branches converted to SKIP** — "the mechanism did not run" is not "the mechanism held". Includes a **secret-leak** test passing on *"may have been scrubbed or Python error"*: a Python error hides the key for the same reason a missing interpreter does, and this repo's Python executor is disabled without pybind11, so the branch was live rather than hypothetical.

## Non-findings, recorded

Vacuous in isolation but correct because a sibling assertion fails on the same absence (`test_signing_bypass.sh` T1, `test_challenge_fail_path.sh` A-07) — documented in place, not restructured. `test_drift_sensitivity.sh` DS-01/DS-02 is the pattern to copy: `${L0_SINGLE:-1}` defaults to a *failing* value so an unset measurement cannot pass.

## On the detector

A first pass reported 17 unfailable assertions; nesting-aware re-checking cut it to 7 — the other 10 were inner blocks inside an outer `if` that does have a `fail`. The detector needed the same correction the tests did, and both numbers were checked by hand before anything was changed.

## Test plan

- [x] Every fix verified by **breaking the property, confirming the assertion now fails, restoring** — the only technique that has caught this class
- [x] Vacuity demonstrated, not asserted: with the subprocess removed from the fixture, the old orphan-kill test reports `PASS: no orphan sleep process after timeout`; the new one reports SKIP
- [x] CONTRA-007 degraded case: reverting it to the always-empty intersection makes T20 fail again
- [x] A09 degraded case: changing the engine default to 0.5 makes A09 fail
- [x] `run-all-tests.sh` — 441 tests, 0 unexpected failures
- [x] `tests/security/test_error_msg_leaks.sh` — 874 passed, 0 failed

Not audited: tier 3 (`tests/gorilla`, 62 candidates) — older scenario tests, weaker claims, and auditing them would triple the work for the least.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC)_