### PR TITLE
The calm counter can show the value that fired it, and three corrections

### DIFF
--- a/docs/governance-campaign-findings.md
+++ b/docs/governance-campaign-findings.md
@@ -580,10 +580,22 @@ engine field said 2, and the disagreement was the finding. Deleting the proxy
 first would have replaced a correct external reconstruction with an
 authoritative-looking field that silently understated.
 
-`report.py` now corrects for it explicitly. The engine is unchanged: emitting the
-pre-reset value would mean capturing it before the reset, which is a change to
-freshly-merged enforcement-adjacent code and wants its own trace and test. Filed
-here rather than fixed in a report migration.
+**Fixed.** The engine now reports the value it EVALUATED this turn rather than
+live counter state (`deescalate_calm_observed_`), so the firing turn shows the
+count that fired it and `max(field)` is directly comparable to
+`deescalate_sustained`. The trigger value was never lost — it already existed in
+a local at the `fetch_add` site and was discarded before telemetry read the
+atomic.
+
+`report.py`'s compensation is removed accordingly. Traces captured before the fix
+under-report by one on the firing turn and carry no marker distinguishing them, so
+a maximum of exactly `deescalate_sustained - 1` on a run that DID step down is the
+signature of an old trace rather than a near miss.
+
+Regression: `test_deescalation_hysteresis.sh` D-06, verified to FAIL when the fix
+is reverted (it reports 0, the pre-fix value). D-07 is its control — a non-firing
+calm turn must still report its running count, without which D-06 would pass on a
+field pinned to the threshold.
 
 ---
 

--- a/docs/open-investigations.md
+++ b/docs/open-investigations.md
@@ -70,7 +70,7 @@ campaign doc's live-status column.
 
 | # | Item | Status | Note |
 |---|---|---|---|
-| D1 | **30 suites still use the inline one-shot stub port pick** (`grep -rl 'RANDOM % 20000'`, re-counted 2026-08-09). The hardened launcher is shared (`tests/helpers/stub_launch.sh`) but exactly one suite is repointed. | open | Expect more intermittent CI red. Repoint on touch; converting all 30 blind just repeats "freeze one guess into 29 callers" in the other direction. |
+| D1 | **30 suites still use the inline one-shot stub port pick** (`grep -rl 'RANDOM % 20000'`, re-counted 2026-08-09). The hardened launcher is shared (`tests/helpers/stub_launch.sh`); **22 suites now use it** (re-counted 2026-08-16), 30 still inline. The original note said one — that was true when written and is not now. | open | Expect more intermittent CI red. Repoint on touch; converting all 30 blind just repeats "freeze one guess into 29 callers" in the other direction. |
 | D2 | **Tier 3 vacuity audit** — `tests/gorilla`, 62 absence-guarded assertions | parked | Older scenario tests, weakest claims. Tiers 1–2 done. |
 | D3 | **Retrofit v1 and v2 to `gatelib.sh`** with per-gate negative fixtures | open | Roadmap increment. v1 has ~151 gates, v2 ~89. |
 | D4 | **Keyless runs overwrite `summary.json`**, destroying a keyed record (already lost v2's 108/0/1 once) | open | Fixed in `gate_summary_json`; lands when v1/v2 are retrofitted. |

--- a/docs/plan-engine-observability.md
+++ b/docs/plan-engine-observability.md
@@ -24,11 +24,24 @@ campaign's evidence names threshold suspects but no values, so anything moving a
 threshold is unsupported. Observability and config validation are supported by
 everything found.
 
-**Test of success:** `report.py` should shrink. Its Sections 3–4 are
-reconstructions; if this plan lands they become reads. A forensic tool
-re-deriving what the engine already computed is a standing bug report about the
-engine's observability — and this one re-derived it wrong twice before it was
-right.
+**Test of success (as written, and it was WRONG):** `report.py` should shrink.
+Its Sections 3–4 are reconstructions; if this plan lands they become reads. A
+forensic tool re-deriving what the engine already computed is a standing bug
+report about the engine's observability — and this one re-derived it wrong twice
+before it was right.
+
+**Corrected after execution.** The migration kept the old reconstructions running
+beside the new fields instead of deleting them, and they disagreed: the proxy was
+right and the new engine field, read naively, was off by one — the counter is
+reset before its row is written, so it could not show the value that triggered
+the step-down. Deleting the proxy on sight, which "shrink" called for, would have
+replaced a correct external reconstruction with an authoritative-looking field
+that silently understated.
+
+So `report.py` GREW, and should. The right criterion is **not** that the report
+shrinks but that it stops being the ONLY source of truth: the engine publishes its
+inputs, and the report cross-checks them. An independent reconstruction that
+agrees is cheap; one that disagrees is a finding. Keep the proxies.
 
 ---
 

--- a/examples/living-script_v3/report.py
+++ b/examples/living-script_v3/report.py
@@ -273,18 +273,18 @@ if lc:
               " longest run %d" % eng_max)
         print("         pressure handle(s) owning the counter: %s"
               % (",".join(handles) or "n/a"))
