### PR TITLE
Add a gate library that makes a gate's failure case mandatory

### DIFF
--- a/tests/governance_v4/test_gatelib.sh
+++ b/tests/governance_v4/test_gatelib.sh
@@ -1,0 +1,169 @@
+#!/usr/bin/env bash
+# ============================================================
+# test_gatelib.sh — the gate library proves gates failable, including its own
+#
+# gatelib.sh exists because a gate that cannot fail is indistinguishable from a
+# gate that passes. This suite has to demonstrate that claim rather than assert
+# it, so it registers a KNOWN-UNFAILABLE gate (GL-BAD, carrying the exact
+# grep -E trailing-empty-alternative defect that made living-script_v2's L7-03
+# and L10-01 match every line) and requires the self-test to catch it.
+#
+# GL-05 is the load-bearing case. Without it this suite would pass just as
+# happily against a self-test that rubber-stamped everything.
+# ============================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers/gatelib.sh"
+source "$SCRIPT_DIR/../helpers/gate_selftest.sh"
+
+if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
+    _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
+else
+    _SYSTMP="${TMPDIR:-/tmp}"
+fi
+TEST_TMP="${_SYSTMP}/gatelib-$$"
+trap 'rm -rf "$TEST_TMP"' EXIT
+FIX="$TEST_TMP/fixtures"
+mkdir -p "$TEST_TMP"
+
+# ------------------------------------------------------------------
+# Fixtures: a good gate, and a deliberately broken one
+# ------------------------------------------------------------------
+mk() { mkdir -p "$FIX/$1/$2"; printf '%s\n' "$3" > "$FIX/$1/$2/stdout.txt"; }
+
+mk GL-DEMO pass 'PHASE|INIT|start
+CREATED|agent=builder
+PHASE|INIT|end'
+mk GL-DEMO fail 'PHASE|INIT|start
+nothing useful happened here'
+
+# The unfailable gate gets the same fixtures. Its fail/ fixture is non-empty,
+# which is exactly the condition its broken pattern matches.
+mk GL-BAD pass 'PHASE|INIT|start
+CREATED|agent=builder'
+mk GL-BAD fail 'PHASE|INIT|start
+nothing useful happened here'
+
+# ------------------------------------------------------------------
+# Suite under test
+# ------------------------------------------------------------------
+gate_init "gatelib-demo"
+gate_def GL-DEMO INIT "agent creation marker present"
+gate_def GL-BAD  INIT "deliberately unfailable (trailing empty alternative)"
+
+gate_GL_DEMO() {
+    if grep_alt "$G_OUT" 'CREATED|agent='; then
+        pass GL-DEMO "agent creation marker present"
+    else
+        fail GL-DEMO "no agent creation marker"
+    fi
+}
+
+# The defect, preserved verbatim: under -E the trailing `|` is an empty
+# alternative, so this matches any non-empty line.
+gate_GL_BAD() {
+    if echo "x" | grep -qE 'CREATED|agent=|'; then
+        pass GL-BAD "matched"
+    else
+        fail GL-BAD "did not match"
+    fi
+}
+
+# Deliberately EMPTY for the demo run. Pointing it at this file made the
+# registry lint fire on GL-01..GL-06 — the assertion ids below, which are not
+# registered while the demo suite is loaded — so the self-test exited non-zero
+# for a reason unrelated to failability, and GL-03 passed even with
+# unfailable-detection disabled. The lint gets its own isolated case (GL-07).
+GATE_SOURCES=()
+
+# ------------------------------------------------------------------
+# Run the self-test and assert on its verdict
+# ------------------------------------------------------------------
+SELFTEST_OUT="$TEST_TMP/selftest.txt"
+gate_selftest_run "$FIX" > "$SELFTEST_OUT" 2>&1; SELFTEST_RC=$?
+
+# The self-test used gate_* counters; reset before asserting with them.
+gate_init "test_gatelib"
+gate_def GL-01 SELFTEST "good gate proven failable"
+gate_def GL-02 SELFTEST "unfailable gate detected"
+gate_def GL-03 SELFTEST "self-test exits non-zero when a gate is unprovable"
+gate_def GL-04 SELFTEST "count_matches returns a usable integer on no match"
+gate_def GL-05 SELFTEST "grep_alt cannot express a trailing empty alternative"
+gate_def GL-06 SELFTEST "phase_complete requires both start and end"
+gate_def GL-07 SELFTEST "registry lint catches an unregistered gate id"
+
+echo ""
+echo -e "${CYAN}+==============================================================+${NC}"
+echo -e "${CYAN}|  gatelib: gates prove themselves failable                    |${NC}"
+echo -e "${CYAN}+==============================================================+${NC}"
+echo ""
+
+grep -q 'PROVEN.*GL-DEMO' "$SELFTEST_OUT" \
+    && pass GL-01 "good gate proven failable" \
+    || fail GL-01 "self-test did not prove the good gate" "$(head -20 "$SELFTEST_OUT")"
+
+grep -q 'NOT FAILABLE.*GL-BAD' "$SELFTEST_OUT" \
+    && pass GL-02 "unfailable gate detected" \
+    || fail GL-02 "self-test did NOT catch the unfailable gate" "$(head -20 "$SELFTEST_OUT")"
+
+[ "$SELFTEST_RC" -ne 0 ] \
+    && pass GL-03 "self-test exits non-zero when a gate is unprovable" \
+    || fail GL-03 "self-test exited 0 despite an unfailable gate"
+
+# The "0\n0" trap: grep -c prints 0 AND exits 1, so `|| echo 0` yields a
+# two-line string that every later integer test errors on.
+: > "$TEST_TMP/empty.txt"
+N=$(count_matches 'nothing-matches-this' "$TEST_TMP/empty.txt")
+if [ "$N" = "0" ] && [ "$N" -eq 0 ] 2>/dev/null; then
+    pass GL-04 "count_matches returns a usable integer on no match (got '$N')"
+else
+    fail GL-04 "count_matches returned an unusable value" "got '$N'"
+fi
+
+# grep_alt drops empty alternatives, so the defect cannot be expressed.
+printf 'totally unrelated line\n' > "$TEST_TMP/unrel.txt"
+if grep_alt "$TEST_TMP/unrel.txt" 'CREATED|agent=' '' ; then
+    fail GL-05 "grep_alt matched an unrelated line — the empty alternative survived"
+else
+    pass GL-05 "grep_alt cannot express a trailing empty alternative"
+fi
+
+printf 'PHASE|X|start\n' > "$TEST_TMP/half.txt"
+G_OUT="$TEST_TMP/half.txt"
+if phase_complete X; then
+    fail GL-06 "phase_complete accepted a start with no end"
+else
+    printf 'PHASE|X|start\nPHASE|X|end\n' > "$TEST_TMP/whole.txt"
+    G_OUT="$TEST_TMP/whole.txt"
+    phase_complete X \
+        && pass GL-06 "phase_complete requires both start and end" \
+        || fail GL-06 "phase_complete rejected a complete phase"
+fi
+
+# GL-07: the lint, isolated. A gate id emitted by a body but never gate_def'd
+# is a gate nobody can prove; a declared id no run emits has silently stopped
+# existing. Tested on its own file so its verdict cannot be confused with the
+# failability verdicts above — which is precisely the mistake this suite made
+# on its first run.
+LINTSRC="$TEST_TMP/lintsrc.sh"
+printf '%s\n' 'gate_GL_LINT() { pass "GL-UNREGISTERED" "never declared"; }' > "$LINTSRC"
+(
+    source "$SCRIPT_DIR/../helpers/gatelib.sh"
+    source "$SCRIPT_DIR/../helpers/gate_selftest.sh"
+    gate_init lint-demo
+    gate_def GL-LINT LINT "declared"
+    mkdir -p "$FIX/GL-LINT/fail"
+    printf 'x\n' > "$FIX/GL-LINT/fail/stdout.txt"
+    gate_GL_LINT() { fail GL-LINT "always fails"; }
+    GATE_SOURCES=("$LINTSRC")
+    gate_selftest_run "$FIX" 2>&1
+) > "$TEST_TMP/lint.txt" 2>&1
+if grep -q 'UNREGISTERED.*GL-UNREGISTERED' "$TEST_TMP/lint.txt"; then
+    pass GL-07 "registry lint catches an unregistered gate id"
+else
+    fail GL-07 "lint missed an unregistered id" "$(head -10 "$TEST_TMP/lint.txt")"
+fi
+
+gate_print_summary
+gate_exit

