### PR TITLE
Measure de-escalation with the engine's own predicate, and add a run report

### DIFF
--- a/examples/living-script_v3/gates/fixtures/V3-11/fail/telemetry.jsonl
+++ b/examples/living-script_v3/gates/fixtures/V3-11/fail/telemetry.jsonl
@@ -1,77 +1,41 @@
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "1"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "1", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 1.0, "coherence_damage_total": 0.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "2"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "2", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 1.0, "coherence_damage_total": 0.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "3"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "3", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 1.0, "coherence_damage_total": 0.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "pm", "event_type": "CDD_TURN", "turn": "1"}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "4"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "4", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 1.0, "coherence_damage_total": 0.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "5"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "5", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 1.0, "coherence_damage_total": 0.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "6"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "6", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 1.0, "coherence_damage_total": 0.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "7"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "7", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.8200000000000001, "coherence_damage_total": 0.17999999999999994, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "8"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "8", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.6400000000000001, "coherence_damage_total": 0.3599999999999999, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "9"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "9", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.46000000000000013, "coherence_damage_total": 0.5399999999999998, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "10"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "10", "cdd_snapshot": {"cb_sustained_elevated": 1, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.2800000000000001, "coherence_damage_total": 0.7199999999999999, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "11"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "11", "cdd_snapshot": {"cb_sustained_elevated": 2, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.10000000000000007, "coherence_damage_total": 0.8999999999999999, "coherence_healed_total": 0.0}}
-{"coherence_at_escalation": "0.1000", "config_name": "drift_worker", "event_type": "GOVERNANCE_LEVEL_CHANGE", "from_level": "normal", "to_level": "elevated", "turn": "11"}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "12"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "12", "cdd_snapshot": {"cb_sustained_elevated": 3, "cb_sustained_high": 1, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "13"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "13", "cdd_snapshot": {"cb_sustained_elevated": 4, "cb_sustained_high": 2, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "14"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "14", "cdd_snapshot": {"cb_sustained_elevated": 5, "cb_sustained_high": 3, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"coherence_at_escalation": "0.0000", "config_name": "drift_worker", "event_type": "GOVERNANCE_LEVEL_CHANGE", "from_level": "elevated", "to_level": "high", "turn": "14"}
-{"analyzed": "true", "config_name": "pm", "event_type": "CDD_TURN", "turn": "2"}
-{"analyzed": "true", "config_name": "judge", "event_type": "CDD_TURN", "turn": "1"}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "15"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "15", "cdd_snapshot": {"cb_sustained_elevated": 6, "cb_sustained_high": 2, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "16"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "16", "cdd_snapshot": {"cb_sustained_elevated": 7, "cb_sustained_high": 1, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "17"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "17", "cdd_snapshot": {"cb_sustained_elevated": 8, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "18"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "18", "cdd_snapshot": {"cb_sustained_elevated": 9, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "19"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "19", "cdd_snapshot": {"cb_sustained_elevated": 10, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "20"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "20", "cdd_snapshot": {"cb_sustained_elevated": 11, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "21"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "21", "cdd_snapshot": {"cb_sustained_elevated": 12, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "22"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "22", "cdd_snapshot": {"cb_sustained_elevated": 13, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "23"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "23", "cdd_snapshot": {"cb_sustained_elevated": 14, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "24"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "24", "cdd_snapshot": {"cb_sustained_elevated": 15, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "25"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "25", "cdd_snapshot": {"cb_sustained_elevated": 16, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "26"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "26", "cdd_snapshot": {"cb_sustained_elevated": 17, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "27"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "27", "cdd_snapshot": {"cb_sustained_elevated": 18, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "28"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "28", "cdd_snapshot": {"cb_sustained_elevated": 19, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "29"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "29", "cdd_snapshot": {"cb_sustained_elevated": 20, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "30"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "30", "cdd_snapshot": {"cb_sustained_elevated": 21, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "31"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "31", "cdd_snapshot": {"cb_sustained_elevated": 22, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "32"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "32", "cdd_snapshot": {"cb_sustained_elevated": 23, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "33"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "33", "cdd_snapshot": {"cb_sustained_elevated": 24, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "34"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "34", "cdd_snapshot": {"cb_sustained_elevated": 25, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "35"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "35", "cdd_snapshot": {"cb_sustained_elevated": 26, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "36"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "36", "cdd_snapshot": {"cb_sustained_elevated": 27, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "1", "analyzed": "true", "pressure": "0.0000", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "2", "analyzed": "true", "pressure": "0.0083", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "3", "analyzed": "true", "pressure": "0.0167", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "pm", "turn": "1", "analyzed": "true", "pressure": "0.0000", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "4", "analyzed": "true", "pressure": "0.0250", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "5", "analyzed": "true", "pressure": "0.0333", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "6", "analyzed": "true", "pressure": "0.0417", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "7", "analyzed": "true", "pressure": "0.1750", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "8", "analyzed": "true", "pressure": "0.2133", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "9", "analyzed": "true", "pressure": "0.3117", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "10", "analyzed": "true", "pressure": "0.4100", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "11", "analyzed": "true", "pressure": "0.5083", "governance_level": "elevated"}
+{"event_type": "GOVERNANCE_LEVEL_CHANGE", "turn": "11", "from_level": "normal", "to_level": "elevated", "config_name": "drift_worker", "handle_id": "1"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "12", "analyzed": "true", "pressure": "0.5667", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "13", "analyzed": "true", "pressure": "0.5750", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "14", "analyzed": "true", "pressure": "0.5750", "governance_level": "high"}
+{"event_type": "GOVERNANCE_LEVEL_CHANGE", "turn": "14", "from_level": "elevated", "to_level": "high", "config_name": "drift_worker", "handle_id": "1"}
+{"event_type": "CDD_TURN", "config_name": "pm", "turn": "2", "analyzed": "true", "pressure": "0.0083", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "judge", "turn": "1", "analyzed": "true", "pressure": "0.0000", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "15", "analyzed": "true", "pressure": "0.5125", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "16", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "17", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "18", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "19", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "20", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "21", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "22", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "23", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "24", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "25", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "26", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "27", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "28", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "29", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "30", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "31", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "32", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "33", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "34", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "35", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "36", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}

--- a/examples/living-script_v3/gates/fixtures/V3-11/pass/telemetry.jsonl
+++ b/examples/living-script_v3/gates/fixtures/V3-11/pass/telemetry.jsonl
@@ -1,78 +1,42 @@
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "1"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "1", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 1.0, "coherence_damage_total": 0.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "2"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "2", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 1.0, "coherence_damage_total": 0.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "3"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "3", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 1.0, "coherence_damage_total": 0.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "pm", "event_type": "CDD_TURN", "turn": "1"}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "4"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "4", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 1.0, "coherence_damage_total": 0.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "5"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "5", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 1.0, "coherence_damage_total": 0.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "6"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "6", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 1.0, "coherence_damage_total": 0.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "7"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "7", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.8200000000000001, "coherence_damage_total": 0.17999999999999994, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "8"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "8", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.6400000000000001, "coherence_damage_total": 0.3599999999999999, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "9"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "9", "cdd_snapshot": {"cb_sustained_elevated": 0, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.46000000000000013, "coherence_damage_total": 0.5399999999999998, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "10"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "10", "cdd_snapshot": {"cb_sustained_elevated": 1, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.2800000000000001, "coherence_damage_total": 0.7199999999999999, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "11"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "11", "cdd_snapshot": {"cb_sustained_elevated": 2, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.10000000000000007, "coherence_damage_total": 0.8999999999999999, "coherence_healed_total": 0.0}}
-{"coherence_at_escalation": "0.1000", "config_name": "drift_worker", "event_type": "GOVERNANCE_LEVEL_CHANGE", "from_level": "normal", "to_level": "elevated", "turn": "11"}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "12"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "12", "cdd_snapshot": {"cb_sustained_elevated": 3, "cb_sustained_high": 1, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "13"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "13", "cdd_snapshot": {"cb_sustained_elevated": 4, "cb_sustained_high": 2, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "14"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "14", "cdd_snapshot": {"cb_sustained_elevated": 5, "cb_sustained_high": 3, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"coherence_at_escalation": "0.0000", "config_name": "drift_worker", "event_type": "GOVERNANCE_LEVEL_CHANGE", "from_level": "elevated", "to_level": "high", "turn": "14"}
-{"analyzed": "true", "config_name": "pm", "event_type": "CDD_TURN", "turn": "2"}
-{"analyzed": "true", "config_name": "judge", "event_type": "CDD_TURN", "turn": "1"}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "15"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "15", "cdd_snapshot": {"cb_sustained_elevated": 6, "cb_sustained_high": 2, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "16"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "16", "cdd_snapshot": {"cb_sustained_elevated": 7, "cb_sustained_high": 1, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "17"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "17", "cdd_snapshot": {"cb_sustained_elevated": 8, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"coherence_at_escalation": "0.0000", "config_name": "drift_worker", "event_type": "GOVERNANCE_LEVEL_CHANGE", "from_level": "high", "to_level": "elevated", "turn": "17"}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "18"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "18", "cdd_snapshot": {"cb_sustained_elevated": 9, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "19"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "19", "cdd_snapshot": {"cb_sustained_elevated": 10, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "20"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "20", "cdd_snapshot": {"cb_sustained_elevated": 11, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "21"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "21", "cdd_snapshot": {"cb_sustained_elevated": 12, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "22"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "22", "cdd_snapshot": {"cb_sustained_elevated": 13, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "23"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "23", "cdd_snapshot": {"cb_sustained_elevated": 14, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "24"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "24", "cdd_snapshot": {"cb_sustained_elevated": 15, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "25"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "25", "cdd_snapshot": {"cb_sustained_elevated": 16, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "26"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "26", "cdd_snapshot": {"cb_sustained_elevated": 17, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "27"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "27", "cdd_snapshot": {"cb_sustained_elevated": 18, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "28"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "28", "cdd_snapshot": {"cb_sustained_elevated": 19, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "29"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "29", "cdd_snapshot": {"cb_sustained_elevated": 20, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "30"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "30", "cdd_snapshot": {"cb_sustained_elevated": 21, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "31"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "31", "cdd_snapshot": {"cb_sustained_elevated": 22, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "32"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "32", "cdd_snapshot": {"cb_sustained_elevated": 23, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "33"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "33", "cdd_snapshot": {"cb_sustained_elevated": 24, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "34"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "34", "cdd_snapshot": {"cb_sustained_elevated": 25, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "35"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "35", "cdd_snapshot": {"cb_sustained_elevated": 26, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
-{"analyzed": "true", "config_name": "drift_worker", "event_type": "CDD_TURN", "turn": "36"}
-{"config_name": "drift_worker", "event_type": "SEMANTIC_TURN", "turn": "36", "cdd_snapshot": {"cb_sustained_elevated": 27, "cb_sustained_high": 0, "cb_sustained_critical": 0, "coherence_score": 0.0, "coherence_damage_total": 1.0, "coherence_healed_total": 0.0}}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "1", "analyzed": "true", "pressure": "0.0000", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "2", "analyzed": "true", "pressure": "0.0083", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "3", "analyzed": "true", "pressure": "0.0167", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "pm", "turn": "1", "analyzed": "true", "pressure": "0.0000", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "4", "analyzed": "true", "pressure": "0.0250", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "5", "analyzed": "true", "pressure": "0.0333", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "6", "analyzed": "true", "pressure": "0.0417", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "7", "analyzed": "true", "pressure": "0.1750", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "8", "analyzed": "true", "pressure": "0.2133", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "9", "analyzed": "true", "pressure": "0.3117", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "10", "analyzed": "true", "pressure": "0.4100", "governance_level": "normal"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "11", "analyzed": "true", "pressure": "0.5083", "governance_level": "elevated"}
+{"event_type": "GOVERNANCE_LEVEL_CHANGE", "turn": "11", "from_level": "normal", "to_level": "elevated", "config_name": "drift_worker", "handle_id": "1"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "12", "analyzed": "true", "pressure": "0.5667", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "13", "analyzed": "true", "pressure": "0.5750", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "14", "analyzed": "true", "pressure": "0.5750", "governance_level": "high"}
+{"event_type": "GOVERNANCE_LEVEL_CHANGE", "turn": "14", "from_level": "elevated", "to_level": "high", "config_name": "drift_worker", "handle_id": "1"}
+{"event_type": "CDD_TURN", "config_name": "pm", "turn": "2", "analyzed": "true", "pressure": "0.0083", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "judge", "turn": "1", "analyzed": "true", "pressure": "0.0000", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "15", "analyzed": "true", "pressure": "0.5125", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "16", "analyzed": "true", "pressure": "0.4500", "governance_level": "high"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "17", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "GOVERNANCE_LEVEL_CHANGE", "turn": "17", "from_level": "high", "to_level": "elevated", "config_name": "drift_worker", "handle_id": "1"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "18", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "19", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "20", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "21", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "22", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "23", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "24", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "25", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "26", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "27", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "28", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "29", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "30", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "31", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "32", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "33", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "34", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "35", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}
+{"event_type": "CDD_TURN", "config_name": "drift_worker", "turn": "36", "analyzed": "true", "pressure": "0.4500", "governance_level": "elevated"}

--- a/examples/living-script_v3/gates/registry.sh
+++ b/examples/living-script_v3/gates/registry.sh
@@ -61,6 +61,44 @@ print(eval(sys.argv[2]))
 PY
 }
 
+# Longest run of CONSECUTIVE calm turns from drift_worker after the first
+# escalation, where "calm" is the engine's own predicate: composite pressure
+# below the threshold the level in force at that moment must hold. Kept as its
+# own helper because expressing it inline made it unreadable, and an unreadable
+# predicate is how the two earlier wrong versions survived review.
+_calm_run() {
+    python3 - "$G_TELE" <<'PY' 2>/dev/null
+import json, sys, itertools
+rows = []
+try:
+    for line in open(sys.argv[1]):
+        try: rows.append(json.loads(line))
+        except Exception: pass
+except OSError:
+    pass
+def ev(t): return [r for r in rows if r.get("event_type") == t]
+LV = {"normal": 0, "elevated": 1, "high": 2, "critical": 3}
+HOLD = {1: 0.35, 2: 0.55, 3: 0.80}   # v3 govern.json circuit_breaker
+lc = ev("GOVERNANCE_LEVEL_CHANGE")
+first = min([int(r.get("turn", 0)) for r in lc] or [10**9])
+cdd = sorted([r for r in ev("CDD_TURN")
+              if r.get("config_name") == "drift_worker"
+              and str(r.get("analyzed")) == "true"],
+             key=lambda r: int(r.get("turn", 0)))
+flags = []
+for i in range(1, len(cdd)):
+    if int(cdd[i].get("turn", 0)) <= first:
+        continue
+    # level IN FORCE for this turn = the previous row's, since a row's own
+    # governance_level is written after the update
+    lvl = LV.get(str(cdd[i - 1].get("governance_level")), 0)
+    try: p = float(cdd[i].get("pressure") or 0)
+    except Exception: p = 0.0
+    flags.append(lvl > 0 and p < HOLD[lvl])
+print(max([0] + [sum(1 for _ in g) for k, g in itertools.groupby(flags) if k]))
+PY
+}
+
 # --- gates -----------------------------------------------------------------
 gate_V3_01() {
     if grep -q 'AGENTS|created|3' "$G_OUT" 2>/dev/null; then
@@ -196,12 +234,32 @@ gate_V3_10() {
 gate_V3_11() {
     local down post
     down=$(_tel 'len([r for r in ev("GOVERNANCE_LEVEL_CHANGE") if (r.get("from_level"),r.get("to_level")) in (("high","elevated"),("elevated","normal"),("high","normal"))])')
-    # CALM turns, not merely turns. The first version counted every analyzed
-    # CDD_TURN after the first escalation, which is not the precondition
-    # de-escalation actually needs -- keyed run 2 reported "8 calm turns" when
-    # all 8 fired 2-3 signals each, so the gate called a correct non-firing a
-    # failure. A turn is calm only if it recorded no penalty.
-    post=$(_tel '(lambda t: len([r for r in ev("CDD_TURN") if r.get("config_name")=="drift_worker" and str(r.get("analyzed"))=="true" and int(r.get("turn",0))>t and not str(r.get("penalties_detail") or "").strip()]))(min([int(r.get("turn",0)) for r in ev("GOVERNANCE_LEVEL_CHANGE")] or [10**9]))')
+    # The engine's actual precondition, twice corrected. Version 1 counted every
+    # analyzed CDD_TURN after the first escalation, so keyed run 2 reported "8
+    # calm turns" when all 8 fired 2-3 signals and a correct non-firing was
+    # called a governance failure. Version 2 counted turns with no penalty --
+    # closer, but still not what the engine tests, and far too generous: on a
+    # keyless run it reads 21 where the mechanism saw 3.
+    #
+    # The engine steps down when the COMPUTED TARGET is below the current level
+    # for deescalate_sustained CONSECUTIVE turns from the raising handle. A turn
+    # is calm when composite pressure falls below the threshold its CURRENT level
+    # must hold -- that alone is sufficient for target < level. Two details this
+    # depends on, both of which invert the answer if missed:
+    #
+    #   1. HOLD is keyed by the level being LEFT (elevated 0.35, high 0.55), not
+    #      the level being entered.
+    #   2. A row's governance_level is written AFTER the update, so on the very
+    #      turn a step-down lands the row already shows the LOWER level and would
+    #      score itself against a threshold it was never held to. Judge each turn
+    #      by the previous row's level -- the one in force when it was evaluated.
+    #
+    # With both right this reproduces the run exactly: 3 calm turns,
+    # deescalate_sustained 3, one step-down. With (2) wrong it reads 2, and the
+    # gate contradicts a step-down sitting in its own telemetry.
+    #
+    # CONSECUTIVE, not total: the counter resets on any non-calm turn.
+    post=$(_calm_run)
     if [ "${down:-0}" -gt 0 ]; then
         pass V3-11 "de-escalation fired ($down step-downs)"
     elif [ "${post:-0}" -lt 3 ]; then
@@ -209,7 +267,7 @@ gate_V3_11() {
         # simply did not act enough times afterwards for the calm counter to
         # reach deescalate_sustained. SKIP naming why, rather than failing.
         skip V3-11 "de-escalation not evaluable" \
-             "raising handle had only ${post:-0} CALM turns after escalating (turns with no penalty); needs >= deescalate_sustained"
+             "longest run of consecutive calm turns from the raising handle was ${post:-0}; needs >= deescalate_sustained (3)"
     else
         # The precondition held and nothing stepped down. This branch was a
         # SKIP while I believed the hysteresis could not fire at all; the run

--- a/examples/living-script_v3/report.py
+++ b/examples/living-script_v3/report.py
@@ -1,0 +1,240 @@
+#!/usr/bin/env python3
+"""living-script_v3 run report. python3 stdlib only. Reads telemetry only.
+
+  python3 report.py <telemetry.jsonl> [stdout.txt]
+
+Prints FACTS, not diagnoses: every number is re-derivable from the input file,
+and nothing here decides whether the run was good. That division exists because
+the two keyed runs this tool was written for were each mis-attributed on first
+reading -- to the wrong timeout knob, then to the wrong token limit -- by
+reasoning about the config instead of reading the trace.
+
+NEVER share transcript_*.jsonl. It carries raw prompts and responses. Telemetry
+is audited and safe: response text appears only as content_hash.
+"""
+import json, os, sys, collections
+
+tel = sys.argv[1]
+out = sys.argv[2] if len(sys.argv) > 2 else None
+
+rows = []
+for line in open(tel, errors="replace"):
+    line = line.strip()
+    if not line:
+        continue
+    try:
+        rows.append(json.loads(line))
+    except Exception:
+        pass
+
+
+def ev(t):
+    return [r for r in rows if r.get("event_type") == t]
+
+
+def num(v, d=0.0):
+    try:
+        return float(v)
+    except Exception:
+        return d
+
+
+WORKER = "drift_worker"
+LEVEL_NAME = {0: "normal", 1: "elevated", 2: "high", 3: "critical"}
+NAME_LEVEL = {v: k for k, v in LEVEL_NAME.items()}
+
+# HOLD[L] is the composite a run must keep to STAY at level L; falling below it
+# is what makes the computed target drop. Keyed by the level being LEFT, not the
+# level being entered -- misaligning those two by one silently turns "explains
+# the run" into "contradicts it": a keyless run whose calm turns exactly produce
+# its single step-down reported 23 calm turns and no account of why 21 of them
+# did nothing. Read from govern.json rather than hardcoded, so retuning the
+# scenario cannot leave this table describing a config that no longer exists.
+_CFG = os.path.join(os.path.dirname(os.path.abspath(__file__)), "src", "govern.json")
+HOLD = {1: 0.35, 2: 0.55, 3: 0.80}
+DEESC = 3
+try:
+    _cb = json.load(open(_CFG)).get("circuit_breaker", {})
+    HOLD = {1: float(_cb.get("elevated_threshold", 0.35)),
+            2: float(_cb.get("high_threshold", 0.55)),
+            3: float(_cb.get("critical_threshold", 0.80))}
+    DEESC = int(_cb.get("deescalate_sustained", 3))
+    _CFG_OK = "read from %s" % _CFG
+except Exception as e:
+    _CFG_OK = "govern.json unreadable (%s) -- using built-in defaults" % e
+
+print("=" * 72)
+print("SECTION 1 — run shape")
+print("=" * 72)
+print("telemetry rows: %d" % len(rows))
+kinds = collections.Counter(r.get("event_type") for r in rows)
+for k, v in sorted(kinds.items(), key=lambda kv: -kv[1]):
+    print("  %-32s %d" % (k, v))
+if out:
+    try:
+        txt = open(out, errors="replace").read()
+        print("RUN|complete|true present: %s" % ("RUN|complete|true" in txt))
+        for ln in txt.splitlines():
+            if ln.startswith("PHASE|") or ln.startswith("WORKER|") or ln.startswith("AGENTS|"):
+                print("  %s" % ln)
+    except OSError as e:
+        print("stdout unreadable: %s" % e)
+
+print()
+print("=" * 72)
+print("SECTION 2 — every governance level change")
+print("=" * 72)
+lc = ev("GOVERNANCE_LEVEL_CHANGE")
+if not lc:
+    print("NONE — the ladder never moved")
+for r in lc:
+    print("  turn %-4s %-9s -> %-9s  handle=%s config=%s" % (
+        r.get("turn"), r.get("from_level"), r.get("to_level"),
+        r.get("handle_id"), r.get("config_name")))
+downs = [r for r in lc if NAME_LEVEL.get(str(r.get("to_level")), 9) <
+         NAME_LEVEL.get(str(r.get("from_level")), -1)]
+print("STEP-DOWNS: %d" % len(downs))
+
+print()
+print("=" * 72)
+print("SECTION 3 — %s, every ANALYZED turn (stale rows excluded)" % WORKER)
+print("=" * 72)
+print("hold thresholds: elevated %.2f  high %.2f  critical %.2f  "
+      "deescalate_sustained %d" % (HOLD[1], HOLD[2], HOLD[3], DEESC))
+print("config: %s" % _CFG_OK)
+print()
+print("%-5s %-9s %-9s %-7s %-4s %s" %
+      ("turn", "pressure", "coherence", "level", "sig", "penalties_detail"))
+cdd = [r for r in ev("CDD_TURN")
+       if r.get("config_name") == WORKER and str(r.get("analyzed")) == "true"]
+cdd.sort(key=lambda r: int(num(r.get("turn"))))
+for r in cdd:
+    print("%-5s %-9s %-9s %-7s %-4s %s" % (
+        r.get("turn"), r.get("pressure"), r.get("coherence"),
+        r.get("governance_level"), r.get("signals_fired"),
+        (r.get("penalties_detail") or "")[:70]))
+skipped = len([r for r in ev("CDD_TURN")
+               if r.get("config_name") == WORKER and str(r.get("analyzed")) != "true"])
+print("interval-skipped (stale) rows not shown: %d  <-- must be 0" % skipped)
+
+print()
+print("=" * 72)
+print("SECTION 4 — de-escalation precondition, both readings")
+print("=" * 72)
+print("The engine steps DOWN when the COMPUTED TARGET is below the current")
+print("level for deescalate_sustained consecutive turns FROM THE HANDLE THAT")
+print("RAISED IT. Two readable proxies, printed separately because they are")
+print("NOT the same predicate:")
+print("  A: pressure < HOLD[current level]       -- sufficient for target<level")
+print("  B: penalties_detail empty               -- stricter; a turn can pay a")
+print("     penalty and still compute a lower target")
+if lc:
+    first = min(int(num(r.get("turn"))) for r in lc)
+    post = [r for r in cdd if int(num(r.get("turn"))) > first]
+    prior = 0
+    a = b = 0
+    a_run = b_run = 0
+    a_max = b_max = 0
+    # The level a turn is judged against is the one IN FORCE when it was
+    # evaluated -- i.e. the previous row's -- not the one its own row reports.
+    # A row's governance_level is written AFTER the update, so on the very turn
+    # a step-down lands, the row already shows the lower level and the turn
+    # scores itself against a threshold it was never held to. That single
+    # misclassification is the difference between "longest calm run 2" and the
+    # 3 that deescalate_sustained actually required, on a run that DID step down.
+    prev_lvls = []
+    for r in cdd:
+        if int(num(r.get("turn"))) > first:
+            prev_lvls.append(prior)
+        prior = NAME_LEVEL.get(str(r.get("governance_level")), 0)
+    for r, lvl in zip(post, prev_lvls):
+        # At NORMAL there is no level to step down from, so no turn counts.
+        is_a = lvl > 0 and num(r.get("pressure")) < HOLD.get(lvl, 0.35)
+        is_b = not str(r.get("penalties_detail") or "").strip()
+        a += is_a
+        b += is_b
+        a_run = a_run + 1 if is_a else 0
+        b_run = b_run + 1 if is_b else 0
+        a_max = max(a_max, a_run)
+        b_max = max(b_max, b_run)
+    print()
+    print("first escalation at turn %d; %d analyzed worker turns after it" % (first, len(post)))
+    print("  A (pressure below the level it must hold): %d turns, longest run %d" % (a, a_max))
+    print("  B (no penalty recorded):                   %d turns, longest run %d" % (b, b_max))
+    print()
+    print("Reading it: A's LONGEST RUN is what deescalate_sustained (%d) is" % DEESC)
+    print("compared against.")
+    if a_max >= DEESC and not downs:
+        print("  >>> longest calm run %d >= %d and ZERO step-downs: the"
+              % (a_max, DEESC))
+        print("  >>> hysteresis had what it needs and did not fire. REGRESSION.")
+    elif downs:
+        print("  >>> %d step-down(s) occurred. The mechanism fired." % len(downs))
+    else:
+        print("  >>> longest calm run %d < %d: the run never gave the mechanism"
+              % (a_max, DEESC))
+        print("  >>> the calm it needs. Scenario shortfall, NOT a governance")
+        print("  >>> failure -- do not report this as a defect.")
+    print("  min pressure after first escalation: %s" %
+          (min([num(r.get("pressure")) for r in post]) if post else "n/a"))
+else:
+    print("no escalation, so nothing to de-escalate from")
+
+print()
+print("=" * 72)
+print("SECTION 5 — coherence conservation invariant")
+print("=" * 72)
+snaps = []
+for r in ev("SEMANTIC_TURN"):
+    s = r.get("cdd_snapshot")
+    if isinstance(s, str):
+        try:
+            s = json.loads(s)
+        except Exception:
+            continue
+    if isinstance(s, dict):
+        snaps.append((r.get("config_name"), s))
+worst = 0.0
+n = 0
+for cfg, s in snaps:
+    if "coherence_damage_total" not in s:
+        continue
+    n += 1
+    resid = num(s.get("coherence_score")) - (1.0 - num(s.get("coherence_damage_total"))
+                                             + num(s.get("coherence_healed_total")))
+    worst = max(worst, abs(resid))
+print("snapshots with ledger fields: %d" % n)
+print("worst |coherence - (1 - damage + healed)|: %.12f   <-- must be 0.000000000000" % worst)
+peak = max([int(num(s.get("cb_sustained_elevated"))) for _, s in snaps] or [0])
+print("peak cb_sustained_elevated: %d" % peak)
+print("peak consecutive_high_pressure_turns: %d" %
+      max([int(num(s.get("consecutive_high_pressure_turns"))) for _, s in snaps] or [0]))
+
+print()
+print("=" * 72)
+print("SECTION 6 — signal counts and anything that went wrong")
+print("=" * 72)
+sig = collections.Counter()
+for r in cdd:
+    for part in str(r.get("signals_detail") or "").replace(";", ",").split(","):
+        part = part.strip()
+        if part:
+            sig[part.split("=")[0].split("(")[0].strip()] += 1
+for k, v in sorted(sig.items(), key=lambda kv: -kv[1]):
+    print("  %-32s %d" % (k, v))
+print()
+for t in ("RESPONSE_SUPPRESSED", "RESPONSE_TRUNCATED", "AGENT_RETRY", "AGENT_FALLBACK",
+          "AGENT_KEY_DISABLED", "AGENT_HARD_STOP", "OUTPUT_INADMISSIBLE",
+          "QUARANTINE_STREAK_EXCEEDED", "AGENT_CHALLENGE_FAIL", "AGENT_CHALLENGE_SKIPPED",
+          "THINKING_UNREPORTED", "PULSE_TRANSITION"):
+    c = len(ev(t))
+    if c:
+        print("  %-32s %d" % (t, c))
+print()
+print("prompt_compliance (S20) firings: %d   <-- expect 0" %
+      sum(1 for r in cdd if "prompt_compliance" in str(r.get("signals_detail") or "")))
+tok = ev("AGENT_RESPONSE")
+print("AGENT_RESPONSE events: %d" % len(tok))
+per = collections.Counter(r.get("config_name") for r in tok)
+for k, v in per.most_common():
+    print("  %-20s %d responses" % (k, v))


### PR DESCRIPTION
## Summary

Preparation for keyed run 3, which is meant to answer the one v3 property never observed live: de-escalation. The prompt for that run was only worth sending if the data it produces gets judged correctly — and the gate that judges it was still measuring the wrong thing.

## V3-11 has now had three predicates; the first two were wrong the same way

Each measured something *adjacent* to what the engine tests.

| version | predicate | what it read on a keyless run |
|---|---|---|
| v1 | every analyzed `CDD_TURN` after the first escalation | keyed run 2: "8 calm turns" when all 8 fired 2–3 signals — a correct non-firing reported as a governance failure |
| v2 | turns with no penalty | **21**, where the mechanism saw 3 |
| v3 | composite pressure below the threshold the level **in force** must hold, consecutive | **3** — exactly `deescalate_sustained`, producing exactly the 1 observed step-down |

Two details decide it, and each one alone inverts the answer:

1. **The threshold table is keyed by the level being LEFT** (elevated 0.35, high 0.55), not the level being entered.
2. **A row's `governance_level` is written AFTER the update**, so on the very turn a step-down lands, the row already shows the *lower* level and would score itself against a threshold it was never held to. Each turn must be judged by the previous row's level — the one in force when it was evaluated.

With both right the predicate reproduces the run exactly. With (2) wrong it reads 2, and the gate contradicts a step-down sitting in its own telemetry.

The predicate moved into a named helper (`_calm_run`) rather than an inline expression. The inline form was unreadable, and unreadability is how both earlier versions survived review.

## The self-test caught the fixtures, which is the harness working

Under the stricter predicate, V3-11's negative fixture became **un-failable** — the fixtures had been trimmed to only the fields the looser predicate read, so `pressure` and `governance_level` were absent entirely.

Both regenerated carrying those fields. The negative one now holds the reported level at `high` after the removed step-down, so it reads as *a run that had the calm and did not step down* — the regression the gate exists to catch — rather than a file that contradicts itself. `SEMANTIC_TURN` rows are dropped since V3-11 never reads them: **6.0K and 5.8K**, not the 117K a naive regeneration produced (oversized fixtures have crept back in twice before).

## New: `examples/living-script_v3/report.py`

Six sections over a run's telemetry — run shape, every level change, the per-turn `drift_worker` table, the de-escalation precondition under both readings, the coherence conservation invariant, and signal/error counts.

It prints **facts, not diagnoses**. Both keyed runs so far were misattributed on first reading — to the wrong timeout knob, then to the wrong token limit — by reasoning about the config instead of reading the trace. Thresholds are read from `govern.json` rather than hardcoded, so retuning the scenario cannot leave the tool describing a config that no longer exists.

## Test Plan

- [x] `bash run-all-tests.sh` — 441/441 accounted for, 0 unexpected failures
- [x] `bash tests/security/test_error_msg_leaks.sh` — 874 passed, 0 failed
- [x] `bash examples/living-script_v3/run.sh --self-test` — 11/11, every gate still fails its negative fixture
- [x] `bash examples/living-script_v3/run.sh` — 11/11 keyless
- [x] Predicate validated against three independent keyless runs: 3 calm turns, 1 step-down, each time
- [ ] Tested manually in the REPL — n/a

## Related Issues

Follows #140. Prepares keyed run 3 (E6 in `docs/open-investigations.md`), which remains the only way to observe de-escalation live.

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC)_