### PR TITLE
Vacuity audit tier 2: a timeout suite that had never run a timeout

### DIFF
--- a/docs/governance-campaign-findings.md
+++ b/docs/governance-campaign-findings.md
@@ -988,6 +988,29 @@ scans can claim:
   built. That suite also isolates its own trust store, which is the practice the
   leaking suites below lack.
 
+And the sharpest instance in the campaign happened to the *instrument*, not the
+subject. Waiting on CI for this very PR, I armed a poll loop that counted
+incomplete checks:
+
+```
+sum(1 for c in d.get('check_runs', []) if c.get('status') != 'completed')
+```
+
+`curl` to the GitHub API is not authorized in this session — it returns
+`{"message": "GitHub access is not enabled for this session..."}`, a payload with
+no `check_runs` key. The `.get(..., [])` default turned that into an empty list,
+the sum came out `0`, and the loop announced **ALL CHECKS COMPLETED** while eight
+jobs were still running — including every compile-and-test job.
+
+"Zero incomplete checks" and "no access to any checks" are the same observation,
+and the script took the flattering reading. The `.get` default was the permissive
+branch and I never asked what could land in it — the identical mistake as the JS
+timeout branch order, made minutes after writing that lesson down, in the tool
+built to verify the audit. A monitor that cannot distinguish *the work finished*
+from *I cannot see the work* is not a monitor. Any watcher of this kind needs to
+require **positive** evidence — a check count greater than zero — exactly as
+`test_drift_sensitivity.sh` defaults `${L0_SINGLE:-1}` to a failing value.
+
 I also assumed, from the V-GOV-009 work, that `naab-lang` discovers `govern.json`
 from the CWD, and concluded that 11 of the 12 tests in `test_govern_json_config.sh`
 were loading the wrong config. That was wrong: **`naab-lang` discovers from the

--- a/docs/governance-campaign-findings.md
+++ b/docs/governance-campaign-findings.md
@@ -943,6 +943,18 @@ V-RT-002's fix is now demonstrated for the first time rather than assumed.
 Restoring the old fixture under the new assertions fails with the syntax error
 quoted; under the old assertions the identical state was a PASS.
 
+**Branch order is part of the fix, and I got it wrong first.** The
+executor-missing check lived in the final `else`, reachable only when `ec == 0`
+— but a missing JS executor exits NON-ZERO, so that branch had always been
+unreachable and the old code caught the case one branch earlier as "timeout
+enforced". Adding a fast-exit failure while leaving the check where it sat
+converted every platform without a JS executor from a false pass into a hard
+FAIL. Linux CI could not have caught it: Linux has the executor. Found by
+re-reading the diff before merge, confirmed by pointing the block at a
+nonexistent language (pre-fix: FAIL, post-fix: SKIP), and fixed by hoisting the
+executor check above the exit-code branches. The general form: **when you make a
+previously-accepting branch strict, check what used to land in it.**
+
 ### `test_govern_json_config.sh` T6 / T10
 
 Both unfailable. T6's fallback condition was `elif [ $? -eq 0 ] || true` — the

--- a/docs/governance-campaign-findings.md
+++ b/docs/governance-campaign-findings.md
@@ -908,3 +908,87 @@ because a passing test looks identical either way.
 
 Not audited: tier 3 (`tests/gorilla`, 62 candidates) — older scenario tests,
 weaker claims, and auditing them would triple the work.
