### PR TITLE
Per-agent stub queues, a checksheet, and the first thing the checksheet turned up

### DIFF
--- a/docs/govern-template.json
+++ b/docs/govern-template.json
@@ -387,7 +387,7 @@
       "block_command_injection": true
     },
     "crypto": {
-      "enabled": false,
+      "enabled": true,
       "level": "advisory",
       "block_weak_hashing": true,
       "weak_hashes": ["md5", "sha1"],

--- a/docs/governance-campaign-findings.md
+++ b/docs/governance-campaign-findings.md
@@ -1110,3 +1110,85 @@ A key dated Aug 3 sits in `~/.naab/trusted-keys`. Suites that write an unsigned
 failing standalone, 12/12 isolated). Pre-existing on master, and the same shape
 one level up — the harness hides the state the test would have reported. Not
 fixed here; whichever suite installs a key without isolation needs finding first.
+
+## `"enabled": false` that turns a check on
+
+Working the contradiction-check coverage list turned this up sideways, which is
+the same way `CONTRA-007` and the pressure ladder were found.
+
+`CONTRA-010` fires when `capabilities.shell.blocked_commands` is set while
+`restrictions.code_injection` is off. A config written to trip it — blocked
+commands plus `"restrictions": {"code_injection": {"enabled": false}}` — stayed
+silent. The check was fine. The config was not doing what it said: writing
+`"enabled": false` had **enabled** code_injection.
+
+Six of the twelve `restrictions.*` sub-blocks enable themselves from the mere
+presence of the block and never read `enabled` at all:
+
+| honours `enabled` | ignores it, forces on |
+|---|---|
+| `vcs_secret_extraction`, `obfuscation`, `data_exfiltration`, `resource_abuse`, `information_disclosure` | `dangerous_calls`, `shell_injection`, `privilege_escalation`, `code_injection`, `crypto`, `imports` |
+
+(`polyglot_output` has no `enabled` concept at all.)
+
+So the same JSON means opposite things depending on which sibling it is written
+under, and omitting the block is the only way to leave one of the six off. All
+six were confirmed empirically, not read off the source: each fires with
+`"enabled": false` exactly as it does with `true`, and not at all when the block
+is absent. The control matters as much — `data_exfiltration` with a canary
+pattern gives 0 findings at `false` and 1 at `true`, so the key demonstrably
+works on that side of the table.
+
+**Direction of risk.** Fail-closed: the accident is *more* enforcement, not
+less. Nothing is unprotected because of this. What is wrong is that an operator
+who believes they turned a check off is wrong, has no way to find out, and
+cannot generalise from the five siblings where the key does work.
+
+**What was changed: only the silence.** The value is still ignored. Making all
+twelve honour the key is a **loosening** — every config carrying `"enabled":
+false` today is being enforced and would silently stop being enforced on
+upgrade. That is the trade already rejected for default-on secret scanning, run
+in the other direction, and it is not one to make while closing a reporting gap.
+So the six now print
+
+```
+[governance] Warning: "restrictions.crypto.enabled": false has no effect — this
+check is enabled by the presence of its block. Remove the "crypto" block to
+leave it disabled.
+```
+
+following the precedent of the existing `security.blocked_commands` warning. One
+helper, called from six sites, with a brace-accurate audit asserting the call
+reaches exactly the sub-blocks that force and none that read — because "a fix
+that reached one of N callers" is this campaign's most repeated finding and a
+sixth copy of a `fprintf` is how it happens.
+
+`tests/governance_v4/test_restrictions_enabled_key.sh` covers it, and RE-10 is
+the gate that matters: it asserts the check *still runs* under `"enabled":
+false`, so it fails if someone later converts this into the loosening. Verified
+by doing exactly that (degradation E4). RE-07/RE-08/RE-09 are the controls
+against an indiscriminate warning — without them, warning on every sub-block
+passes six of ten gates.
+
+### A vacuity in the gate written to catch a vacuity
+
+RE-10 first passed while measuring nothing. Its counter was
+`grep -c 'restrictions.crypto'`, and the new warning *names the rule it is
+warning about* — so the gate counted its own warning as evidence that the check
+had run. It was only visible because the trust-store leak (below) was in its
+active state at that moment: every config was an `INTEGRITY BLOCK`, nothing
+executed at all, and RE-10 still passed. Under an isolated trust store it would
+have passed for the right reason and the defect would have shipped.
+
+Two things follow. A gate must exclude the artefact it introduced from its own
+evidence. And the environment did the work here that review did not — the same
+lesson as everything else in this document, arriving from the least convenient
+direction available.
+
+The trust-store leak also has a better description now than "unknown cause": the
+store is not written during a run. `~/.naab/trusted-keys` is dated Aug 3 and
+unchanged since; what varies is that suites using `trust_setup.sh` point
+`NAAB_TRUST_STORE_DIR` elsewhere while they run. Probes issued during that
+window see an empty store and succeed; the same probes outside it are blocked.
+Findings taken from ad-hoc runs against a developer container are therefore
+timing-dependent unless the probe isolates the store itself.

