### PR TITLE
Fix two v2 gates that could not fail, and three inflated by the same bug

### DIFF
--- a/examples/living-script_v2/run.sh
+++ b/examples/living-script_v2/run.sh
@@ -244,7 +244,10 @@ else
         gk_fail "L1-01" "Agent creation" "only $AGENTS_CREATED agents, expected >= 8"
     fi
 
-    OP_ACTIONS=$(echo "$OUTPUT" | grep -cE 'OPERATOR|action=' || true)
+    # BRE: 'OPERATOR|action=' is a literal marker, not an alternation of
+    # "OPERATOR" or "action=". Under -E this counted every line containing
+    # either token, inflating the operator-consultation count.
+    OP_ACTIONS=$(echo "$OUTPUT" | grep -c 'OPERATOR|action=' || true)
     if [ "$OP_ACTIONS" -ge 3 ]; then
         pass "L1-02" "Operator consulted ($OP_ACTIONS times)"
     else
@@ -257,7 +260,7 @@ else
         gk_fail "L1-03" "No adjustments tracked (ADJUSTMENTS=$ADJUSTMENTS)"
     fi
 
-    if echo "$OUTPUT" | grep -qE 'PHASE|INIT'; then
+    if echo "$OUTPUT" | grep -q 'PHASE|INIT|'; then
         pass "L1-04" "PM agent created (INIT phase reached)"
     else
         gk_fail "L1-04" "PM agent not created (no INIT phase)"
@@ -274,7 +277,7 @@ else
     # ============================================================
     echo -e "${CYAN}Level 2: Pytest Validation${NC}"
 
-    PYTEST_RUNS=$(echo "$OUTPUT" | grep -cE 'PYTEST|exit=' || true)
+    PYTEST_RUNS=$(echo "$OUTPUT" | grep -c 'PYTEST|exit=' || true)
     if [ "$PYTEST_RUNS" -ge 1 ]; then
         pass "L2-01" "Pytest executed ($PYTEST_RUNS runs)"
     else
@@ -423,7 +426,13 @@ else
         gk_fail "L7-02" "deploy.sh syntax not validated"
     fi
 
-    if echo "$OUTPUT" | grep -qE 'CODEGEN_EXEC|shell|SHELL_CODEGEN|'; then
+    # BRE, not -E: every marker this harness emits is pipe-delimited, so in an
+    # extended regex an unescaped `|` is alternation rather than the literal it
+    # was meant to be. This pattern was 'CODEGEN_EXEC|shell|SHELL_CODEGEN|' under
+    # -E — a trailing EMPTY alternative, which matches every non-empty line, so
+    # L7-03 could not fail on any run that produced output at all.
+    # The real evidence is the telemetry audit line: TELEMETRY_AUDIT|type=CODEGEN_EXEC|count=N
+    if echo "$OUTPUT" | grep -q 'type=CODEGEN_EXEC|count=[1-9]'; then
         pass "L7-03" "Shell codegen.run executed"
     else
         gk_fail "L7-03" "Shell codegen.run not executed"
@@ -482,7 +491,9 @@ else
 
     if ! govkill_block "L10-*" 'PHASE|FAN_OUT_REVIEW|'; then
 
-    if echo "$OUTPUT" | grep -qE 'FAN_OUT|judges=|FAN_OUT_REVIEW|'; then
+    # Was 'FAN_OUT|judges=|FAN_OUT_REVIEW|' under -E: trailing empty alternative,
+    # so L10-01 passed on any non-empty output. BRE keeps the pipes literal.
+    if echo "$OUTPUT" | grep -q 'PHASE|FAN_OUT_REVIEW|'; then
         pass "L10-01" "Fan-out review executed"
     else
         gk_fail "L10-01" "Fan-out review not executed"


### PR DESCRIPTION
## The bug

Every marker this harness emits is pipe-delimited (`PHASE|INIT|start`), so inside `grep -E` an unescaped `|` is **alternation**, not the literal it was meant to be. Five sites in v2 got this wrong. v1 escapes correctly throughout.

## Two gates were structurally unfailable

`'CODEGEN_EXEC|shell|SHELL_CODEGEN|'` and `'FAN_OUT|judges=|FAN_OUT_REVIEW|'` each end in an **empty alternative**, which matches every non-empty line:

```
$ echo "totally unrelated line" | grep -qE 'FAN_OUT|judges=|FAN_OUT_REVIEW|' && echo MATCH
MATCH
```

So `L7-03` "Shell codegen.run executed" and `L10-01` "Fan-out review executed" passed on **any** run that produced output at all. Only a wholly empty run could fail them, and `RUN-01` already covers that case.

Both also named markers the script never prints. Checked against the committed Aug 3 keyed run: `CODEGEN_EXEC` appears only as `TELEMETRY_AUDIT|type=CODEGEN_EXEC|count=N`, and `SHELL_CODEGEN` only as `PHASE|SHELL_CODEGEN_BOUNDARY|start`. The gates now match evidence that actually exists.

## Three more were badly over-broad

| gate | pattern | counted on a real run | true value |
|---|---|---|---|
| `L1-02` | `'OPERATOR\|action='` | **14** | 6 |
| `L2-01` | `'PYTEST\|exit='` | **92** | 12 (7.7× inflated) |
| `L1-04` | `'PHASE\|INIT'` | matched any line containing `PHASE` *or* `INIT` | — |

All five now use BRE, where `|` is literal.

## Verification

Each fixed pattern checked both ways against the committed keyed run — it must match the real output **and** reject unrelated input:

```
  L7-03    real=MATCH unrelated=no     OK (failable + still true)
  L10-01   real=MATCH unrelated=no     OK (failable + still true)
  L1-04    real=MATCH unrelated=no     OK (failable + still true)
  L1-02    real=MATCH unrelated=no     OK (failable + still true)
  L2-01    real=MATCH unrelated=no     OK (failable + still true)
```

Both counting gates still clear their thresholds (6 ≥ 3, 12 ≥ 1), so **no gate flips to failing**. The inflation was never load-bearing — it just meant the numbers reported were not the numbers measured.

`bash -n` clean. No keyless run was performed in the working tree, because a keyless run overwrites `summary.json` and would have clobbered the committed keyed record — that's a separate known bug, noted below.

## Deliberately not fixed here

Ten further sites in v2 use unescaped `|` where a literal was meant (lines 293, 299, 305, 311, 381, 387, 399, 518, 524, 551, 584, 646). They are **over-broad rather than strictly unfailable**, and several reference markers — `BUILD_ENGINE`, `TEST_HARNESS`, `DEPLOY_SCRIPT` — that appear **nowhere** in a real run, so those gates are currently passing on their loose alternatives alone. Fixing them needs marker archaeology against real output and belongs with the gate-harness retrofit, not a hotfix.

Also unfixed and worth tracking: a keyless run overwrites `summary.json` (this already destroyed the v2 `108/0/1` record), the keyless placeholder count `seq 1 115` is hand-maintained and doesn't match the real keyed total of 109, and v2's `summary.json` lacks the `failed` ID array that v1 carries.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC)_