--- a/tests/helpers/gate_selftest.sh
+++ b/tests/helpers/gate_selftest.sh
@@ -1,0 +1,118 @@
+#!/usr/bin/env bash
+# ============================================================
+# gate_selftest.sh — prove every gate can fail, without an API key.
+#
+# A keyed run costs money and ~30 minutes, so "can this assertion fail?" must
+# be answerable without one. It is answerable, because a gate reads only G_OUT
+# and G_TELE: point those at a crafted fixture instead of a live run's
+# artifacts and the gate cannot tell the difference.
+#
+# For each registered gate:
+#   fixtures/<ID>/pass/  -> the gate must emit exactly one PASS
+#   fixtures/<ID>/fail/  -> the gate must emit exactly one FAIL
+#
+# Both directions are load-bearing. Without the fail/ half a gate that always
+# passes looks perfect. Without the pass/ half a gate can be "fixed" by making
+# it match nothing, which also always fails and is equally useless.
+#
+# A gate with no fail/ fixture is itself reported as a failure. That is the
+# whole point: vacuity becomes impossible to ADD, rather than something a
+# reviewer is expected to notice.
+#
+# USAGE
+#   gate_selftest_run <fixtures_dir>     # after gate_init + gate_def + bodies
+# ============================================================
+
+# Run one gate against one fixture directory; echo the verdict it produced.
+# Verdict is PASS/FAIL/SKIP/NONE/MULTI so the caller can insist on exactly one.
+_gate_selftest_invoke() {
+    local id="$1" dir="$2"
+    G_OUT="$dir/stdout.txt"; G_TELE="$dir/telemetry.jsonl"
+    [ -f "$G_OUT" ]  || : > "$G_OUT"
+    [ -f "$G_TELE" ] || : > "$G_TELE"
+    # A fixture describes the artifacts, not the run's liveness — clear the
+    # gov-kill state so gk_fail does not silently convert an expected FAIL
+    # into a SKIP and hide an unfailable gate.
+    GOV_KILL=""; RUN_TRUNCATED=""
+    local qsave="$GATE_QUIET"; GATE_QUIET=1
+    gate_reset_counters
+    gate_run "$id"
+    GATE_QUIET="$qsave"
+    local n=$((PASS_COUNT + FAIL_COUNT + SKIP_COUNT))
+    if   [ "$n" -eq 0 ]; then echo "NONE"
+    elif [ "$n" -gt 1 ]; then echo "MULTI"
+    elif [ "$PASS_COUNT" -eq 1 ]; then echo "PASS"
+    elif [ "$FAIL_COUNT" -eq 1 ]; then echo "FAIL"
+    else echo "SKIP"; fi
+}
+
+# $1 = fixtures root. Returns non-zero if any gate is unproven.
+gate_selftest_run() {
+    local root="$1"
+    local ids=("${GATE_IDS[@]}")
+    local descs=("${GATE_DESCS[@]}")
+    local bad=0 i id got
+
+    echo ""
+    echo -e "${CYAN}+==============================================================+${NC}"
+    echo -e "${CYAN}|  Gate self-test — every gate must fail on its fail fixture   |${NC}"
+    echo -e "${CYAN}+==============================================================+${NC}"
+    echo ""
+
+    if [ "${#ids[@]}" -eq 0 ]; then
+        echo -e "  ${RED}NO GATES REGISTERED${NC} — nothing to prove"
+        return 1
+    fi
+
+    for i in "${!ids[@]}"; do
+        id="${ids[$i]}"
+        local fdir="$root/$id/fail" pdir="$root/$id/pass"
+
+        if [ ! -d "$fdir" ]; then
+            echo -e "  ${RED}UNPROVEN${NC} [$id] no fail/ fixture — this gate has never been seen to fail"
+            bad=$((bad + 1)); continue
+        fi
+
+        got=$(_gate_selftest_invoke "$id" "$fdir")
+        if [ "$got" != "FAIL" ]; then
+            echo -e "  ${RED}NOT FAILABLE${NC} [$id] fail/ fixture produced $got, expected FAIL"
+            bad=$((bad + 1)); continue
+        fi
+
+        if [ -d "$pdir" ]; then
+            got=$(_gate_selftest_invoke "$id" "$pdir")
+            if [ "$got" != "PASS" ]; then
+                echo -e "  ${RED}NOT SATISFIABLE${NC} [$id] pass/ fixture produced $got, expected PASS"
+                bad=$((bad + 1)); continue
+            fi
+            echo -e "  ${GREEN}PROVEN${NC} [$id] fails on fail/, passes on pass/"
+        else
+            echo -e "  ${YELLOW}PARTIAL${NC} [$id] fails on fail/; no pass/ fixture, so it could be matching nothing"
+        fi
+    done
+
+    # Registry lint: an id emitted by a gate body but never declared is a gate
+    # nobody can prove, and a declared id no run emits is a gate that has
+    # silently stopped existing. Both are invisible without this check.
+    local src lint_bad=0
+    for src in "${GATE_SOURCES[@]:-}"; do
+        [ -f "$src" ] || continue
+        while IFS= read -r lit; do
+            [ -n "$lit" ] || continue
+            if ! gate_registered "$lit"; then
+                echo -e "  ${RED}UNREGISTERED${NC} [$lit] emitted by $(basename "$src") but never gate_def'd"
+                lint_bad=$((lint_bad + 1))
+            fi
+        done < <(grep -ohE '\b(pass|fail|skip|gk_fail) +"?[A-Za-z0-9][A-Za-z0-9._-]*"?' "$src" \
+                 | awk '{print $2}' | tr -d '"' | sort -u)
+    done
+    bad=$((bad + lint_bad))
+
+    echo ""
+    if [ "$bad" -eq 0 ]; then
+        echo -e "  ${GREEN}All ${#ids[@]} gates proven failable.${NC}"
+        return 0
+    fi
+    echo -e "  ${RED}$bad gate(s) unproven.${NC} A gate that cannot fail is not a test."
+    return 1
+}

