### PR TITLE
Share the hardened stub launcher; fixes red master

### DIFF
--- a/tests/governance_v4/test_per_agent_signals.sh
+++ b/tests/governance_v4/test_per_agent_signals.sh
@@ -67,17 +67,11 @@ presign() {  # $1=json content
     rm -rf "$pdir"
 }
 
-start_stub() {  # $1=fixture $2=workdir
-    STUB_PORT=$(( (RANDOM % 20000) + 20000 ))
-    python3 "$SCRIPT_DIR/../helpers/agent_stub.py" "$STUB_PORT" "$1" "$2" > "$2/stub.log" 2>&1 &
-    STUB_PID=$!
-    for _ in $(seq 1 50); do
-        grep -q READY "$2/stub.log" 2>/dev/null && return 0
-        sleep 0.1
-    done
-    return 1
-}
-stop_stub() { [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null; wait "$STUB_PID" 2>/dev/null; STUB_PID=""; }
+# The one-shot port pick this used to carry is why CI went red the first time
+# it ran: a collision leaves the stub dead and the suite aborts at P-00 for a
+# reason unrelated to what it measures. The hardened launcher lives in
+# tests/helpers/stub_launch.sh so the next fix reaches every caller.
+source "$SCRIPT_DIR/../helpers/stub_launch.sh"
 
 # Off-mandate fixture: HTML-parser code with zero overlap with the
 # calculator mandate — mandate_alignment fires unless overridden off.

--- a/tests/helpers/stub_launch.sh
+++ b/tests/helpers/stub_launch.sh
@@ -1,0 +1,89 @@
+#!/usr/bin/env bash
+# ============================================================
+# stub_launch.sh — one hardened launcher for agent_stub.py
+#
+# WHY THIS IS SHARED
+#
+# The naive launcher picks a random port with no bind check and waits a flat
+# 5s for READY. Both fail on a loaded CI runner: a collision (or a lingering
+# TIME_WAIT socket) leaves the stub dead, and python3 startup + bind can exceed
+# 5s. Either way every assertion in the suite then fails, or the suite aborts,
+# for a reason that has nothing to do with what it measures.
+#
+# That diagnosis was made once and the fix reached 2 of 29 suites. The rest
+# kept the one-shot pick — invisibly, because CI was not running most of them.
+# When the governance_v4 sweep started running all of them, the very first CI
+# run went red on test_per_agent_signals.sh with "stub failed to start". The
+# defect was years old; only its visibility was new.
+#
+# So the launcher lives here, once. A fix to it now reaches every caller,
+# which is the whole point.
+#
+# WINDOWS
+#
+# The retry path is actively harmful under MSYS2 and this is the FAILURE path
+# specifically — a stub that comes up promptly never enters it, which is why
+# Windows passed until the retry itself was added:
+#   * `wait` after a plain TERM can block forever. run-all-tests.sh already
+#     warns that native Windows binaries under MSYS2 ignore TERM; a process
+#     tree holding an unkillable child is also why the runner could not
+#     enforce its own step timeout.
+#   * fork/exec costs ~50-100ms there, so a loop spawning grep + kill + sleep
+#     per iteration is dominated by spawning rather than by intended waiting.
+# Windows therefore keeps the single 5s attempt that ran green for many jobs.
+# Most callers also source stub_platform.sh and skip Windows outright, but the
+# guard is kept here so this is safe for the ones that do not.
+#
+# USAGE
+#   source "$SCRIPT_DIR/../helpers/stub_launch.sh"
+#   start_stub "$WDIR/fixture.json" "$WDIR" || { skip "X-00" "stub failed"; exit 0; }
+#   ...                                     # $STUB_PORT is set
+#   stop_stub
+#
+# Requires $SCRIPT_DIR to point at the calling suite's directory.
+# ============================================================
+
+STUB_PID="${STUB_PID:-}"
+STUB_PORT="${STUB_PORT:-}"
+
+start_stub() {  # $1=fixture json  $2=workdir
+    local _fx="$1" _dir="$2" _try _i _tries=3
+    case "$(uname -s)" in MINGW*|MSYS*|CYGWIN*) _tries=1 ;; esac
+    [ -n "${WINDIR:-}" ] && _tries=1
+
+    for _try in $(seq 1 $_tries); do
+        STUB_PORT=$(( (RANDOM % 20000) + 20000 ))
+        : > "$_dir/stub.log"
+        python3 "$SCRIPT_DIR/../helpers/agent_stub.py" "$STUB_PORT" "$_fx" "$_dir" \
+            > "$_dir/stub.log" 2>&1 &
+        STUB_PID=$!
+
+        if [ "$_tries" -eq 1 ]; then
+            for _i in $(seq 1 50); do
+                grep -q READY "$_dir/stub.log" 2>/dev/null && return 0
+                sleep 0.1
+            done
+            return 1
+        fi
+
+        # 30s, not 5s — a slow start is not a failed start. sleep 0.5 keeps the
+        # spawn count near the original despite the longer ceiling.
+        for _i in $(seq 1 60); do
+            grep -q READY "$_dir/stub.log" 2>/dev/null && return 0
+            kill -0 "$STUB_PID" 2>/dev/null || break
+            sleep 0.5
+        done
+        # SIGKILL, and no unbounded wait: reaping is not worth a hang.
+        kill -9 "$STUB_PID" 2>/dev/null; STUB_PID=""
+    done
+
+    echo "  start_stub: no READY after $_tries port attempt(s) — stub log tail:" >&2
+    tail -3 "$_dir/stub.log" >&2 2>/dev/null
+    return 1
+}
+
+stop_stub() {
+    [ -n "$STUB_PID" ] && kill "$STUB_PID" 2>/dev/null
+    wait "$STUB_PID" 2>/dev/null
+    STUB_PID=""
+}