-        # THE COUNTER CANNOT SHOW ITS OWN TRIGGER VALUE. It is reset when the
-        # step-down fires and the row is written afterwards, so on the firing
-        # turn it reads 0. Observed directly: calm 1 (t15), 2 (t16), then 0 at
-        # t17 with high->elevated on that same turn. The observable maximum is
-        # therefore deescalate_sustained - 1 on any run that steps down, and
-        # max(counter) must NOT be compared to deescalate_sustained.
-        eff_max = eng_max + 1 if downs else eng_max
-        if downs:
-            print("         a step-down fired, so the counter reached %d and was"
-                  % DEESC)
-            print("         reset before this row was written — observable max %d"
-                  " understates by one" % eng_max)
+        # The field reports the value the engine EVALUATED this turn, not the
+        # live counter, so the firing turn shows the count that fired it and
+        # max(field) is directly comparable to deescalate_sustained.
+        #
+        # It did not always. The field first emitted live state, which is reset
+        # the instant the step-down fires with the row written afterwards — so
+        # the firing turn read 0 and the visible maximum was
+        # deescalate_sustained - 1. Traces captured before that engine fix
+        # under-report by one on the firing turn; there is no marker
+        # distinguishing them, so a max of exactly DEESC-1 on a run that DID step
+        # down is the signature of an old trace rather than a near miss.
+        eff_max = eng_max
         if a_max == eff_max:
             print("         proxy A agrees with the engine (%d)" % a_max)
         else:
@@ -365,14 +365,26 @@ for k, v in sorted(sig.items(), key=lambda kv: -kv[1]):
 # A signal absent from the counts above is not evidence of good behaviour: it may
 # be switched off, or enabled but never given its inputs. Those three states used
 # to be one observation.
-_off, _starved = set(), set()
+# Counted per signal and reported only when it held on EVERY analyzed turn.
+#
+# A union across turns is misleading: coherence_velocity is starved until
+# coherence_history reaches 2 and evaluable afterwards, so a union listed it as
+# "could not have fired" on a run where it fired five times. The claim worth
+# making is "never evaluable in this run", which is an intersection.
+_offc, _starvedc, _rows = collections.Counter(), collections.Counter(), 0
 for r in cdd:
+    if r.get("signals_off") is None and r.get("signals_starved") is None:
+        continue
+    _rows += 1
     for k in str(r.get("signals_off") or "").split(","):
         if k.strip():
-            _off.add(k.strip())
+            _offc[k.strip()] += 1
     for k in str(r.get("signals_starved") or "").split(","):
         if k.strip():
-            _starved.add(k.strip())
+            _starvedc[k.strip()] += 1
+_off = {k for k, v in _offc.items() if v == _rows}
+_starved = {k for k, v in _starvedc.items() if v == _rows}
+_partial = {k: v for k, v in _starvedc.items() if 0 < v < _rows}
 if _off or _starved:
     print()
     print("signals that could not have fired (names are govern.json config keys):")
@@ -380,6 +392,10 @@ if _off or _starved:
         print("  disabled : %s" % ",".join(sorted(_off)))
     if _starved:
         print("  starved  : %s" % ",".join(sorted(_starved)))