--- a/tests/helpers/gatelib.sh
+++ b/tests/helpers/gatelib.sh
@@ -1,0 +1,223 @@
+#!/usr/bin/env bash
+# ============================================================
+# gatelib.sh — one definition of a test gate, and the machinery that makes a
+# gate's failure case provable.
+#
+# WHY THIS EXISTS
+#
+# 146 shell suites in this repo each declare their own pass/fail/skip. That
+# duplication is survivable. What is not survivable is that a gate can be
+# written which cannot fail, and nothing notices — because a passing gate and
+# an unfailable gate produce identical output. Found repeatedly:
+#
+#   * seven assertions in tests/security + tests/governance_v4 where every
+#     reachable branch passed (three were concealing real defects);
+#   * examples/living-script_v2 L7-03 and L10-01, whose grep -E patterns ended
+#     in an empty alternative and so matched every non-empty line;
+#   * a JS timeout suite that had never once run a JS timeout.
+#
+# None were caught by review. Every one was caught by running the degraded
+# case. So the degraded case stops being a thing someone remembers to do:
+# every gate declares itself in a registry, ships a fixture on which it MUST
+# fail, and `gate_selftest.sh` enforces both — keylessly, in CI.
+#
+# THE CONTRACT
+#
+# A gate is a shell function `gate_<id>` reading exactly two globals:
+#     G_OUT   path to a file holding captured run stdout
+#     G_TELE  path to telemetry.jsonl
+# and calling pass/fail/skip/gk_fail exactly once. Nothing in a gate may know
+# whether those bytes came from a live run or a fixture. That is the entire
+# refactor that makes a gate independently invocable.
+#
+# USAGE
+#     source "$SCRIPT_DIR/../../tests/helpers/gatelib.sh"
+#     gate_init "my-suite"
+#     gate_def L1-01 INIT "agent created"
+#     gate_L1_01() { grep -q 'CREATED' "$G_OUT" && pass L1-01 "agent created" \
+#                                              || fail L1-01 "no agent"; }
+#     G_OUT=$WORKDIR/stdout.txt G_TELE=$WORKDIR/telemetry.jsonl
+#     gate_run L1-01
+#     gate_summary_json "$RESULTS/summary.json" keyed
+#     gate_exit
+# ============================================================
+
+# --- counters -------------------------------------------------------------
+PASS_COUNT=0; FAIL_COUNT=0; SKIP_COUNT=0; TOTAL=0
+FAILURES=""
+# Machine-readable failure IDs. summary.json used to record only a COUNT, and
+# the identities lived solely in results_<ts>.txt — which one keyed run did not
+# commit, leaving "fail: 1" in the permanent record with nothing naming it.
+FAILED_IDS=""
+EMITTED_IDS=""
+
+GATE_SUITE=""
+GATE_QUIET="${GATE_QUIET:-}"      # self-test sets this to suppress per-gate echo
+
+# Registry: parallel indexed arrays rather than an associative array, so this
+# works on bash 3.2 (macOS) as well as 4+.
+GATE_IDS=(); GATE_PHASES=(); GATE_DESCS=()
+
+RED='\033[0;31m'; GREEN='\033[0;32m'; YELLOW='\033[1;33m'; CYAN='\033[0;36m'; NC='\033[0m'
+
+gate_init() {
+    GATE_SUITE="${1:-suite}"
+    gate_reset_counters
+    GATE_IDS=(); GATE_PHASES=(); GATE_DESCS=()
+}
+
+gate_reset_counters() {
+    PASS_COUNT=0; FAIL_COUNT=0; SKIP_COUNT=0; TOTAL=0
+    FAILURES=""; FAILED_IDS=""; EMITTED_IDS=""
+}
+
+# --- verdicts -------------------------------------------------------------
+_gate_note_emitted() { EMITTED_IDS="${EMITTED_IDS}${EMITTED_IDS:+ }$1"; }
+
+pass() {
+    local id="$1" desc="${2:-}"
+    PASS_COUNT=$((PASS_COUNT + 1)); TOTAL=$((TOTAL + 1)); _gate_note_emitted "$id"
+    [ -n "$GATE_QUIET" ] || echo -e "  ${GREEN}PASS${NC} [$id] $desc"
+}
+
+fail() {
+    local id="$1" desc="${2:-}" detail="${3:-}"
+    FAIL_COUNT=$((FAIL_COUNT + 1)); TOTAL=$((TOTAL + 1)); _gate_note_emitted "$id"
+    FAILURES="${FAILURES}\n  [$id] $desc${detail:+ -- $detail}"
+    FAILED_IDS="${FAILED_IDS}${FAILED_IDS:+,}\"$id\""
+    [ -n "$GATE_QUIET" ] || { echo -e "  ${RED}FAIL${NC} [$id] $desc"
+        [ -n "$detail" ] && echo -e "       ${RED}-> $detail${NC}"; }
+    return 0
+}
+
+skip() {
+    local id="$1" desc="${2:-}" reason="${3:-}"
+    SKIP_COUNT=$((SKIP_COUNT + 1)); TOTAL=$((TOTAL + 1)); _gate_note_emitted "$id"
+    [ -n "$GATE_QUIET" ] || echo -e "  ${YELLOW}SKIP${NC} [$id] $desc${reason:+ -- $reason}"
+}
+
+# --- governance-kill awareness -------------------------------------------
+# A run killed by governance (exit 3) is governance succeeding, not the harness
+# failing, so checks on phases never reached report SKIP rather than FAIL.
+GOV_KILL=""; RUN_TRUNCATED=""
+
+run_incomplete() { [ -n "$GOV_KILL" ] || [ -n "$RUN_TRUNCATED" ]; }
+
+incomplete_reason() {
+    if [ -n "$GOV_KILL" ]; then echo "governance kill: $GOV_KILL"
+    else echo "run truncated: $RUN_TRUNCATED"; fi
+}
+
+gk_fail() {
+    local id="$1" desc="${2:-}" detail="${3:-}"
+    if run_incomplete; then skip "$id" "$desc" "unreached — $(incomplete_reason)"
+    else fail "$id" "$desc" "$detail"; fi
+}
+
+# Skip every registered gate whose id starts with <prefix> when the run died
+# before <marker>'s phase began. The old form emitted ONE skip under a glob-ish
+# label ("L19b-*") that never appeared as a pass, so a diff of gate ids across
+# runs could not tell "suppressed" from "deleted". Fanning out over the registry
+# keeps suppressed gates in the same namespace as the gates they suppress.
+govkill_block() {
+    local prefix="$1" marker="$2" i id
+    run_incomplete || return 1
+    grep -q "$marker" "$G_OUT" 2>/dev/null && return 1
+    for i in "${!GATE_IDS[@]}"; do
+        id="${GATE_IDS[$i]}"
+        case "$id" in
+            "$prefix"*) skip "$id" "${GATE_DESCS[$i]}" "not reached ($(incomplete_reason))" ;;
+        esac
+    done
+    return 0
+}
+
+# --- registry -------------------------------------------------------------
+gate_def() {
+    GATE_IDS+=("$1"); GATE_PHASES+=("${2:-}"); GATE_DESCS+=("${3:-}")
+}
+
+gate_fn_name() { echo "gate_$(echo "$1" | tr '.-' '__')"; }
+
+gate_run() {
+    local fn; fn="$(gate_fn_name "$1")"
+    if ! declare -F "$fn" >/dev/null 2>&1; then
+        fail "$1" "gate function $fn is not defined"
+        return 0
+    fi
+    "$fn"
+}
+
+gate_registered() {
+    local i
+    for i in "${!GATE_IDS[@]}"; do [ "${GATE_IDS[$i]}" = "$1" ] && return 0; done
+    return 1
+}
+
+# --- matching helpers -----------------------------------------------------
+# Every marker this repo's harnesses emit is pipe-delimited (PHASE|INIT|start),
+# so inside grep -E an unescaped `|` is alternation rather than the literal it
+# was meant to be. Two v2 gates ended in an EMPTY alternative and matched every
+# line as a result. Taking alternatives as separate ARGUMENTS makes that defect
+# unrepresentable: a caller cannot write a trailing empty alternative because
+# there is no string syntax to get it wrong in.
+#
+# Only `|` is escaped. Other regex metacharacters still work, so a caller can
+# write 'count=[1-9]'. That is deliberate: this fixes one defect class rather
+# than degrading every pattern to a fixed string.
+grep_alt() {
+    local file="$1"; shift
+    local pat="" a
+    for a in "$@"; do
+        [ -n "$a" ] || continue          # an empty alternative is the bug; drop it
+        a=${a//|/\\|}
+        pat="${pat}${pat:+|}${a}"
+    done
+    [ -n "$pat" ] || return 1
+    grep -qE "$pat" "$file" 2>/dev/null
+}
+
+# grep -c PRINTS "0" and EXITS 1 when nothing matches, so `|| echo 0` appends a
+# SECOND zero and the variable becomes the non-integer "0\n0". Every later
+# integer test then errors, bash reads the error as false, and the gate reports
+# the opposite of the truth. Use `|| true` and default the empty case.
+count_matches() {
+    local n
+    n=$(grep -c "$1" "$2" 2>/dev/null || true)
+    n=$(echo "$n" | head -1)
+    echo "${n:-0}"
+}
+
+# A phase is only ever "reached" if you check for its start marker alone, which
+# makes truncation mid-phase indistinguishable from completion.
+phase_complete() {
+    grep -q "PHASE|$1|start" "$G_OUT" 2>/dev/null && \
+    grep -q "PHASE|$1|end" "$G_OUT" 2>/dev/null
+}
+
+# --- reporting ------------------------------------------------------------
+# mode is keyed|keyless|selftest. Only a keyed run may claim summary.json:
+# a keyless run overwriting it already destroyed one keyed record permanently.
+gate_summary_json() {
+    local path="$1" mode="${2:-keyed}" dir base
+    dir="$(dirname "$path")"; base="$(basename "$path" .json)"
+    mkdir -p "$dir"
+    local commit; commit=$(git -C "$dir" rev-parse HEAD 2>/dev/null || echo unknown)
+    cat > "$dir/${base}_${mode}.json" << EOF
+{"suite": "$GATE_SUITE", "mode": "$mode", "pass": $PASS_COUNT, "fail": $FAIL_COUNT,
+ "skip": $SKIP_COUNT, "total": $TOTAL, "registered": ${#GATE_IDS[@]},
+ "governance_kill": "${GOV_KILL:-}", "commit": "$commit", "failed": [$FAILED_IDS]}
+EOF
+    [ "$mode" = "keyed" ] && cp "$dir/${base}_${mode}.json" "$path"
+    return 0
+}
+
+gate_print_summary() {
+    echo ""
+    echo -e "${CYAN}+==============================================================+${NC}"
+    echo -e "  Total: $TOTAL | ${GREEN}Pass: $PASS_COUNT${NC} | ${RED}Fail: $FAIL_COUNT${NC} | ${YELLOW}Skip: $SKIP_COUNT${NC}  (registered: ${#GATE_IDS[@]})"
+    if [ "$FAIL_COUNT" -gt 0 ]; then echo -e "${RED}Failures:${NC}$FAILURES"; fi
+}
+
+# exit $FAIL_COUNT wraps above 255 and collides with the engine's own exit 3.
+gate_exit() { [ "$FAIL_COUNT" -eq 0 ]; }


### PR DESCRIPTION
Increment 1 of the vacuity roadmap. **No callers yet** — the library, the self-test driver, and a suite proving the machinery works.

## Why

A gate that cannot fail is indistinguishable from a gate that passes. That has now happened often enough to stop treating it as a review problem:

- seven assertions in `tests/security` + `tests/governance_v4` where **every reachable branch passed** (three concealing real defects)
- v2's `L7-03` and `L10-01` matching every non-empty line (#132)
- a JS timeout suite that had **never once run a timeout** (#127)
- twelve `governance_v4` suites CI had never executed (#129)

None were caught by review. Every one was caught by running the degraded case. So the degraded case stops being something someone remembers to do.

## The contract

A gate is a function reading exactly two globals — `G_OUT` (captured stdout) and `G_TELE` (telemetry) — so it **cannot tell a live run from a fixture**. That substitution is the entire refactor needed to make a gate independently invocable, which is what lets "can this fail?" be answered keylessly while "did the property hold?" stays the expensive live question.

## `tests/helpers/gatelib.sh`

One definition replacing what 146 suites each redeclare. Each helper closes a defect found in the existing harnesses:

| helper | closes |
|---|---|
| `grep_alt` | alternatives as separate **arguments**, escaping literal `\|` — the trailing-empty-alternative bug becomes *unrepresentable*, not merely fixed |
| `count_matches` | `\|\| true` + `${V:-0}`; `\|\| echo 0` yields `"0\n0"`, which every later integer test errors on |
| `phase_complete` | requires `PHASE\|X\|start` **and** `\|end`, so truncation mid-phase stops looking like completion |
| `govkill_block` | fans out over the registry — one skip per suppressed gate, in the **same namespace**, not a glob label like `"L19b-*"` |
| `gate_summary_json` | writes `summary_<mode>.json`; only a **keyed** run may claim `summary.json` (a keyless overwrite already destroyed one keyed record) |
| `gate_exit` | 0/1 rather than `exit $FAIL_COUNT`, which wraps above 255 and collides with the engine's exit 3 |

## `tests/helpers/gate_selftest.sh`

For each registered gate: run against `fixtures/<ID>/fail/` and require **exactly one FAIL**, then `fixtures/<ID>/pass/` and require **exactly one PASS**.

Both halves are load-bearing — without `fail/` an always-passing gate looks perfect; without `pass/` a gate can be "fixed" by matching nothing, which also always fails and is equally useless. **A gate with no `fail/` fixture is itself reported as a failure.** That is the enforcement: vacuity becomes impossible to *add*.

Plus a registry lint catching ids emitted by a gate body but never declared, and declared ids no run emits.

## A vacuity in my own proof suite

Worth recording rather than quietly fixing. The first version of `test_gatelib.sh` had `GL-03` ("self-test exits non-zero when a gate is unprovable") **passing in the degraded case for the wrong reason**: `GATE_SOURCES` pointed at the whole test file, so the registry lint fired on the *assertion* ids and drove the exit code independently of failability. GL-03 would have passed with unfailable-detection removed entirely.

Isolating the lint into its own case (`GL-07`) made GL-03 discriminate. This is the fourth time this session the checking apparatus carried the defect it was built to catch — which is the argument for the mechanism rather than against it.

## Test plan

- [x] `test_gatelib.sh` registers a **deliberately unfailable gate** carrying the exact v2 defect; the self-test must catch it (`GL-02`)
- [x] **Degraded case**: disabling unfailable-detection makes `GL-02` *and* `GL-03` fail; both pass when restored
- [x] `GL-04`…`GL-07` cover `count_matches`, `grep_alt`, `phase_complete`, and the registry lint individually
- [x] `run-all-tests.sh` — 441 tests, 0 unexpected (the directory sweep picks up the new suite automatically)
- [x] `tests/security/test_error_msg_leaks.sh` — 874 passed, 0 failed

Next increments: retrofit v1, finish v2's remaining `grep -E` sites with fixtures proving each now fails, per-agent stub routing, then v3.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC)_