--- a/docs/open-investigations.md
+++ b/docs/open-investigations.md
@@ -1,0 +1,110 @@
+# Open investigations
+
+A checksheet, not a narrative. `governance-campaign-findings.md` records what was
+found and why; this records **what has not been looked at yet**, so it does not
+have to be rediscovered from a chat log.
+
+Each item: what to check, why it might matter, and what would settle it. Status
+is one of **open**, **in progress**, **parked** (deliberate, with a reason), or
+**done** (move the finding to the campaign doc and delete the row).
+
+---
+
+## A. Inert mechanisms — the high-yield category
+
+Two engine features have now been found **configured, believed working, and
+structurally incapable of firing**:
+
+- `CONTRA-007` iterated a set its own loader empties at parse time, so the
+  conflict it looks for cannot exist by the time it runs.
+- The circuit-breaker ladder's middle levels were gated by a *second* threshold
+  (default 0.70) sitting above their own (0.4 / 0.6), so ELEVATED and HIGH could
+  never be reached through pressure.
+
+Both were found by accident, from a different direction. Neither was found by
+review. That base rate is the argument for looking systematically.
+
+**The two shapes to search for:**
+1. a check reading state that a loader, normalizer or resolver clears first;
+2. a gate whose counter/condition is fed by a threshold other than its own.
+
+| # | Item | Status | How to settle it |
+|---|---|---|---|
+| A1 | **6 of 9 contradiction checks have no test at all** — `CONTRA-001, 003, 004, 005, 008, 010`. Of the three that do, one (`007`) was dead. `CONTRA-006` does not exist; explain the gap. | open | For each: construct a config that should trip it, confirm it fires. Any that cannot fire is a `CONTRA-007` repeat. Cheap, keyless. |
+| A2 | **Systematic inert-mechanism sweep of the engine.** Beyond CONTRA: which other checks read state that is normalized away, or depend on a counter fed by a different threshold? | open | Enumerate `enforce()` / `recordPass()` call sites; for each, ask what input would make it fire and whether that input can reach it. |
+| A3 | **Which `enforce()` sites have never fired in any committed run?** A check that has never fired in 38 archived runs is a candidate for being unfireable. | open | Cross-reference rule names in `src/` against `results/*.txt` and `telemetry_*.jsonl` in `examples/*/results/`. |
+
+## B. Known engine behaviour, decided but unfixed
+
+| # | Item | Status | Note |
+|---|---|---|---|
+| B1 | **Scrutiny does not survive a process restart.** `governance_level_` is `std::atomic<int>{0}` with no persistence and no restore path. An agent that escalated gets a clean slate in the next process — observed live (v1 Aug 8: segment 1 ended `elevated`, segment 2 began `normal`). A long-running system that restarts periodically can never accumulate scrutiny. | **open — undocumented** | Not yet written up anywhere. Decide: document as a boundary, or persist. Persisting raises scope, expiry and tamper-evidence questions that should not be answered off one run. |
+| B2 | **`governance.telemetry` resolves CWD-relative while `govern.json` is discovered script-dir-relative.** An operator putting the two side by side gets telemetry wherever they happened to run from. | parked | Documented. Changing it moves files for every existing user. |
+| B3 | **Response secret/PII scanning defaults off.** A config that never sets `code_quality.no_secrets` / `no_pii` has *no* response scanning. | parked | Deliberate: enabling by default would start blocking responses that pass today. Worth knowing if you assumed otherwise. |
+| B4 | **CRITICAL is marginally harder to reach after #129** — needs `critical_sustained` turns at or above `critical_threshold`, rather than that many above 0.70 plus one spike. | parked | Accepted trade: severity should now be caught at ELEVATED/HIGH instead. Revisit if a live run shows CRITICAL missed where it was wanted. |
+
+## C. Never observed working (stub-only)
+
+Passing tests, no live run has produced the triggering condition. See the
+campaign doc's live-status column.
+
+| # | Item | Status | Blocker |
+|---|---|---|---|
+| C1 | **De-escalation hysteresis** | open | Needs a run where the *raising handle* takes ≥3 further turns. v3 is designed for this. |
+| C2 | **HIGH and CRITICAL levels** | open | Peak live pressure ever observed is 0.375 against a 0.55 threshold. Needs genuine drift, not a longer run. |
+| C3 | **Five campaign findings** — pulse streak field, evidence-count shrink, lease expiry mid-deliberation, config generation guard, CRITICAL suspension | open | All five need adversarial conditions a clean run cannot produce. |
+| C4 | **Reviewer separation of duties** (`allowed_actions: ["AGENT_SEND"]` only) | open | Never live-confirmed: no reviewer has yet *attempted* a tool call, so the absence of blocks proves nothing. |
+
+## D. Test-harness debt
+
+| # | Item | Status | Note |
+|---|---|---|---|
+| D1 | **30 suites still use the inline one-shot stub port pick** (`grep -rl 'RANDOM % 20000'`, re-counted 2026-08-09). The hardened launcher is shared (`tests/helpers/stub_launch.sh`) but exactly one suite is repointed. | open | Expect more intermittent CI red. Repoint on touch; converting all 30 blind just repeats "freeze one guess into 29 callers" in the other direction. |
+| D2 | **Tier 3 vacuity audit** — `tests/gorilla`, 62 absence-guarded assertions | parked | Older scenario tests, weakest claims. Tiers 1–2 done. |
+| D3 | **Retrofit v1 and v2 to `gatelib.sh`** with per-gate negative fixtures | open | Roadmap increment. v1 has ~151 gates, v2 ~89. |
+| D4 | **Keyless runs overwrite `summary.json`**, destroying a keyed record (already lost v2's 108/0/1 once) | open | Fixed in `gate_summary_json`; lands when v1/v2 are retrofitted. |
+| D5 | **Keyless placeholder counts are hand-maintained and wrong** — `seq 1 155` (v1) / `seq 1 115` (v2) against real keyed totals 171 / 109 | open | Registry-driven skips fix this; same retrofit. |
+| D6 | **No `PHASE\|X\|end` markers** — a phase is only ever "reached", so truncation mid-phase looks like completion | open | `phase_complete()` exists in gatelib; the `.naab` scripts must emit the end markers. |
+| D7 | **v2 `summary.json` lacks the `failed` ID array** that v1 carries — a fail count with no identities cannot be triaged later | open | Same retrofit. |
+| D8 | **Trust-store leak has no identified cause.** A stray key breaks three suites when run standalone; all 49 files were checked and none leaked. | parked | Likely a manual `--trust-key` during development. Defensive fix (isolate ~35 suites that create a `govern.json`) offered, not applied. |
+
+## E. living-script v3 roadmap
+
+Full design in the session plan file; increments 1–2 are merged.
+
+| # | Increment | Status |
+|---|---|---|
+| E1 | Gate library + self-test driver (#133) | **done** |
+| E2 | v2 pattern archaeology (#132, #134) | **done** |
+| E3 | Per-agent routing in `agent_stub.py` | open |
+| E4 | v3 scenario skeleton, ladder walked **keylessly** against the stub first | open |
+| E5 | v3 gates + negative fixtures, `--self-test` green in CI | open |
+| E6 | One keyed run | open |
+
+**Two constraints verified in source; do not re-derive:**
+- `check_interval_turns` **must be 1**. `behavioral_sequence.cpp:785` zeroes
+  `signals_fired_this_turn`, and the interval gate returns at `:802` before
+  anything can increment it — so every skipped turn contributes zero signal
+  density *and decays* `cb_sustained`.
+- Disabling CDD signals on all agents **except one** pins
+  `deescalate_pressure_handle_` to that agent: a sibling with no signals caps at
+  `risk 0.20 + depth 0.10 = 0.30`, below `elevated_threshold`, so it can never
+  raise the level. This is what makes de-escalation testable at all.
+
+## F. Standing rules earned the hard way
+
+Not tasks — the things that keep being rediscovered.
+
+- **A zero is only evidence if you can say what would have made it non-zero.**
+  "Both counters read 0" does not show independence when neither gate was
+  approached.
+- **When you make a permissive branch strict, check what used to land in it.**
+  Cost once: a fast-exit failure that would have broken every platform lacking a
+  JS executor, invisible to Linux CI.
+- **Count turns, not telemetry rows.** Each turn emits both a `SEMANTIC_TURN`
+  and an `OUTPUT_ADMISSIBILITY_EVAL`; row counts double.
+- **A fix reaching one of N callers is the default outcome, not the exception.**
+  Observed at 1/29, 2/29, 2/31, and on both halves of several config pairs.
+- **A gate must never assert "agent X is at level Y".** `governance_level_` is a
+  single global atomic; only "the system reached Y while X was the pressure
+  handle" is falsifiable.

--- a/docs/open-investigations.md
+++ b/docs/open-investigations.md
@@ -30,7 +30,8 @@ review. That base rate is the argument for looking systematically.
 
 | # | Item | Status | How to settle it |
 |---|---|---|---|
-| A1 | **6 of 9 contradiction checks have no test at all** — `CONTRA-001, 003, 004, 005, 008, 010`. Of the three that do, one (`007`) was dead. `CONTRA-006` does not exist; explain the gap. | open | For each: construct a config that should trip it, confirm it fires. Any that cannot fire is a `CONTRA-007` repeat. Cheap, keyless. |
+| A1 | **6 of 9 contradiction checks have no test at all** — `CONTRA-001, 003, 004, 005, 008, 010`. Of the three that do, one (`007`) was dead. `CONTRA-006` does not exist; explain the gap. | **in progress** | All nine now confirmed to fire against a hand-built config (probed 2026-08-09) — none is a `CONTRA-007` repeat. Two notes: `CONTRA-001` is hardcoded SOFT, so it aborts the load and prints its description with an **empty `Rule:` field** — the pattern id never reaches the operator; and probing it turned up the `restrictions.*.enabled` finding below. Remaining: commit a coverage suite so this cannot regress, and fix the empty `Rule:`. |
+| A1a | **A SOFT/HARD contradiction block does not name which pattern fired.** `CONTRA-001` at SOFT prints `Rule: ` empty. The ADVISORY path prints `contradiction.CONTRA-001` correctly. | open | Pass `rule_name` through the `formatError` call in `detectContradictions()`. Small, but it is the difference between an operator being able to look the pattern up and not. |
 | A2 | **Systematic inert-mechanism sweep of the engine.** Beyond CONTRA: which other checks read state that is normalized away, or depend on a counter fed by a different threshold? | open | Enumerate `enforce()` / `recordPass()` call sites; for each, ask what input would make it fire and whether that input can reach it. |
 | A3 | **Which `enforce()` sites have never fired in any committed run?** A check that has never fired in 38 archived runs is a candidate for being unfireable. | open | Cross-reference rule names in `src/` against `results/*.txt` and `telemetry_*.jsonl` in `examples/*/results/`. |
 
@@ -66,7 +67,7 @@ campaign doc's live-status column.
 | D5 | **Keyless placeholder counts are hand-maintained and wrong** — `seq 1 155` (v1) / `seq 1 115` (v2) against real keyed totals 171 / 109 | open | Registry-driven skips fix this; same retrofit. |
 | D6 | **No `PHASE\|X\|end` markers** — a phase is only ever "reached", so truncation mid-phase looks like completion | open | `phase_complete()` exists in gatelib; the `.naab` scripts must emit the end markers. |
 | D7 | **v2 `summary.json` lacks the `failed` ID array** that v1 carries — a fail count with no identities cannot be triaged later | open | Same retrofit. |
-| D8 | **Trust-store leak has no identified cause.** A stray key breaks three suites when run standalone; all 49 files were checked and none leaked. | parked | Likely a manual `--trust-key` during development. Defensive fix (isolate ~35 suites that create a `govern.json`) offered, not applied. |
+| D8 | **Trust-store leak: cause now understood, fix still not applied.** The store is NOT written during a run — `~/.naab/trusted-keys` is dated Aug 3 and unchanged. What varies is that suites using `trust_setup.sh` repoint `NAAB_TRUST_STORE_DIR` while they run, so a probe issued during that window sees an empty store and succeeds, and the same probe outside it hits `INTEGRITY BLOCK`. | open | Not a leak — a missing isolation in the ~35 suites that write an unsigned `govern.json`. Repoint them at `trust_setup.sh` on touch. **Any ad-hoc probe against a dev container must isolate the store itself**, or its results are timing-dependent; this cost a wrong reading once already. |
 
 ## E. living-script v3 roadmap
 
@@ -108,3 +109,11 @@ Not tasks — the things that keep being rediscovered.
 - **A gate must never assert "agent X is at level Y".** `governance_level_` is a
   single global atomic; only "the system reached Y while X was the pressure
   handle" is falsifiable.
+- **A gate must exclude its own artefact from its own evidence.** `RE-10` counted
+  `restrictions.crypto` to show the check ran, and the warning it was testing
+  *names the rule it warns about* — so the gate counted the warning as proof of
+  the thing the warning complains about. It passed under an `INTEGRITY BLOCK`
+  where nothing executed at all.
+- **Isolate the trust store in any ad-hoc probe.** Otherwise the result depends
+  on whether some other suite happened to have `NAAB_TRUST_STORE_DIR` repointed
+  at the time (D8).

--- a/docs/open-investigations.md
+++ b/docs/open-investigations.md
@@ -51,8 +51,8 @@ campaign doc's live-status column.
 
 | # | Item | Status | Blocker |
 |---|---|---|---|
-| C1 | **De-escalation hysteresis** | open | Needs a run where the *raising handle* takes ≥3 further turns. v3 is designed for this. |
-| C2 | **HIGH and CRITICAL levels** | open | Peak live pressure ever observed is 0.375 against a 0.55 threshold. Needs genuine drift, not a longer run. |
+| C1 | **De-escalation hysteresis** | **open — now known to be structurally blocked** | Not just "no run has produced it": with `coherence_natural_healing` at its default 0.0, a floored agent's composite cannot fall back below `elevated_threshold`, so the mechanism's input never occurs. See the E-section probe result. Decide whether that is intended before spending a keyed run on it. |
+| C2 | **HIGH and CRITICAL levels** | **HIGH reached (stub), CRITICAL open** | HIGH reached keylessly at turn 5 on 2026-08-09 — the scenario question is answered, only the live run remains. CRITICAL was deliberately tuned out of reach in that probe. |
 | C3 | **Five campaign findings** — pulse streak field, evidence-count shrink, lease expiry mid-deliberation, config generation guard, CRITICAL suspension | open | All five need adversarial conditions a clean run cannot produce. |
 | C4 | **Reviewer separation of duties** (`allowed_actions: ["AGENT_SEND"]` only) | open | Never live-confirmed: no reviewer has yet *attempted* a tool call, so the absence of blocks proves nothing. |
 
@@ -81,6 +81,43 @@ Full design in the session plan file; increments 1–2 are merged.
 | E4 | v3 scenario skeleton, ladder walked **keylessly** against the stub first | open |
 | E5 | v3 gates + negative fixtures, `--self-test` green in CI | open |
 | E6 | One keyed run | open |
+
+**Increment 4b result (probed keylessly 2026-08-09, routed stub, 2 agents,
+20 turns).** The ladder *does* walk: `normal → elevated` at turn 3,
+`elevated → high` at turn 5, with the plan's tuning
+(`check_interval_turns: 1`, elevated 0.35/2, high 0.55/3). **This is the first
+time HIGH has been reached at all** — C2 above is no longer blocked on "needs
+genuine drift", only on doing it live. Composite peaked at 0.70.
+
+**De-escalation did not fire, and the reason is structural, not scenario shape:**
+
+- `context_drift.coherence_natural_healing` defaults to **0.0**
+  (`governance.h:1343`). With it off, coherence only ever decreases — the sole
+  increase path is S22's fail→pass credit (`behavioral_sequence.cpp:1458`),
+  which needs `agent.record_validation()`.
+- Once coherence floored at 0.0, twelve consecutive calm turns brought composite
+  down only to **0.567**, never near `elevated_threshold` 0.35. The level
+  therefore cannot step down however well the agent behaves. The hysteresis
+  machinery (`deescalate_sustained`, `deescalate_pressure_handle_`) is not
+  reached because its input — a lower computed target — never occurs.
+- Enabling healing at 0.06/turn was **not** enough: `heal_factor` is
+  `1/(1 + signals_fired_this_turn)`, and ~2 signals kept firing through the calm
+  phase, so healing stayed below the penalties.
+- Part of that tail is `mandate_alignment`'s rolling window of 20 — a 6-turn
+  drift keeps paying for roughly 20 calm turns. A v3 recovery phase of 8–10
+  turns is too short by construction; it needs to outlast the window.
+
+Two fixture bugs of my own were found and fixed on the way, both worth not
+repeating: 14 identical "recovery" responses fire `response_repetition` every
+turn (a recovery phase must be varied *and* on-mandate), and the first drift
+fixture was so far off-mandate that coherence floored by turn 3, which destroys
+the de-escalation observation before the recovery phase begins. Drift has to be
+strong enough to escalate and mild enough to leave headroom.
+
+**Open question this raises (new, not yet an item above):** is a permanently
+pinned level the intended design? It is defensible — scrutiny earned should not
+be cheap to shed — but combined with B1 (scrutiny does not survive a restart)
+the pair is odd: unshakeable within a process, free to reset by restarting it.
 
 **Two constraints verified in source; do not re-derive:**
 - `check_interval_turns` **must be 1**. `behavioral_sequence.cpp:785` zeroes

--- a/docs/open-investigations.md
+++ b/docs/open-investigations.md
@@ -76,7 +76,7 @@ Full design in the session plan file; increments 1–2 are merged.
 |---|---|---|
 | E1 | Gate library + self-test driver (#133) | **done** |
 | E2 | v2 pattern archaeology (#132, #134) | **done** |
-| E3 | Per-agent routing in `agent_stub.py` | open |
+| E3 | Per-agent routing in `agent_stub.py` | **done** |
 | E4 | v3 scenario skeleton, ladder walked **keylessly** against the stub first | open |
 | E5 | v3 gates + negative fixtures, `--self-test` green in CI | open |
 | E6 | One keyed run | open |

--- a/govern-template.json
+++ b/govern-template.json
@@ -390,7 +390,7 @@
       "block_command_injection": true
     },
     "crypto": {
-      "enabled": false,
+      "enabled": true,
       "level": "advisory",
       "block_weak_hashing": true,
       "weak_hashes": ["md5", "sha1"],

--- a/src/runtime/governance_config.cpp
+++ b/src/runtime/governance_config.cpp
@@ -825,6 +825,35 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
     if (j.contains("restrictions") && j["restrictions"].is_object()) {
         auto& res = j["restrictions"];
 
+        // Six of the twelve restrictions.* sub-blocks enable themselves from the
+        // mere PRESENCE of the block and never read "enabled" at all, so writing
+        //     "restrictions": {"crypto": {"enabled": false}}
+        // does not disable the check -- it turns it ON, identically to writing
+        // true. The only way to leave one off is to omit the block. The other
+        // five (vcs_secret_extraction, obfuscation, data_exfiltration,
+        // resource_abuse, information_disclosure) DO read the key and disable
+        // properly, so the same JSON means opposite things depending on which
+        // sibling it is written under, and an operator cannot learn the rule
+        // from one example.
+        //
+        // The value is deliberately NOT honoured here. Making all twelve read
+        // the key is a loosening: every config carrying "enabled": false today
+        // is being enforced, and would silently stop being enforced on upgrade.
+        // That is the same trade rejected for default-on secret scanning, in
+        // the other direction. What is actually wrong is the silence -- the
+        // operator believes they turned something off -- so the silence is what
+        // gets fixed, additively, with no change to what is enforced.
+        auto warnIgnoredEnable = [](const nlohmann::json& blk, const char* name) {
+            if (blk.contains("enabled") && blk["enabled"].is_boolean() &&
+                !blk["enabled"].get<bool>()) {
+                fprintf(stderr,
+                        "[governance] Warning: \"restrictions.%s.enabled\": false has no effect — "
+                        "this check is enabled by the presence of its block. "
+                        "Remove the \"%s\" block to leave it disabled.\n",
+                        name, name);
+            }
+        };
+
         if (res.contains("polyglot_output") && res["polyglot_output"].is_object()) {
             auto& po = res["polyglot_output"];
             if (po.contains("format") && po["format"].is_string()) { rules_.restrictions.polyglot_output.format = po["format"].get<std::string>(); rules_.polyglot_output = rules_.restrictions.polyglot_output.format; rules_.explicitly_set.insert("restrictions.polyglot_output.format"); }
@@ -834,6 +863,7 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
         }
         if (res.contains("dangerous_calls") && res["dangerous_calls"].is_object()) {
             auto& dc = res["dangerous_calls"];
+            warnIgnoredEnable(dc, "dangerous_calls");
             rules_.restrictions.dangerous_calls.enabled = true;
             rules_.explicitly_set.insert("restrictions.dangerous_calls");
             rules_.restrict_dangerous_calls = true;
@@ -844,6 +874,7 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
         }
         if (res.contains("shell_injection") && res["shell_injection"].is_object()) {
             auto& si = res["shell_injection"];
+            warnIgnoredEnable(si, "shell_injection");
             rules_.restrictions.shell_injection.enabled = true;
             rules_.explicitly_set.insert("restrictions.shell_injection");
             if (si.contains("level")) { auto [en, lv] = parseEnforcementLevel(si["level"]); rules_.restrictions.shell_injection.level = lv; }
@@ -852,6 +883,7 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
         }
         if (res.contains("privilege_escalation") && res["privilege_escalation"].is_object()) {
             auto& pe = res["privilege_escalation"];
+            warnIgnoredEnable(pe, "privilege_escalation");
             rules_.restrictions.privilege_escalation.enabled = true;
             rules_.explicitly_set.insert("restrictions.privilege_escalation");
             if (pe.contains("level")) { auto [en, lv] = parseEnforcementLevel(pe["level"]); rules_.restrictions.privilege_escalation.level = lv; }
@@ -861,6 +893,7 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
         }
         if (res.contains("code_injection") && res["code_injection"].is_object()) {
             auto& ci = res["code_injection"];
+            warnIgnoredEnable(ci, "code_injection");
             rules_.restrictions.code_injection.enabled = true;
             rules_.explicitly_set.insert("restrictions.code_injection");
             if (ci.contains("level")) { auto [en, lv] = parseEnforcementLevel(ci["level"]); rules_.restrictions.code_injection.level = lv; }
@@ -874,6 +907,7 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
         }
         if (res.contains("crypto") && res["crypto"].is_object()) {
             auto& cr = res["crypto"];
+            warnIgnoredEnable(cr, "crypto");
             rules_.restrictions.crypto.enabled = true;
             rules_.explicitly_set.insert("restrictions.crypto");
             if (cr.contains("level")) { auto [en, lv] = parseEnforcementLevel(cr["level"]); rules_.restrictions.crypto.level = lv; }
@@ -897,6 +931,7 @@ static void loadFromJson(const nlohmann::json& j, GovernanceRules& rules_) {
         }
         if (res.contains("imports") && res["imports"].is_object()) {
             auto& im = res["imports"];
+            warnIgnoredEnable(im, "imports");
             rules_.restrictions.imports.enabled = true;
             rules_.explicitly_set.insert("restrictions.imports");
             if (im.contains("level")) { auto [en, lv] = parseEnforcementLevel(im["level"]); rules_.restrictions.imports.level = lv; }

--- a/tests/governance_v4/test_restrictions_enabled_key.sh
+++ b/tests/governance_v4/test_restrictions_enabled_key.sh
@@ -1,0 +1,211 @@
+#!/usr/bin/env bash
+# ============================================================
+# test_restrictions_enabled_key.sh — "enabled": false that turns a check ON
+#
+# WHAT WAS FOUND
+#
+# Six of the twelve restrictions.* sub-blocks enable themselves from the mere
+# PRESENCE of the block and never read "enabled" at all. So
+#
+#     "restrictions": {"crypto": {"enabled": false}}
+#
+# does not disable the crypto check. It ENABLES it, byte-identically to writing
+# true. Omitting the block is the only way to leave one off. The other five
+# (vcs_secret_extraction, obfuscation, data_exfiltration, resource_abuse,
+# information_disclosure) do read the key and disable properly — so the same
+# JSON means opposite things depending on which sibling it is written under,
+# and an operator cannot learn the rule from one example.
+#
+# Found by working the contradiction-check coverage list: CONTRA-010 refused to
+# fire on a config written to trip it, because the "restrictions":
+# {"code_injection": {"enabled": false}} that was supposed to create the
+# contradiction had quietly enabled code_injection instead.
+#
+# WHAT WAS CHANGED, AND WHAT WAS NOT
+#
+# Only the silence. The value is still ignored, because honouring it in all
+# twelve is a LOOSENING: every config carrying "enabled": false today is being
+# enforced and would silently stop being enforced on upgrade. That is the trade
+# rejected for default-on secret scanning, in the other direction. So nothing
+# about what is enforced changes here; the operator is simply told.
+#
+# EVERY GATE HAS A DEMONSTRATED FAILURE CASE
+#
+# Four degradations applied to governance_config.cpp one at a time:
+#
+#   E1  warning suppressed                        -> RE-01..RE-06
+#   E2  warn on block presence, ignoring value    -> RE-08 RE-09
+#   E3  warn on a key-honouring sibling too       -> RE-07
+#   E4  crypto honours enabled:false              -> RE-10
+#
+# E2 and E3 are the ones worth keeping. A change that printed the warning for
+# every sub-block, or on every presence of an "enabled" key, satisfies
+# RE-01..RE-06 completely — those six alone cannot tell a correct warning from
+# an indiscriminate one.
+#
+# E4 is the degradation that IS the rejected fix: making crypto honour the key.
+# RE-10 fails under it, which is the point — RE-10 measures engine behaviour
+# rather than the presence of a warning string, and it is what would catch
+# someone quietly turning this into a loosening later.
+# ============================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers/gatelib.sh"
+# Without an isolated trust store, a stray trusted key in the developer's
+# ~/.naab (this container has carried one since Aug 3) makes every unsigned
+# govern.json an INTEGRITY BLOCK. Parse-time warnings still print, so the
+# warning gates go on passing while nothing executes — which is how RE-10 was
+# first observed passing while counting its own warning text.
+source "$SCRIPT_DIR/../helpers/trust_setup.sh"
+setup_isolated_trust
+
+NAAB="$SCRIPT_DIR/../../build/naab-lang"
+if [ ! -x "$NAAB" ]; then
+    echo "  test_restrictions_enabled_key.sh: SKIPPED — build/naab-lang not found"
+    exit 0
+fi
+
+if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
+    _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
+else
+    _SYSTMP="${TMPDIR:-/tmp}"
+fi
+W="${_SYSTMP}/restr-enabled-$$"
+trap 'teardown_isolated_trust; rm -rf "$W"' EXIT
+mkdir -p "$W"
+
+echo "=== restrictions.*.enabled: the key that does nothing ==="
+
+gate_init "restrictions-enabled-key"
+gate_def RE-01 WARN    "dangerous_calls warns on enabled:false"
+gate_def RE-02 WARN    "shell_injection warns on enabled:false"
+gate_def RE-03 WARN    "privilege_escalation warns on enabled:false"
+gate_def RE-04 WARN    "code_injection warns on enabled:false"
+gate_def RE-05 WARN    "crypto warns on enabled:false"
+gate_def RE-06 WARN    "imports warns on enabled:false"
+gate_def RE-07 CONTROL "a key-honouring sibling stays silent and is really disabled"
+gate_def RE-08 CONTROL "no warning when no enabled key is written"
+gate_def RE-09 CONTROL "no warning on enabled:true"
+gate_def RE-10 TRUTH   "the warning is true — the check still runs"
+
+cat > "$W/t.naab" << 'EOF'
+main {
+    <<python
+import hashlib
+hashlib.md5(b"abc").hexdigest()
+print("x")
+>>
+}
+EOF
+
+# Runs the binary with the given restrictions JSON, echoes combined output.
+run_with() {  # $1 = value of "restrictions"
+    cat > "$W/govern.json" << EOF
+{"version": "4.0", "restrictions": $1}
+EOF
+    "$NAAB" --governance-dashboard "$W/t.naab" 2>&1
+}
+
+warned_for() {  # $1 = sub-block name ; 0 if the ignored-key warning was printed
+    echo "$2" | grep -q "restrictions.$1.enabled\": false has no effect"
+}
+
+# Count evidence that the CHECK itself ran, excluding the ignored-key warning.
+# The warning names the same rule, so a naive `grep -c restrictions.crypto`
+# counts the warning as proof of the thing the warning is complaining about.
+# RE-10 was observed passing that way under an INTEGRITY BLOCK, where nothing
+# executed at all.
+check_hits() {  # $1 = sub-block name, $2 = output
+    local n
+    n=$(echo "$2" | grep -v 'has no effect' | grep -c "restrictions\.$1" || true)
+    echo "${n:-0}"
+}
+
+# ------------------------------------------------------------------
+# RE-01..RE-06 — every forcing sub-block warns
+# ------------------------------------------------------------------
+i=0
+for sub in dangerous_calls shell_injection privilege_escalation code_injection crypto imports; do
+    i=$((i + 1))
+    id="RE-0$i"
+    out="$(run_with "{\"$sub\": {\"enabled\": false}}")"
+    if warned_for "$sub" "$out"; then
+        pass "$id" "$sub warns on enabled:false"
+    else
+        fail "$id" "$sub did not warn that enabled:false is ignored" \
+             "an operator writing false gets the check enabled with no notice"
+    fi
+done
+
+# ------------------------------------------------------------------
+# RE-07 — control: a sibling that honours the key must stay silent AND
+# must actually be disabled by it. Both halves matter: silence alone would
+# also be produced by a check that had been broken into never running.
+# ------------------------------------------------------------------
+cat > "$W/exfil.naab" << 'EOF'
+main {
+    <<python
+CANARY_EXFIL = 1
+print("x")
+>>
+}
+EOF
+mk_exfil() {  # $1 = true|false
+    cat > "$W/govern.json" << EOF
+{"version": "4.0", "restrictions": {"data_exfiltration":
+  {"enabled": $1, "patterns": ["CANARY_EXFIL"]}}}
+EOF
+    "$NAAB" --governance-dashboard "$W/exfil.naab" 2>&1
+}
+OFF="$(mk_exfil false)"
+ON="$(mk_exfil true)"
+OFF_HITS=$(check_hits data_exfiltration "$OFF")
+ON_HITS=$(check_hits data_exfiltration "$ON")
+
+if warned_for data_exfiltration "$OFF"; then
+    fail RE-07 "warned about a sub-block that honours enabled" \
+         "the warning is firing indiscriminately"
+elif [ "$OFF_HITS" -eq 0 ] && [ "$ON_HITS" -gt 0 ]; then
+    pass RE-07 "a key-honouring sibling stays silent and is really disabled"
+else
+    fail RE-07 "control sibling did not demonstrate a working enabled key" \
+         "enabled:false -> $OFF_HITS hits, enabled:true -> $ON_HITS hits (want 0 then >0)"
+fi
+
+# ------------------------------------------------------------------
+# RE-08 / RE-09 — control: the warning is about the FALSE value, not about
+# the block or the key existing.
+# ------------------------------------------------------------------
+NOKEY="$(run_with '{"crypto": {"weak_hashes": ["md5"]}}')"
+if warned_for crypto "$NOKEY"; then
+    fail RE-08 "warned when no enabled key was written" \
+         "the warning fires on block presence rather than on the value"
+else
+    pass RE-08 "no warning when no enabled key is written"
+fi
+
+TRUEOUT="$(run_with '{"crypto": {"enabled": true}}')"
+if warned_for crypto "$TRUEOUT"; then
+    fail RE-09 "warned on enabled:true" "the warning does not read the value"
+else
+    pass RE-09 "no warning on enabled:true"
+fi
+
+# ------------------------------------------------------------------
+# RE-10 — the substantive claim: the check really does still run, so the
+# warning is telling the truth rather than apologising for nothing.
+# ------------------------------------------------------------------
+FALSE_OUT="$(run_with '{"crypto": {"enabled": false}}')"
+ABSENT_OUT="$(run_with '{}')"
+F=$(check_hits crypto "$FALSE_OUT")
+A=$(check_hits crypto "$ABSENT_OUT")
+if [ "$F" -gt 0 ] && [ "$A" -eq 0 ]; then
+    pass RE-10 "the warning is true — the check still runs"
+else
+    fail RE-10 "could not show that enabled:false leaves the check running" \
+         "enabled:false -> $F hits, block absent -> $A hits (want >0 then 0)"
+fi
+
+gate_print_summary
+gate_exit

--- a/tests/governance_v4/test_stub_routing.sh
+++ b/tests/governance_v4/test_stub_routing.sh
@@ -1,0 +1,246 @@
+#!/usr/bin/env bash
+# ============================================================
+# test_stub_routing.sh — per-agent response queues in agent_stub.py
+#
+# WHY
+#
+# agent_stub.py had ONE global counter, so every agent in a scenario drew from
+# one interleaved queue. A scenario cannot then script a failure sequence for
+# one agent while another stays clean — which is exactly what living-script_v3
+# needs in order to produce drift on a single handle and keep its siblings
+# quiet. Routing gives each matched agent its own counter.
+#
+# EVERY GATE HAS A DEMONSTRATED FAILURE CASE
+#
+# Five degradations were applied to agent_stub.py one at a time and the suite
+# re-run against each. Recorded here rather than in a commit message because
+# the next person to touch this needs it, and a commit message is not where
+# they will look:
+#
+#   D1  route matching disabled (`if False`)      -> SR-02 SR-03 SR-05 SR-06
+#   D2  routed requests also bump global_idx      -> SR-02 SR-03
+#   D3  a routes key shifts the global queue      -> SR-02 SR-03 SR-04
+#   D4  last matching key wins, not first         -> SR-05
+#   D5  wrap-around instead of last-repeats       -> SR-01 SR-02 SR-04
+#
+# Each gate is isolated by at least one row (SR-01/SR-02 by D5, SR-04 by D3,
+# SR-05 by D4), so none of them is riding on a neighbour.
+#
+# SR-04 is worth stating plainly because the obvious version of it is
+# worthless: comparing a routed fixture's output against a SEPARATE routeless
+# fixture's output proves nothing, since two different fixtures produce
+# different output whatever the stub does. What can actually go wrong is
+# subtler — the mere PRESENCE of a "routes" key perturbing the unrouted path.
+# SR-04 therefore runs a fixture that HAS a route table whose keys match
+# nothing in any request body, and requires byte-identical output to the
+# routeless baseline. That is the claim every other stub-backed suite depends
+# on, and D3 shows it is a real claim rather than a restatement of SR-01.
+#
+# SR-03 is the other easily-missed half: the global index must NOT advance on
+# routed requests, so the one unrouted request still draws G1. A stub that
+# routed correctly but also consumed the global queue would pass SR-02 (D2).
+# ============================================================
+set -uo pipefail
+
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+source "$SCRIPT_DIR/../helpers/gatelib.sh"
+source "$SCRIPT_DIR/../helpers/stub_platform.sh"
+skip_if_no_stub_support
+source "$SCRIPT_DIR/../helpers/stub_launch.sh"
+
+if [ -d "/data/data/com.termux/files/usr/tmp" ]; then
+    _SYSTMP="${TMPDIR:-/data/data/com.termux/files/usr/tmp}"
+else
+    _SYSTMP="${TMPDIR:-/tmp}"
+fi
+TEST_TMP="${_SYSTMP}/stub-routing-$$"
+trap 'stop_stub; rm -rf "$TEST_TMP"' EXIT
+mkdir -p "$TEST_TMP"
+
+echo "=== agent_stub.py per-agent routing ==="
+
+gate_init "stub-routing"
+gate_def SR-01 COMPAT   "routeless fixture keeps global ordering and last-repeats"
+gate_def SR-02 ROUTING  "each route consumes its own queue"
+gate_def SR-03 ROUTING  "routed requests do not advance the global index"
+gate_def SR-04 CONTROL  "a route table matching nothing is byte-identical to no route table"
+gate_def SR-05 ROUTING  "first matching key in fixture order wins"
+gate_def SR-06 EVIDENCE "routes.log records one decision per request"
+
+# ------------------------------------------------------------------
+# A minimal client: POST a body, print the model's text on one line.
+# ------------------------------------------------------------------
+cat > "$TEST_TMP/post.py" << 'PYEOF'
+import json, sys, urllib.request
+port = sys.argv[1]
+out = []
+for body in sys.argv[2:]:
+    req = urllib.request.Request("http://127.0.0.1:%s/v1" % port,
+                                 data=body.encode("utf-8"),
+                                 headers={"Content-Type": "application/json"})
+    with urllib.request.urlopen(req, timeout=10) as r:
+        d = json.load(r)
+    parts = d["candidates"][0]["content"]["parts"]
+    out.append(parts[0].get("text", "") or "-")
+print(" ".join(out))
+PYEOF
+
+# The bodies. Tokens stand in for what the v3 harness plants in each agent's
+# system_prompt; the seventh carries neither.
+BODY_A='{"contents":[{"parts":[{"text":"TOKEN_ALPHA work"}]}]}'
+BODY_B='{"contents":[{"parts":[{"text":"TOKEN_BRAVO work"}]}]}'
+BODY_N='{"contents":[{"parts":[{"text":"no token here"}]}]}'
+SEQ=("$BODY_A" "$BODY_B" "$BODY_A" "$BODY_B" "$BODY_A" "$BODY_B" "$BODY_N")
+
+# ------------------------------------------------------------------
+# Fixtures
+# ------------------------------------------------------------------
+cat > "$TEST_TMP/routed.json" << 'EOF'
+{
+  "routes": {
+    "TOKEN_ALPHA": {"responses": [{"content": "A1"}, {"content": "A2"}, {"content": "A3"}]},
+    "TOKEN_BRAVO": {"responses": [{"content": "B1"}, {"content": "B2"}]}
+  },
+  "responses": [{"content": "G1"}, {"content": "G2"}]
+}
+EOF
+
+cat > "$TEST_TMP/flat.json" << 'EOF'
+{"responses": [{"content": "G1"}, {"content": "G2"}, {"content": "G3"}, {"content": "G4"}]}
+EOF
+
+# Same global queue as flat.json, plus a route table whose keys appear in no
+# request body. The 30 suites that never heard of routing depend on this being
+# indistinguishable from flat.json.
+cat > "$TEST_TMP/unmatched.json" << 'EOF'
+{
+  "routes": {
+    "TOKEN_ZULU":   {"responses": [{"content": "Z1"}]},
+    "TOKEN_YANKEE": {"responses": [{"content": "Y1"}]}
+  },
+  "responses": [{"content": "G1"}, {"content": "G2"}, {"content": "G3"}, {"content": "G4"}]
+}
+EOF
+
+# Both tokens in one route table, ALPHA declared first; the request carries
+# BRAVO's token before ALPHA's, so a body-order match would pick BRAVO.
+cat > "$TEST_TMP/ambiguous.json" << 'EOF'
+{
+  "routes": {
+    "TOKEN_ALPHA": {"responses": [{"content": "FIRST"}]},
+    "TOKEN_BRAVO": {"responses": [{"content": "SECOND"}]}
+  }
+}
+EOF
+
+run_seq() {  # $1=fixture  $2=state subdir ; echoes the response line
+    local fx="$1" dir="$TEST_TMP/$2"
+    mkdir -p "$dir"
+    start_stub "$fx" "$dir" || return 1
+    python3 "$TEST_TMP/post.py" "$STUB_PORT" "${SEQ[@]}" 2>"$dir/client.err"
+    local rc=$?
+    stop_stub
+    return $rc
+}
+
+# ------------------------------------------------------------------
+# SR-01 / SR-04 — the routeless baseline, which is also the control
+# ------------------------------------------------------------------
+FLAT_OUT="$(run_seq "$TEST_TMP/flat.json" flat)"
+FLAT_RC=$?
+FLAT_EXPECT="G1 G2 G3 G4 G4 G4 G4"
+
+if [ $FLAT_RC -ne 0 ]; then
+    skip SR-01 "routeless fixture keeps global ordering" "stub or client failed"
+else
+    if [ "$FLAT_OUT" = "$FLAT_EXPECT" ]; then
+        pass SR-01 "routeless fixture keeps global ordering and last-repeats"
+    else
+        fail SR-01 "routeless fixture changed behaviour" \
+             "expected '$FLAT_EXPECT', got '$FLAT_OUT'"
+    fi
+fi
+
+# SR-04 — an unmatched route table must not perturb the unrouted path.
+UNM_OUT="$(run_seq "$TEST_TMP/unmatched.json" unmatched)"
+UNM_RC=$?
+if [ $FLAT_RC -ne 0 ] || [ $UNM_RC -ne 0 ]; then
+    skip SR-04 "unmatched route table is inert" "stub or client failed"
+elif [ "$UNM_OUT" = "$FLAT_OUT" ] && [ "$FLAT_OUT" = "$FLAT_EXPECT" ]; then
+    pass SR-04 "a route table matching nothing is byte-identical to no route table"
+else
+    fail SR-04 "an unmatched route table changed the unrouted path" \
+         "flat='$FLAT_OUT' unmatched='$UNM_OUT' (both should be '$FLAT_EXPECT')"
+fi
+
+# ------------------------------------------------------------------
+# SR-02 / SR-03 — routing
+# ------------------------------------------------------------------
+ROUTED_OUT="$(run_seq "$TEST_TMP/routed.json" routed)"
+ROUTED_RC=$?
+# A: A1 A2 A3 (three sends)   B: B1 B2 B2 (last repeats)   unrouted: G1
+ROUTED_EXPECT="A1 B1 A2 B2 A3 B2 G1"
+
+if [ $ROUTED_RC -ne 0 ]; then
+    skip SR-02 "each route consumes its own queue" "stub or client failed"
+    skip SR-03 "routed requests do not advance the global index" "stub or client failed"
+else
+    if [ "$ROUTED_OUT" = "$ROUTED_EXPECT" ]; then
+        pass SR-02 "each route consumes its own queue"
+    else
+        fail SR-02 "route queues interleaved or mis-ordered" \
+             "expected '$ROUTED_EXPECT', got '$ROUTED_OUT'"
+    fi
+
+    # The seventh request is the only unrouted one. G1 means the global index
+    # sat still through six routed requests; G2 or a default means it did not.
+    LAST="${ROUTED_OUT##* }"
+    if [ "$LAST" = "G1" ]; then
+        pass SR-03 "routed requests do not advance the global index"
+    else
+        fail SR-03 "global index advanced on routed requests" \
+             "unrouted request got '$LAST', expected the first global response G1"
+    fi
+fi
+
+# ------------------------------------------------------------------
+# SR-05 — determinism when a body carries two tokens
+# ------------------------------------------------------------------
+AMB_DIR="$TEST_TMP/amb"; mkdir -p "$AMB_DIR"
+if start_stub "$TEST_TMP/ambiguous.json" "$AMB_DIR"; then
+    BOTH='{"contents":[{"parts":[{"text":"TOKEN_BRAVO then TOKEN_ALPHA"}]}]}'
+    AMB_OUT="$(python3 "$TEST_TMP/post.py" "$STUB_PORT" "$BOTH" 2>/dev/null)"
+    stop_stub
+    if [ "$AMB_OUT" = "FIRST" ]; then
+        pass SR-05 "first matching key in fixture order wins"
+    else
+        fail SR-05 "ambiguous body did not resolve to the first declared route" \
+             "expected 'FIRST', got '$AMB_OUT'"
+    fi
+else
+    skip SR-05 "first matching key wins" "stub failed to start"
+fi
+
+# ------------------------------------------------------------------
+# SR-06 — the routing decision is recorded, because mis-routing is silent
+# ------------------------------------------------------------------
+RLOG="$TEST_TMP/routed/routes.log"
+if [ $ROUTED_RC -ne 0 ]; then
+    skip SR-06 "routes.log records one decision per request" "routed run failed"
+elif [ ! -f "$RLOG" ]; then
+    fail SR-06 "routes.log was not written" "expected $RLOG"
+else
+    LINES=$(wc -l < "$RLOG" | tr -d ' ')
+    NALPHA=$(count_matches 'TOKEN_ALPHA' "$RLOG")
+    NBRAVO=$(count_matches 'TOKEN_BRAVO' "$RLOG")
+    NNONE=$(count_matches ' -$' "$RLOG")
+    if [ "$LINES" -eq 7 ] && [ "$NALPHA" -eq 3 ] && [ "$NBRAVO" -eq 3 ] && [ "$NNONE" -eq 1 ]; then
+        pass SR-06 "routes.log records one decision per request"
+    else
+        fail SR-06 "routes.log does not account for every request" \
+             "lines=$LINES alpha=$NALPHA bravo=$NBRAVO unrouted=$NNONE (want 7/3/3/1)"
+    fi
+fi
+
+gate_print_summary
+gate_exit

--- a/tests/helpers/agent_stub.py
+++ b/tests/helpers/agent_stub.py
@@ -20,6 +20,34 @@ Fixture format (responses consumed in order; last repeats when exhausted):
       ]
     }
 
+Optional per-agent routing (each route keeps its OWN counter):
+    {
+      "routes": {
+        "AGENT-TOKEN-WORKER": {"responses": [ ... ]},
+        "AGENT-TOKEN-JUDGE":  {"responses": [ ... ]}
+      },
+      "responses": [ ... ]            # fallback, unchanged semantics
+    }
+
+A route key is matched as a plain SUBSTRING of the raw request body, so the
+harness gives each agent a unique token in its system_prompt. Without this,
+one global counter interleaves every agent's queue and a scenario cannot give
+one agent a scripted failure sequence while another stays clean.
+
+Two rules that a fixture author has to be able to rely on:
+  * First matching key in fixture order wins (json.load preserves object
+    order). A body carrying two tokens is therefore resolved deterministically
+    rather than by dict iteration luck -- but it is still a fixture bug, and
+    it is easy to cause by accident, since conversation history replays
+    earlier turns and a token pasted into one agent's prompt can end up in
+    another agent's body.
+  * Because that failure mode is silent (a plausible response from the wrong
+    queue), every request's routing decision is logged to <state_dir>/routes.log
+    as "<request-number> <route-key-or-->". Assert on it.
+
+The global response index advances only for UNROUTED requests, so a fixture
+with no "routes" key behaves exactly as before.
+
 Prints "READY <port>" on stdout once listening. Writes request bodies to
 <state_dir>/req_N.json when state_dir is given (for test assertions).
 """
@@ -34,24 +62,49 @@ class StubState:
         with open(fixture_path) as f:
             fixture = json.load(f)
         self.responses = fixture.get("responses", [])
+        # Insertion-ordered: first matching key wins, and the fixture author
+        # controls which that is.
+        self.routes = fixture.get("routes", {}) or {}
+        self.route_count = dict((k, 0) for k in self.routes)
         self.state_dir = state_dir
-        self.count = 0
+        self.count = 0        # every request, for req_N.json numbering
+        self.global_idx = 0   # advances only on UNROUTED requests
         self.lock = threading.Lock()
+
+    def _pick(self, responses, idx):
+        if not responses:
+            return {"content": "stub default response"}
+        return responses[min(idx, len(responses) - 1)]
 
     def next_response(self, body):
         with self.lock:
-            idx = min(self.count, len(self.responses) - 1) if self.responses else -1
             self.count += 1
             n = self.count
+            key = None
+            for k in self.routes:
+                if k in body:
+                    key = k
+                    break
+            if key is None:
+                idx = self.global_idx
+                self.global_idx += 1
+                responses = self.responses
+            else:
+                idx = self.route_count[key]
+                self.route_count[key] = idx + 1
+                responses = self.routes[key].get("responses", [])
         if self.state_dir:
             try:
                 with open("%s/req_%d.json" % (self.state_dir, n), "w") as f:
                     f.write(body)
             except OSError:
                 pass
-        if idx < 0:
-            return {"content": "stub default response"}
-        return self.responses[idx]
+            try:
+                with open("%s/routes.log" % self.state_dir, "a") as f:
+                    f.write("%d %s\n" % (n, key if key is not None else "-"))
+            except OSError:
+                pass
+        return self._pick(responses, idx)
 
 
 STATE = None


### PR DESCRIPTION
## Summary

Three things. The third was found by working the second.

**Increment 3 of the v3 roadmap: per-agent response queues in `agent_stub.py`.** The stub had one global counter, so every agent in a scenario drew from a single interleaved queue. v3's design is a scripted failure sequence on one worker while four siblings stay clean — drift from task structure, never from telling an agent to misbehave — and the stub could not express that.

**A checksheet of open investigations.** The v3 roadmap and the list of things not yet looked at existed only in a session plan file outside the repo and in conversation. Neither survives a context boundary, which is how a finding gets rediscovered instead of closed.

**`"enabled": false` that turns a check on.** The first item off the checksheet (A1) produced a real finding within the hour, which is roughly the argument for having written it down.

## Changes

### 1. `tests/helpers/agent_stub.py` — per-agent routing

An optional top-level `"routes"` maps a substring of the raw request body to that route's own queue and counter; the harness plants a unique token in each agent's `system_prompt`. Backward compatible by construction — the global index advances only on unrouted requests, so an absent or unmatched route table leaves the arithmetic identical.

Two properties decided rather than left to chance:
- **First matching key in fixture order wins.** `json.load` preserves object order, so a body carrying two tokens resolves deterministically instead of by dict-iteration luck. It is still a fixture bug and an easy one to cause: conversation history replays earlier turns, so a token in one agent's prompt can end up inside another agent's body.
- **Every routing decision is logged** to `<state_dir>/routes.log`, because the failure mode above is otherwise silent — a plausible response drawn from the wrong queue.

`tests/governance_v4/test_stub_routing.sh`, 6 gates, each with a demonstrated failure case:

| degradation | gates that failed |
|---|---|
| D1 route matching disabled | SR-02 SR-03 SR-05 SR-06 |
| D2 routed requests also bump `global_idx` | SR-02 SR-03 |
| D3 a routes key shifts the global queue | SR-02 SR-03 SR-04 |
| D4 last matching key wins, not first | SR-05 |
| D5 wrap-around instead of last-repeats | SR-01 SR-02 SR-04 |

SR-04 is worth calling out. The obvious control — compare a routed fixture's output against a *separate* routeless fixture's output — proves nothing, since two different fixtures produce different output whatever the stub does. That version was written first and replaced. What can actually go wrong is the mere *presence* of a routes key perturbing the unrouted path, so SR-04 runs a fixture with a route table matching nothing and requires byte-identical output to the routeless baseline. D3 shows that is a real claim rather than a restatement of SR-01.

### 2. `docs/open-investigations.md` — the checksheet

A checksheet, not a narrative; `governance-campaign-findings.md` records what was found and why, this records what has **not** been looked at. Section A leads with inert mechanisms because that category has a base rate: `CONTRA-007` iterated a set its own loader empties at parse time, and the circuit-breaker ladder's middle levels were gated by a threshold above their own. Both found by accident, neither by review.

**B1 is new**: scrutiny does not survive a process restart — `governance_level_` is an atomic with no persistence and no restore path, observed live on Aug 8 (segment 1 ended `elevated`, segment 2 began `normal`). Never written up anywhere before.

### 3. `restrictions.*.enabled` — the key that does nothing

`CONTRA-010` refused to fire on a config written to trip it. The check was fine; the config was not doing what it said. Six of the twelve `restrictions.*` sub-blocks enable themselves from the mere *presence* of the block and never read `enabled` at all:

| honours `enabled` | ignores it, forces on |
|---|---|
| `vcs_secret_extraction`, `obfuscation`, `data_exfiltration`, `resource_abuse`, `information_disclosure` | `dangerous_calls`, `shell_injection`, `privilege_escalation`, `code_injection`, `crypto`, `imports` |

All six confirmed empirically, not read off the source: each fires with `false` exactly as with `true`, and not at all when the block is absent. The control matters as much — `data_exfiltration` with a canary pattern gives 0 findings at `false` and 1 at `true`.

**Direction of risk is fail-closed** — the accident is *more* enforcement. Nothing is unprotected. What is wrong is that an operator who believes they turned a check off is wrong and cannot find out.

**Only the silence is fixed.** Making all twelve honour the key is a *loosening*: every config carrying `"enabled": false` today is being enforced and would silently stop on upgrade. That is the trade already rejected for default-on secret scanning, run the other way. The six now warn, following the existing `security.blocked_commands` precedent — one helper, six call sites, with a brace-accurate audit asserting it reaches exactly the sub-blocks that force and none that read.

Both `govern-template.json` files carried `crypto.enabled: false` and have been running the check all along; they now declare `true`. Documentation fix, no behavioural change — verified with the template's `extends` resolved: 2 crypto findings at either value, 0 with the block removed, which is the control that makes the 2-vs-2 comparison mean anything. The three `llm-ab-testing` configs are archived run artifacts and are left as the record they are.

`tests/governance_v4/test_restrictions_enabled_key.sh`, 10 gates, each with a demonstrated failure case. **E4 is the degradation that IS the rejected fix** (make `crypto` honour the key), so RE-10 catches anyone quietly turning this into a loosening later.

**A vacuity in the gate written to catch a vacuity.** RE-10 first passed while measuring nothing: its counter was `grep -c 'restrictions.crypto'` and the new warning *names the rule it warns about*, so the gate counted its own warning as proof the check had run. It was only visible because the trust store was in its blocking state at that moment — every config an `INTEGRITY BLOCK`, nothing executing, RE-10 still passing. Under an isolated store it would have passed for the right reason and shipped.

That also gives the trust-store leak (D8) a better description than "unknown cause": the store is **not written during a run**. `~/.naab/trusted-keys` is dated Aug 3 and unchanged; what varies is that suites using `trust_setup.sh` repoint `NAAB_TRUST_STORE_DIR` while they run, so a probe issued inside that window sees an empty store and succeeds while the same probe outside it is blocked.

## Test Plan

- [x] Ran `bash run-all-tests.sh` with no new failures — 441/441 accounted for, 0 unexpected fails, both before and after the engine change
- [x] Added/updated tests for new functionality — two suites, 16 gates, every one with a demonstrated failure case
- [ ] Tested manually in the REPL — n/a, no language surface changes

Additional verification:
- All 33 stub-backed suites exit 0 against the modified stub (the risk the routing change carries is regression to existing callers, not the new path).
- `bash tests/security/test_error_msg_leaks.sh` — 874 passed, 0 failed, after the new warning text was added.
- No config in the repo's own test corpus triggers the new warning (`grep -c 'has no effect'` over a full suite run: 0).
- All nine contradiction checks confirmed fireable against hand-built configs — none is a `CONTRA-007` repeat. One new item logged (A1a): on the SOFT/HARD path a contradiction block prints an empty `Rule:` field, so the pattern id never reaches the operator.
- Neither new suite needs registering in `run-all-tests.sh` — the governance_v4 sweep added in #129 globs the directory, which is the point of it. Confirmed both are picked up.

## Related Issues

Increment 3 of the v3 roadmap (E3 in the new checksheet); E1/E2 landed as #133, #132, #134.