+    if _partial:
+        print("  starved on SOME turns only (evaluable later, so not inert):")
+        for k, v in sorted(_partial.items(), key=lambda kv: -kv[1]):
+            print("    %-28s %d/%d turns" % (k, v, _rows))
     print("  anything in neither list and absent above genuinely evaluated and"
           " did not fire;")
     print("  signals with no instrumented precondition appear in neither list —"

--- a/include/naab/governance.h
+++ b/include/naab/governance.h
@@ -3462,6 +3462,19 @@ private:
     // sibling agent says nothing about the degraded one (all handles share the
     // system-wide governance level). 0 = none recorded.
     std::atomic<int> deescalate_pressure_handle_{0};
+    // The calm count AS EVALUATED THIS TURN, which is what telemetry reports.
+    //
+    // deescalate_calm_turns_ above is live state: it is reset to 0 the instant
+    // the step-down fires, and the CDD_TURN row is written afterwards, so an
+    // observer reading the live counter sees 0 on exactly the turn the value
+    // mattered. Its visible maximum was deescalate_sustained - 1 on any run that
+    // stepped down, which made max(field) look comparable to
+    // deescalate_sustained while being reliably off by one. Found by keeping an
+    // external reconstruction running beside the field and noticing they
+    // disagreed (report.py Section 4).
+    //
+    // This mirror holds the value the engine actually tested, before any reset.
+    std::atomic<int> deescalate_calm_observed_{0};
 
     // Governance plugins
     std::string govern_json_dir_;           // Directory containing govern.json

--- a/src/runtime/governance_engine.cpp
+++ b/src/runtime/governance_engine.cpp
@@ -7068,7 +7068,10 @@ GovernanceLevel GovernanceEngine::getGovernanceLevel() const {
 }
 
 int GovernanceEngine::getDeescalateCalmTurns() const {
-    return deescalate_calm_turns_.load(std::memory_order_relaxed);
+    // The value evaluated this turn, NOT the live counter — see
+    // deescalate_calm_observed_ in governance.h for why they differ on exactly
+    // the turn that matters.
+    return deescalate_calm_observed_.load(std::memory_order_relaxed);
 }
 
 int GovernanceEngine::getDeescalatePressureHandle() const {
@@ -7429,6 +7432,7 @@ std::string GovernanceEngine::checkContextDrift(int handle_id, int turn,
                 if (target >= prev_level) {
                     level = target;
                     deescalate_calm_turns_.store(0, std::memory_order_relaxed);
+                    deescalate_calm_observed_.store(0, std::memory_order_relaxed);
                     // Remember which handle is applying pressure — its calm,
                     // not a sibling's, is what de-escalation must observe.
                     if (target > 0) {
@@ -7443,8 +7447,19 @@ std::string GovernanceEngine::checkContextDrift(int handle_id, int turn,
                     // still-degraded agent earned.
                     int pressure_handle =
                         deescalate_pressure_handle_.load(std::memory_order_relaxed);
+                    if (!(pressure_handle == 0 || pressure_handle == state->handle_id)) {
+                        // Sibling turn: the counter is untouched, so report it as
+                        // it stands rather than leaving another handle's value.
+                        deescalate_calm_observed_.store(
+                            deescalate_calm_turns_.load(std::memory_order_relaxed),
+                            std::memory_order_relaxed);
+                    }
                     if (pressure_handle == 0 || pressure_handle == state->handle_id) {
                         int calm = deescalate_calm_turns_.fetch_add(1, std::memory_order_relaxed) + 1;
+                        // Recorded before the reset below: this is the number the
+                        // engine compared against deescalate_sustained, and the
+                        // only turn it is interesting is the turn it fires.
+                        deescalate_calm_observed_.store(calm, std::memory_order_relaxed);
                         if (calm >= std::max(1, cb.deescalate_sustained)) {
                             level = prev_level - 1;
                             deescalate_calm_turns_.store(0, std::memory_order_relaxed);

--- a/tests/governance_v4/test_deescalation_hysteresis.sh
+++ b/tests/governance_v4/test_deescalation_hysteresis.sh
@@ -79,6 +79,11 @@ cdd_level() {  # $1=telemetry file $2=nth CDD_TURN
         | grep -o '"governance_level":"[a-z]*"' | grep -o ':"[a-z]*"' | tr -d ':"'
 }
 
+cdd_field() {  # $1=telemetry file $2=nth CDD_TURN $3=field name
+    grep '"event_type":"CDD_TURN"' "$1" 2>/dev/null | sed -n "${2}p" \
+        | grep -o "\"$3\":\"[^\"]*\"" | head -1 | sed 's/.*":"//; s/"$//'
+}
+
 echo ""
 echo -e "${CYAN}+==============================================================+${NC}"
 echo -e "${CYAN}|         Governance level de-escalation hysteresis            |${NC}"
@@ -189,6 +194,38 @@ if [ "$L4" = "normal" ]; then
     pass "D-05" "Second consecutive calm turn steps down to NORMAL"
 else
     fail "D-05" "De-escalation after sustained calm broken" "turn4 level=$L4"
+fi
+
+# D-06: the counter must report the value that FIRED the step-down.
+#
+# deescalate_calm_turns_ is live state and is reset the instant the step-down
+# fires; the CDD_TURN row is written afterwards. So the field originally read 0
+# on exactly the turn the value mattered, and its visible maximum was
+# deescalate_sustained - 1 on any run that stepped down — which made
+# max(field) look comparable to deescalate_sustained while being reliably off by
+# one. Telemetry now reports the value the engine EVALUATED this turn.
+#
+# This assertion FAILS if that fix is reverted: pre-fix the firing turn reports
+# 0. deescalate_sustained is 2 in this config and turn 4 is the step-down (D-05).
+CALM4=$(cdd_field "$WDIR/telemetry.jsonl" 4 "deescalate_calm_turns")
+if [ "$CALM4" = "2" ]; then
+    pass "D-06" "Firing turn reports the count that fired it (calm=2 = deescalate_sustained)"
+elif [ "$CALM4" = "0" ]; then
+    fail "D-06" "Firing turn reports 0 — the counter was reset before the row was written" \
+         "pre-fix behaviour: max(field) understates deescalate_sustained by one"
+else
+    fail "D-06" "Firing turn reports an unexpected calm count" "got '$CALM4', expected 2"
+fi
+
+# D-07 is the control for D-06: a NON-firing calm turn must still report its
+# running count, so D-06 cannot pass by the field being hardcoded to the
+# threshold. Turn 3 is the first calm turn (D-04 pins that it did NOT step down).
+CALM3=$(cdd_field "$WDIR/telemetry.jsonl" 3 "deescalate_calm_turns")
+if [ "$CALM3" = "1" ]; then
+    pass "D-07" "Non-firing calm turn reports its running count (calm=1) (control)"
+else
+    fail "D-07" "Non-firing calm turn reports '$CALM3', expected 1" \
+         "without this, D-06 would pass on a field pinned to deescalate_sustained"
 fi
 
 echo ""


### PR DESCRIPTION
## Summary

Migrating `report.py` (#149) found that `deescalate_calm_turns` could never report its own trigger value. The counter is reset the instant the step-down fires and the `CDD_TURN` row is written afterwards, so the firing turn read `0` and the visible maximum was `deescalate_sustained - 1` on any run that stepped down — making `max(field)` look comparable to the threshold while being reliably off by one.

**The value was never lost.** It already existed in a local at the `fetch_add` site and was discarded before telemetry read the atomic.

```
before          after
turn 15  1      turn 15  1
turn 16  2      turn 16  2
turn 17  0  ←   turn 17  3   high->elevated
```

Telemetry now reports what the engine **evaluated** this turn, set in all three branches: `0` on escalate/hold, the tested count on a calm turn from the pressure handle, and the unchanged counter on a sibling turn so another handle's value is never left standing.

The semantics change is contained — the getter had exactly one consumer (`agent_impl` telemetry) and one reader (`report.py`), both traced before changing it.

## The test is verified to fail without the fix

`D-06` in `test_deescalation_hysteresis.sh` asserts the firing turn reports the count that fired it. Reverted the fix and re-ran:

```
FAIL [D-06] Firing turn reports 0 — the counter was reset before the row was written
PASS [D-07] Non-firing calm turn reports its running count (calm=1) (control)
```

`D-07` is the control: a non-firing calm turn must still report its running count, without which `D-06` would pass on a field pinned to the threshold. It passes in **both** directions, which is what makes D-06's failure meaningful rather than incidental.

## Three corrections — all of things this branch itself got wrong

1. **The findings entry said the engine was left unchanged** and the limit merely filed. It's fixed; the entry now says so, and records that pre-fix traces carry no marker — so a maximum of exactly `deescalate_sustained - 1` on a run that *did* step down is the signature of an old trace, not a near miss.

2. **`open-investigations` D1 said "exactly one suite is repointed"** at the shared stub launcher. True when written; **22 use it now, 30 still inline.** Recounted.

3. **The plan's success test — *"report.py should shrink"* — was wrong, and this branch is the evidence.** Deleting the proxies, which shrinking called for, would have removed the reconstruction that caught this defect. The criterion is not that the report shrinks but that it stops being the *only* source of truth: a proxy that agrees is cheap, one that disagrees is a finding. **Keep them.**

Also fixed a union-vs-intersection bug I wrote into `report.py` Section 6 hours ago: signals starved on *some* turns were reported as "could not have fired", listing `coherence_velocity` as inert on a run where it fired five times. Now reports only signals starved on **every** analyzed turn, with partial starvation shown separately.

## Test Plan

- [x] `bash run-all-tests.sh` — 441/441, 0 unexpected
- [x] `bash tests/security/test_error_msg_leaks.sh` — 874/0
- [x] `test_evidence_chain.sh` — 28/28
- [x] `test_deescalation_hysteresis.sh` 7/7, `test_deescalation_multiagent.sh` 8/8
- [x] `living-script_v3` gates — 11/11
- [x] **D-06 verified to fail when the fix is reverted**, and to pass when restored
- [x] Live trace: firing turn reports 3 against `deescalate_sustained` 3 (was 0)
- [ ] Tested manually in the REPL — n/a

---
_Generated by [Claude Code](https://claude.ai/code/session_01ELUfjXZvx8kzXo1UJjrAhC)_