+
+## Vacuity audit: tier 2
+
+`tests/governance`, `tests/cli`, `tests/property`, `tests/vm` — 39 suites, 168
+`pass`/`ok` sites. Far cleaner than tier 1 in structure, and it still contained
+the single worst assertion found in either tier.
+
+### A suite that had never tested its own subject
+
+`tests/cli/test_js_timeout_rt002.sh` exists for **V-RT-002: JS blocks respect
+`--timeout`**. Both its tests passed. Neither had ever exercised a JS timeout.
+
+Three defects stacked, each hiding the next:
+
+1. The fixture was a bare `while(true) {}`. The JS executor wraps a block as an
+   *expression*, so this is `(while(true) {}` — a `SyntaxError`. The block never
+   ran.
+2. T1's branch accepted **any** non-zero exit as proof: `elif [[ "$ec" -ne 0 ]];
+   then ok "timeout enforced"`. A parse failure in 0 seconds satisfied a test
+   for a 3-second timeout, because "the timeout fired" and "the code never
+   parsed" produce the same observation.
+3. `ec` was never reset between tests. `|| ec=$?` does not fire on success, so
+   T2 read **T1's** exit code; its catch-all `ok "non-zero exit … acceptable"`
+   then reported that as its own pass.
+
+Fixed: the fixture is now an IIFE (`(function(){ while(true) {} })()`) that the
+expression wrapper accepts; `ec` resets per test; and T1 requires `elapsed >= 2`
+alongside the non-zero exit. The elapsed floor is the load-bearing part — it is
+what makes "exited non-zero" mean the timeout rather than a crash. The corrected
+suite runs the full 3 seconds and reports `InternalError: interrupted`, so
+V-RT-002's fix is now demonstrated for the first time rather than assumed.
+
+Restoring the old fixture under the new assertions fails with the syntax error
+quoted; under the old assertions the identical state was a PASS.
+
+### `test_govern_json_config.sh` T6 / T10
+
+Both unfailable. T6's fallback condition was `elif [ $? -eq 0 ] || true` — the
+`|| true` makes it unconditional, and `$?` referred to the preceding `[ -f ]`
+test rather than to naab, so T6 passed on every possible outcome. T10's was a
+plain `else … pass "(no crash)"`.
+
+T6 was also masking a real mismatch: `govern.json` is discovered relative to the
+**script's** directory, while `governance.telemetry` resolves relative to the
+**CWD**. Running from the repo root therefore wrote `telemetry.json` into the
+repo root while the assertion looked for it in `$WORK_DIR`, and the fallback
+reported success — so neither the mis-based path nor the stray file was ever
+visible. The test now runs from `$WORK_DIR` (as T10 already did) and fails if
+the file is absent. The path-base inconsistency itself is left alone: changing
+where telemetry lands would move files for every existing user, which is not a
+change to make off a test audit.
+
+### Corrections to my own detectors
+
+The absence-guard detector reported 32 tier-2 candidates. Most were false
+positives, and the reasons are worth recording because they bound what these
+scans can claim:
+
+- `count==0` fired on `[ $RC -eq 0 ] && [ -f … ] && grep -q …` conjunctions,
+  where the exit-code test is paired with positive evidence (`test_drift_detection.sh`
+  T54/T56). Not vacuous.
+- Two hits in `tests/cli/test_report_formats.sh` were Python `pass` **statements**
+  inside a heredoc, not the shell helper.
+- `test_drift_detection.sh`'s "unchanged file passes" assertions are each
+  followed by a "modified file blocks" assertion — the pairing shape, correct as
+  built. That suite also isolates its own trust store, which is the practice the
+  leaking suites below lack.
+
+I also assumed, from the V-GOV-009 work, that `naab-lang` discovers `govern.json`
+from the CWD, and concluded that 11 of the 12 tests in `test_govern_json_config.sh`
+were loading the wrong config. That was wrong: **`naab-lang` discovers from the
+script's directory** — `naab-gov` was the binary with CWD-based discovery. Tested
+before writing it up, which is the only reason it is a paragraph here rather than
+a finding.
+
+### Still open: the trust-store leak
+
+A key dated Aug 3 sits in `~/.naab/trusted-keys`. Suites that write an unsigned
+`govern.json` then hit `INTEGRITY BLOCK` fail standalone while passing under
+`run-all-tests.sh`, which isolates the store: `test_env_scrub_polyglot.sh`,
+`test_polyglot_taint_gov006.sh`, and `test_govern_json_config.sh` (8 of 12
+failing standalone, 12/12 isolated). Pre-existing on master, and the same shape
+one level up — the harness hides the state the test would have reported. Not
+fixed here; whichever suite installs a key without isolation needs finding first.

--- a/tests/cli/test_js_timeout_rt002.sh
+++ b/tests/cli/test_js_timeout_rt002.sh
@@ -45,6 +45,17 @@ elif [[ "$elapsed" -ge 10 ]]; then
     fail "JS block ran for ${elapsed}s — timeout too slow (expected ≤8s for --timeout 3)"
 elif echo "$out" | grep -qi "interrupted\|timeout\|time limit\|exceeded"; then
     ok "JS block interrupted within ${elapsed}s with timeout message"
+elif echo "$out" | grep -qi "executor\|javascript\|not found\|not available\|node"; then
+    # This check MUST precede the exit-code branches. A missing JS executor
+    # exits NON-ZERO, so while it lived in the final `else` (reachable only when
+    # ec == 0) it was unreachable — the old code caught that case one branch
+    # earlier and called it "timeout enforced". Leaving it there while adding a
+    # fast-exit failure below would have converted every platform without a JS
+    # executor from a false pass into a hard failure.
+    #
+    # The suite's whole subject is whether the JS executor honours --timeout, so
+    # a run without one is the single outcome that proves nothing about it.
+    skip "no JS executor available — timeout enforcement not exercised"
 elif [[ "$ec" -ne 0 && "$elapsed" -ge 2 ]]; then
     # The elapsed floor is load-bearing. This branch used to accept ANY non-zero
     # exit as "timeout enforced", and the fixture above used to be a bare
@@ -56,15 +67,7 @@ elif [[ "$ec" -ne 0 && "$elapsed" -ge 2 ]]; then
 elif [[ "$ec" -ne 0 ]]; then
     fail "JS block exited non-zero in ${elapsed}s — too fast to be the 3s timeout, the block likely never ran: ${out:0:120}"
 else
-    # JavaScript executor may not be available on this platform. This said
-    # "skipped" and then counted itself as a PASS — the suite's whole subject is
-    # whether the JS executor honours --timeout, so a run without a JS executor
-    # is the one outcome that proves nothing about it.
-    if echo "$out" | grep -qi "executor\|javascript\|not found\|not available\|node"; then
-        skip "no JS executor available — timeout enforcement not exercised"
-    else
-        fail "JS block exited 0 in ${elapsed}s — expected non-zero for infinite loop: ${out:0:120}"
-    fi
+    fail "JS block exited 0 in ${elapsed}s — expected non-zero for infinite loop: ${out:0:120}"
 fi
 
 echo ""

--- a/tests/cli/test_js_timeout_rt002.sh
+++ b/tests/cli/test_js_timeout_rt002.sh
@@ -5,9 +5,10 @@
 
 set -euo pipefail
 NAAB="${1:-$(dirname "$0")/../../build/naab-lang}"
-PASS=0; FAIL=0
+PASS=0; FAIL=0; SKIP=0
 ok()   { echo "  PASS: $1"; PASS=$((PASS + 1)); }
 fail() { echo "  FAIL: $1"; FAIL=$((FAIL + 1)); }
+skip() { echo "  SKIP: $1"; SKIP=$((SKIP + 1)); }
 
 WORKDIR="${HOME}/.naab/test_rt002_$$"
 mkdir -p "$WORKDIR"
@@ -24,15 +25,17 @@ echo "[T1] JS infinite loop with --timeout 3 terminates within ~8s (not 30s)"
 cat > "$WORKDIR/test_t1.naab" << 'EOF'
 main {
   let result = <<javascript
-while(true) {}
-"unreachable"
+(function(){ while(true) {} })()
 >>
 }
 EOF
 
 start_ts=$(date +%s)
+# ec must be reset per test: `|| ec=$?` does not fire on success, so without
+# this a later test silently inherits an earlier test's exit code. T2 was
+# reading T1's non-zero status and reporting it as its own "unrelated failure".
+ec=0
 out=$(timeout 15s "$NAAB" "$WORKDIR/test_t1.naab" --vm --no-governance --timeout 3 2>&1) || ec=$?
-ec=${ec:-0}
 end_ts=$(date +%s)
 elapsed=$((end_ts - start_ts))
 
@@ -42,12 +45,23 @@ elif [[ "$elapsed" -ge 10 ]]; then
     fail "JS block ran for ${elapsed}s — timeout too slow (expected ≤8s for --timeout 3)"
 elif echo "$out" | grep -qi "interrupted\|timeout\|time limit\|exceeded"; then
     ok "JS block interrupted within ${elapsed}s with timeout message"
+elif [[ "$ec" -ne 0 && "$elapsed" -ge 2 ]]; then
+    # The elapsed floor is load-bearing. This branch used to accept ANY non-zero
+    # exit as "timeout enforced", and the fixture above used to be a bare
+    # `while(true) {}` — which the executor wraps as an expression, making it a
+    # SyntaxError that failed in 0s. So the suite for V-RT-002 reported the
+    # timeout as enforced without ever running a JS loop: "the timeout fired"
+    # and "the code never parsed" both produce a non-zero exit.
+    ok "JS block exited non-zero after ${elapsed}s (timeout enforced)"
 elif [[ "$ec" -ne 0 ]]; then
-    ok "JS block exited non-zero within ${elapsed}s (timeout enforced)"
+    fail "JS block exited non-zero in ${elapsed}s — too fast to be the 3s timeout, the block likely never ran: ${out:0:120}"
 else
-    # JavaScript executor may not be available on this platform
+    # JavaScript executor may not be available on this platform. This said
+    # "skipped" and then counted itself as a PASS — the suite's whole subject is
+    # whether the JS executor honours --timeout, so a run without a JS executor
+    # is the one outcome that proves nothing about it.
     if echo "$out" | grep -qi "executor\|javascript\|not found\|not available\|node"; then
-        ok "no JS executor available — timeout test skipped (acceptable)"
+        skip "no JS executor available — timeout enforcement not exercised"
     else
         fail "JS block exited 0 in ${elapsed}s — expected non-zero for infinite loop: ${out:0:120}"
     fi
@@ -69,21 +83,23 @@ main {
 }
 EOF
 
+ec=0
 out=$(timeout 15s "$NAAB" "$WORKDIR/test_t2.naab" --vm --no-governance --timeout 10 2>&1) || ec=$?
-ec=${ec:-0}
 
 if echo "$out" | grep -qi "timeout\|time limit\|exceeded"; then
     fail "false positive — short JS block hit timeout: ${out:0:120}"
 elif echo "$out" | grep -qi "executor\|javascript\|not found\|not available\|node"; then
-    ok "no JS executor available — false-positive test skipped (acceptable)"
+    skip "no JS executor available — false-positive check not exercised"
 elif [[ "$ec" -eq 0 ]]; then
     ok "short JS block completed without timeout"
 else
-    ok "non-zero exit (not a timeout error — acceptable): ${out:0:80}"
+    # Catch-all pass on any non-zero exit: a parse error, a crash or a missing
+    # dependency all reported "no false positive" for a block that never ran.
+    skip "short JS block failed for an unrelated reason — no-false-positive not shown (exit $ec): ${out:0:80}"
 fi
 
 echo ""
 
 TOTAL=$((PASS + FAIL))
-echo "Results: ${PASS}/${TOTAL} passed"
+echo "Results: ${PASS}/${TOTAL} passed${SKIP:+, ${SKIP} skipped}"
 [[ "$FAIL" -eq 0 ]]

--- a/tests/governance/test_govern_json_config.sh
+++ b/tests/governance/test_govern_json_config.sh
@@ -110,12 +110,21 @@ cat > "$WORK_DIR/govern.json" << 'EOF'
   "governance": { "agent_id": "test-bot", "telemetry": "telemetry.json" }
 }
 EOF
-"$NAAB" "$WORK_DIR/test.naab" 2>&1 > /dev/null
-if [ -f "$WORK_DIR/telemetry.json" ] && grep -q "test-bot" "$WORK_DIR/telemetry.json" 2>/dev/null; then
+# Run from WORK_DIR. govern.json is discovered relative to the SCRIPT's
+# directory, but governance.telemetry is resolved relative to the CWD — the two
+# bases disagree, so running this from the repo root wrote telemetry.json into
+# the repo root and the check below never found it. The fallback then reported
+# success, so neither the mis-resolved path nor the stray file was ever visible.
+(cd "$WORK_DIR" && "$NAAB" "$WORK_DIR/test.naab" > /dev/null 2>&1)
+if [ ! -f "$WORK_DIR/telemetry.json" ]; then
+  # The old branch here was `elif [ $? -eq 0 ] || true` — the `|| true` makes the
+  # condition unconditionally true, and $? referred to the [ -f ] test rather
+  # than to naab, so T6 passed on every possible outcome.
+  fail "T6: governance.telemetry from config produced no telemetry file"
+elif grep -q "test-bot" "$WORK_DIR/telemetry.json" 2>/dev/null; then
   pass "T6: governance.agent_id from config in telemetry"
-elif [ $? -eq 0 ] || true; then
-  # Agent ID is accepted without error — sufficient for config acceptance test
-  pass "T6: governance.agent_id accepted from config (no crash)"
+else
+  fail "T6: telemetry written but agent_id 'test-bot' absent"
 fi
 
 # --- Test 7: CLI --governance-verbose overrides governance.verbose:false ---
@@ -172,12 +181,14 @@ cat > "$WORK_DIR/govern.json" << 'EOF'
   "governance": { "report_json": "report.json" }
 }
 EOF
-(cd "$WORK_DIR" && "$NAAB" "$WORK_DIR/test.naab" 2>&1 > /dev/null)
+(cd "$WORK_DIR" && "$NAAB" "$WORK_DIR/test.naab" > /dev/null 2>&1)
 if [ -f "$WORK_DIR/report.json" ]; then
   pass "T10: governance.report_json creates report file"
 else
-  # Report generation may need governance checks to trigger — accept no-crash as pass
-  pass "T10: governance.report_json accepted from config (no crash)"
+  # Both branches passed before ("accept no-crash as pass"), so T10 could not
+  # fail. It does produce the file — verified — so the fallback was masking
+  # nothing here, but it would have masked the key silently ceasing to work.
+  fail "T10: governance.report_json produced no report file"
 fi
 
 # --- Test 11: No governance section → defaults work ---


### PR DESCRIPTION
## Summary

`tests/governance`, `tests/cli`, `tests/property`, `tests/vm` — 39 suites, 168 `pass`/`ok` sites. Structurally cleaner than tier 1, and it still held the worst assertion found in either tier.

## A suite that had never tested its own subject

`tests/cli/test_js_timeout_rt002.sh` exists for **V-RT-002: JS blocks respect `--timeout`**. Both its tests passed. Neither had ever exercised a JS timeout.

Three defects stacked, each hiding the next:

1. **The fixture was a bare `while(true) {}`.** The JS executor wraps a block as an *expression*, so this became `(while(true) {}` — a `SyntaxError`. The block never ran.
2. **T1 accepted any non-zero exit as proof:** `elif [[ "$ec" -ne 0 ]]; then ok "timeout enforced"`. A parse failure in 0 seconds satisfied a test for a 3-second timeout — because "the timeout fired" and "the code never parsed" produce the same observation.
3. **`ec` was never reset between tests.** `|| ec=$?` doesn't fire on success, so T2 read *T1's* exit code; its catch-all `ok "non-zero exit … acceptable"` then reported that as its own pass.

Fixed: the fixture is an IIFE (`(function(){ while(true) {} })()`) the expression wrapper accepts; `ec` resets per test; and T1 requires `elapsed >= 2` alongside the non-zero exit. **The elapsed floor is the load-bearing part** — it is what makes "exited non-zero" mean the timeout rather than a crash. The corrected suite runs the full 3 seconds and reports `InternalError: interrupted`, so V-RT-002's fix is now demonstrated for the first time rather than assumed.

Restoring the old fixture under the new assertions fails with the syntax error quoted; under the old assertions the identical state was a PASS.

## `test_govern_json_config.sh` T6 / T10

Both unfailable. T6's fallback condition was `elif [ $? -eq 0 ] || true` — the `|| true` makes it unconditional, and `$?` referred to the preceding `[ -f ]` test rather than to naab, so T6 passed on every possible outcome. T10's was a plain `else … pass "(no crash)"`.

T6 was also masking a real mismatch: **`govern.json` is discovered relative to the script's directory, while `governance.telemetry` resolves relative to the CWD.** Running from the repo root wrote `telemetry.json` into the repo root while the assertion looked for it in `$WORK_DIR`, and the fallback reported success — so neither the mis-based path nor the stray file was ever visible. The test now runs from `$WORK_DIR` (as T10 already did) and fails if the file is absent.

The path-base inconsistency itself is **documented, not changed**: moving where telemetry lands would affect every existing user, which is not a change to make off a test audit.

## Corrections to my own detectors

Recorded in the doc, because they bound what these scans can claim:

- `count==0` fired on `[ $RC -eq 0 ] && [ -f … ] && grep -q …` conjunctions, where the exit test is paired with positive evidence. Not vacuous.
- Two hits were Python `pass` **statements** inside a heredoc, not the shell helper.
- `test_drift_detection.sh`'s "unchanged file passes" assertions are each followed by a "modified file blocks" assertion — the pairing shape, correct as built. That suite also isolates its own trust store.

I also nearly published a wrong finding: that 11 of 12 tests in `test_govern_json_config.sh` load the wrong config, on the assumption (from the V-GOV-009 work) that `naab-lang` discovers `govern.json` from the CWD. **It discovers from the script's directory** — `naab-gov` was the binary with CWD-based discovery. Tested before writing it up, which is the only reason it's a paragraph rather than a finding.

## Still open, not fixed here

A trust key dated **Aug 3** sits in `~/.naab/trusted-keys`. Suites that write an unsigned `govern.json` then hit `INTEGRITY BLOCK` fail standalone while passing under `run-all-tests.sh`, which isolates the store — `test_env_scrub_polyglot.sh`, `test_polyglot_taint_gov006.sh`, and `test_govern_json_config.sh` (8 of 12 failing standalone, 12/12 isolated). Pre-existing on master, and the same shape one level up: the harness hides the state the test would have reported. Whichever suite installs a key without isolation needs finding first.

## Test plan

- [x] Every fix verified by **breaking the property, confirming the assertion fails, restoring**
- [x] JS timeout: old fixture under new assertions → FAIL naming the syntax error; new fixture → 3s elapsed, `InternalError: interrupted`
- [x] T6/T10 degraded: removing `telemetry`/`report_json` from the config makes both fail
- [x] `run-all-tests.sh` — 441 tests, 0 unexpected failures
- [x] `tests/security/test_error_msg_leaks.sh` — 874 passed, 0 failed

Tier 3 (`tests/gorilla`, 62 candidates) remains unaudited.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC)_