### PR DESCRIPTION
**master is red** at `81969e8`. This fixes it.

## What broke

```
--- Group P: per-agent suppression vs control ---
  SKIP [P-00] stub failed to start
```

`test_per_agent_signals.sh` uses the one-shot random port pick with no bind check. A collision — or a lingering `TIME_WAIT` socket — leaves the stub dead and the suite aborts for a reason unrelated to what it measures.

**The defect is old. What's new is that anyone can see it.** The `governance_v4` sweep added in #129 started running twelve suites CI had never run, and this was the first CI pass over one of them. Nothing regressed; visibility did. That is the sweep doing its job, and the cost of turning it on.

## The "fix reached one caller" pattern, for the third time

The hardened launcher — 3 port attempts, 30s ceiling, `kill -0` to detect a dead child, stub-log tail on failure — was written once and reached **2 of 29** suites. **31 still carry the one-shot pick.**

It now lives in `tests/helpers/stub_launch.sh`, alongside `stub_platform.sh`, which took exactly the same route for the Windows guard after that reached 1 of 29. The next fix to it reaches every caller.

| fix | diagnosed in | reached |
|---|---|---|
| stub port retry (`081f460`) | 1 suite | 2 of 29 |
| Windows/MSYS2 stub guard | 1 suite | 1 of 29 → now shared |
| hardened launcher | 1 suite | 2 of 31 → now shared |

## The Windows hazard

Adding the retry everywhere was previously **withdrawn** because it hung Windows. That's handled two ways here:

- the launcher keeps its internal MSYS2 guard — a single 5s attempt, no retry loop, no unbounded `wait`, because `wait` after a plain TERM can block forever under MSYS2 and fork/exec costs ~50–100 ms there;
- callers like this one also source `stub_platform.sh` and skip Windows outright.

## Scope

**Only `test_per_agent_signals.sh` is repointed** — the suite that is actually red. The other 30 keep their local copies until each is touched. Converting them blind would repeat the "freeze one guess into 29 callers" mistake that the `stub_platform.sh` commit explicitly declined to make, and the correct Windows behaviour of that code is still what's least understood.

## Verification

- [x] `test_per_agent_signals.sh` — 11 pass / 0 fail
- [x] **Retry loop demonstrably runs**: against a stub that cannot start it reports `no READY after 3 port attempt(s)` plus the stub log tail, and returns in ~1s rather than sleeping — `kill -0` detects the dead child instead of waiting out the ceiling. The old launcher returned `1` silently with no diagnostic.
- [x] `run-all-tests.sh` — 441 tests, 0 unexpected
- [x] `tests/security/test_error_msg_leaks.sh` — 874 passed, 0 failed

🤖 Generated with [Claude Code](https://claude.com/claude-code)

https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC)_